### PR TITLE
feat: Use built in MLAPI feature to serialize NetworkedObjects instead of manually passing ids.

### DIFF
--- a/Assets/BossRoom/Scripts/Client/Game/Action/MeleeActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/MeleeActionFX.cs
@@ -51,20 +51,19 @@ namespace BossRoom.Visual
             m_ImpactPlayed = true;
 
             //Is my original target still in range? Then definitely get him!
-            if (Data.TargetIds != null && Data.TargetIds.Length > 0 && SpawnManager.SpawnedObjects.ContainsKey(Data.TargetIds[0]))
+            if (Data.TryGetSingleTarget(out NetworkedObject originalTarget))
             {
-                NetworkedObject originalTarget = SpawnManager.SpawnedObjects[Data.TargetIds[0]];
                 float padRange = Description.Range + k_RangePadding;
 
                 if ((m_Parent.transform.position - originalTarget.transform.position).sqrMagnitude < (padRange * padRange))
                 {
                     ClientCharacterVisualization targetViz = originalTarget.GetComponent<Client.ClientCharacter>().ChildVizObject;
                     targetViz.OurAnimator.SetTrigger("HitReact1");
+
+                    //in the future we may do another physics check to handle the case where a target "ran under our weapon".
+                    //But for now, if the original target is no longer present, then we just don't play our hit react on anything.
                 }
             }
-
-            //in the future we may do another physics check to handle the case where a target "ran under our weapon".
-            //But for now, if the original target is no longer present, then we just don't play our hit react on anything. 
         }
     }
 }

--- a/Assets/BossRoom/Scripts/Server/Game/Action/ChaseAction.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Action/ChaseAction.cs
@@ -27,7 +27,7 @@ namespace BossRoom.Server
                 return false;
             }
 
-            m_Target = MLAPI.Spawning.SpawnManager.SpawnedObjects[m_Data.TargetIds[0]];
+            m_Target = m_Data.TargetObjects[0];
 
             m_Movement = m_Parent.GetComponent<ServerCharacterMovement>();
             m_CurrentTargetPos = m_Target.transform.position;
@@ -48,9 +48,7 @@ namespace BossRoom.Server
         /// </summary>
         private bool HasValidTarget()
         {
-            return m_Data.TargetIds != null &&
-                   m_Data.TargetIds.Length > 0 &&
-                   MLAPI.Spawning.SpawnManager.SpawnedObjects.ContainsKey(m_Data.TargetIds[0]);
+            return m_Data.TryGetSingleTarget(out _);
         }
 
         /// <summary>

--- a/Assets/BossRoom/Scripts/Server/Game/Action/MeleeAction.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Action/MeleeAction.cs
@@ -30,10 +30,9 @@ namespace BossRoom.Server
         private bool m_ExecutionFired;
         private ulong m_ProvisionalTarget;
 
-        //cache Physics Cast hits, to minimize allocs. 
-        public MeleeAction(ServerCharacter parent, ref ActionRequestData data) : base(parent, ref data)
-        {
-        }
+        //cache Physics Cast hits, to minimize allocs.
+        public MeleeAction(ServerCharacter parent, ref ActionRequestData data)
+            : base(parent, ref data) { }
 
         public override bool Start()
         {
@@ -41,7 +40,7 @@ namespace BossRoom.Server
             if (foe != null)
             {
                 m_ProvisionalTarget = foe.NetworkId;
-                Data.TargetIds = new ulong[] { foe.NetworkId };
+                Data.TargetObjects = new[] { foe.NetworkedObject };
             }
 
             m_Parent.NetState.ServerBroadcastAction(ref Data);
@@ -62,7 +61,6 @@ namespace BossRoom.Server
 
             return true;
         }
-
 
         /// <summary>
         /// Returns the ServerCharacter of the foe we hit, or null if none found. 

--- a/Assets/BossRoom/Scripts/Server/Game/Action/ReviveAction.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Action/ReviveAction.cs
@@ -1,3 +1,4 @@
+using MLAPI;
 using MLAPI.Spawning;
 using UnityEngine;
 
@@ -14,17 +15,17 @@ namespace BossRoom.Server
 
         public override bool Start()
         {
-            if (m_Data.TargetIds == null || m_Data.TargetIds.Length == 0 || !SpawnManager.SpawnedObjects.ContainsKey(m_Data.TargetIds[0]))
+            if (m_Data.TryGetSingleTarget(out NetworkedObject targetNetworkedObj))
+            {
+                m_TargetCharacter = targetNetworkedObj.GetComponent<ServerCharacter>();
+                m_Parent.NetState.ServerBroadcastAction(ref Data);
+                return true;
+            }
+            else
             {
                 Debug.Log("Failed to start ReviveAction. The target entity  wasn't submitted or doesn't exist anymore");
                 return false;
             }
-
-            var targetNeworkedObj = SpawnManager.SpawnedObjects[m_Data.TargetIds[0]];
-            m_TargetCharacter = targetNeworkedObj.GetComponent<ServerCharacter>();
-            m_Parent.NetState.ServerBroadcastAction(ref Data);
-
-            return true;
         }
 
         public override bool Update()

--- a/Assets/BossRoom/Scripts/Shared/Game/Action/ActionRequestData.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/Action/ActionRequestData.cs
@@ -1,10 +1,11 @@
 using System.IO;
