### PR TITLE
using networkmanager's connectedclients dictionary for player lookup

### DIFF
--- a/Assets/BossRoom/Scripts/Server/ServerWaveSpawner.cs
+++ b/Assets/BossRoom/Scripts/Server/ServerWaveSpawner.cs
@@ -198,13 +198,14 @@ namespace BossRoom.Server
 
             var ray = new Ray();
 
+            // note: this is not cached to allow runtime modifications to m_ProximityDistance
             var squaredProximityDistance = m_ProximityDistance * m_ProximityDistance;
 
             // iterate through clients and only return true if a player is in range
             // and is not occluded by a blocking collider.
-            foreach (KeyValuePair<ulong, NetworkedClient> client in NetworkingManager.Singleton.ConnectedClients)
+            foreach (KeyValuePair<ulong, NetworkedClient> idToClient in NetworkingManager.Singleton.ConnectedClients)
             {
-                var playerPosition = client.Value.PlayerObject.transform.position;
+                var playerPosition = idToClient.Value.PlayerObject.transform.position;
                 var direction = playerPosition - spawnerPosition;
 
                 if (direction.sqrMagnitude > squaredProximityDistance)


### PR DESCRIPTION
We might've been overcomplicating the issue at hand (at least I did) and overlooked the `ConnectedClients` dictionary inside of `NetworkingManager` which tracks clients on the server (host & other clients) and is refreshed with disconnections. 

`OverlapSphere` usage is replaced with an iteration through this player dictionary for player proximity.