+using MLAPI;
 using UnityEngine;
 
 namespace BossRoom
 {
     /// <summary>
-    /// List of all Actions supported in the game. 
+    /// List of all Actions supported in the game.
     /// </summary>
     public enum ActionType
     {
@@ -19,9 +20,8 @@ namespace BossRoom
         GeneralRevive,
     }
 
-
     /// <summary>
-    /// List of all Types of Actions. There is a many-to-one mapping of Actions to ActionLogics. 
+    /// List of all Types of Actions. There is a many-to-one mapping of Actions to ActionLogics.
     /// </summary>
     public enum ActionLogic
     {
@@ -34,7 +34,6 @@ namespace BossRoom
         //O__O adding a new ActionLogic branch? Update Action.MakeAction!
     }
 
-
     /// <summary>
     /// Comprehensive class that contains information needed to play back any action on the server. This is what gets sent client->server when
     /// the Action gets played, and also what gets sent server->client to broadcast the action event. Note that the OUTCOMES of the action effect
@@ -42,14 +41,14 @@ namespace BossRoom
     /// </summary>
     public struct ActionRequestData : MLAPI.Serialization.IBitWritable
     {
-        public ActionType ActionTypeEnum;      //the action to play. 
-        public Vector3 Position;           //center position of skill, e.g. "ground zero" of a fireball skill. 
-        public Vector3 Direction;          //direction of skill, if not inferrable from the character's current facing. 
-        public ulong[] TargetIds;          //networkIds of targets, or null if untargeted. 
+        public ActionType ActionTypeEnum;      //the action to play.
+        public Vector3 Position;           //center position of skill, e.g. "ground zero" of a fireball skill.
+        public Vector3 Direction;          //direction of skill, if not inferrable from the character's current facing.
+        public NetworkedObject[] TargetObjects; //array of targets, or null if untargeted.
         public float Amount;               //can mean different things depending on the Action. For a ChaseAction, it will be target range the ChaseAction is trying to achieve.
-        public bool ShouldQueue;           //if true, this action should queue. If false, it should clear all current actions and play immediately. 
+        public bool ShouldQueue;           //if true, this action should queue. If false, it should clear all current actions and play immediately.
 
-        //O__O Hey, are you adding something? Be sure to update ActionLogicInfo, as well as the methods below. 
+        //O__O Hey, are you adding something? Be sure to update ActionLogicInfo, as well as the methods below.
 
         //[System.Flags]
         private enum PackFlags
@@ -60,19 +59,36 @@ namespace BossRoom
             HasTargetIds = 1 << 2,
             HasAmount = 1 << 3,
             ShouldQueue = 1 << 4
-            //currently serialized with a byte. Change Read/Write if you add more than 8 fields. 
+
+            //currently serialized with a byte. Change Read/Write if you add more than 8 fields.
         }
 
         private PackFlags GetPackFlags()
         {
             PackFlags flags = PackFlags.None;
             if (Position != Vector3.zero) { flags |= PackFlags.HasPosition; }
+
             if (Direction != Vector3.zero) { flags |= PackFlags.HasDirection; }
-            if (TargetIds != null) { flags |= PackFlags.HasTargetIds; }
+
+            if (TargetObjects != null) { flags |= PackFlags.HasTargetIds; }
+
             if (Amount != 0) { flags |= PackFlags.HasAmount; }
+
             if (ShouldQueue) { flags |= PackFlags.ShouldQueue; }
 
             return flags;
+        }
+
+        public bool TryGetSingleTarget(out NetworkedObject targetObject)
+        {
+            targetObject = null;
+            if (TargetObjects != null && TargetObjects.Length > 0 && TargetObjects[0] != null)
+            {
+                targetObject = TargetObjects[0];
+                return true;
+            }
+
+            return false;
         }
 
         public void Read(Stream stream)
@@ -88,14 +104,17 @@ namespace BossRoom
                 {
                     Position = reader.ReadVector3();
                 }
+
                 if ((flags & PackFlags.HasDirection) != 0)
                 {
                     Direction = reader.ReadVector3();
                 }
+
                 if ((flags & PackFlags.HasTargetIds) != 0)
                 {
-                    TargetIds = reader.ReadULongArray();
+                    TargetObjects = (NetworkedObject[])reader.ReadObjectPacked(typeof(NetworkedObject[]));
                 }
+
                 if ((flags & PackFlags.HasAmount) != 0)
                 {
                     Amount = reader.ReadSingle();
@@ -116,22 +135,22 @@ namespace BossRoom
                 {
                     writer.WriteVector3(Position);
                 }
+
                 if ((flags & PackFlags.HasDirection) != 0)
                 {
                     writer.WriteVector3(Direction);
                 }
+
                 if ((flags & PackFlags.HasTargetIds) != 0)
                 {
-                    writer.WriteULongArray(TargetIds);
+                    writer.WriteObjectPacked(TargetObjects);
                 }
+
                 if ((flags & PackFlags.HasAmount) != 0)
                 {
                     writer.WriteSingle(Amount);
                 }
             }
         }
-
     }
-
 }
-


### PR DESCRIPTION
- This replaces the ulong array with an NetworkedObject array in our action request data and in other instances of our code. MLAPI will deal with serializing/deserializing objects and finding them on the other side. 
- I also cleaned up the way we get a single target from the request data to reduce duplicate code.