### PR TITLE
Boss Dual Hammers Attack

### DIFF
--- a/Assets/BossRoom/GameData/Action/General/Chase.asset
+++ b/Assets/BossRoom/GameData/Action/General/Chase.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ea4744d2fe879b4e53fe5120e4963b68ae516cd906e3a2736039778a1ae713d
-size 525
+oid sha256:df58eaf6faa557729cb0a18968b8081ed43edc2af86fa239800f486a328bee03
+size 540

--- a/Assets/BossRoom/GameData/Action/General/Revive.asset
+++ b/Assets/BossRoom/GameData/Action/General/Revive.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c71ee79f4d1c26f49a6f9d8e7e4a4c96a21625186c78bf74db0d7b601cd59a34
-size 530
+oid sha256:4e77bbbdb5c8c0cc78145f32899697b40954ac035a7f3639fe57cfa20de78416
+size 541

--- a/Assets/BossRoom/GameData/Action/Imp/BossImpBaseAttack.asset
+++ b/Assets/BossRoom/GameData/Action/Imp/BossImpBaseAttack.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad087be4c1365adb0e658806b78d7542f4fc529185c1cf8eaa6b1f2649de6007
-size 572
+oid sha256:2a70b9701970f613eb931b15d062971aac9c7e40f56a7f9a865510a4bcaa3364
+size 595

--- a/Assets/BossRoom/GameData/Action/Imp/BossImpBaseAttack.asset
+++ b/Assets/BossRoom/GameData/Action/Imp/BossImpBaseAttack.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ea6d017698e74094f01a07fc04adb8a084c9c59b012b170309c70b6ecaf0eb0f
-size 549
+oid sha256:ad087be4c1365adb0e658806b78d7542f4fc529185c1cf8eaa6b1f2649de6007
+size 572

--- a/Assets/BossRoom/GameData/Action/Imp/BossImpBasicAttack2.asset
+++ b/Assets/BossRoom/GameData/Action/Imp/BossImpBasicAttack2.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f7e2a427124a58eb4e9e49bc0d3f73ecf0ba05a09ada17e93fb73a73680ea070
-size 574
+oid sha256:ec51ff6931e4c8adf4fd67dfe65a8f7d70dbe4f59033adf1d86ef37a5372e3ad
+size 597

--- a/Assets/BossRoom/GameData/Action/Imp/BossImpBasicAttack2.asset
+++ b/Assets/BossRoom/GameData/Action/Imp/BossImpBasicAttack2.asset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7e2a427124a58eb4e9e49bc0d3f73ecf0ba05a09ada17e93fb73a73680ea070
+size 574

--- a/Assets/BossRoom/GameData/Action/Imp/BossImpBasicAttack2.asset.meta
+++ b/Assets/BossRoom/GameData/Action/Imp/BossImpBasicAttack2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 591b7e6bec2ce374687041254fa6d347
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/BossRoom/GameData/Action/Tank/TankBaseAttack.asset
+++ b/Assets/BossRoom/GameData/Action/Tank/TankBaseAttack.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:255784c0fdfacacb572523a45a7edd6760aac850b60001f0042fce7dabe80db1
-size 557
+oid sha256:37e541eeaf8066f89049d25baf2607f103151e7e107341ef3048d786a69fc0de
+size 580

--- a/Assets/BossRoom/GameData/Action/Tank/TankBaseAttack.asset
+++ b/Assets/BossRoom/GameData/Action/Tank/TankBaseAttack.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:72c56141dd93e08f0347547ac50a0156df8462d2bf49a0491a0d6666337ca334
-size 546
+oid sha256:255784c0fdfacacb572523a45a7edd6760aac850b60001f0042fce7dabe80db1
+size 557

--- a/Assets/BossRoom/GameData/Character/ImpBoss.asset
+++ b/Assets/BossRoom/GameData/Character/ImpBoss.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:920b0ed9d2d3a9e965a86de9873bc8a67edc7b35f8b47f240af02d1174f63432
+oid sha256:ddb92d425145a0e60a9390f481cfd1a5a8bb81548119acdefe5743761f59c82d
 size 508

--- a/Assets/BossRoom/Models/CharacterSetController.controller
+++ b/Assets/BossRoom/Models/CharacterSetController.controller
@@ -232,6 +232,78 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &-4912089196091370847
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: BossAttack2
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -1450812080402980878}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.04634022
+  m_TransitionOffset: 0
+  m_ExitTime: 0.019221107
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-4824461529854540857
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -1068572555509609370}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.17442489
+  m_TransitionOffset: 0.009127505
+  m_ExitTime: 0.91278756
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-3976680793195450479
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: BossAttack1
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3506148273302275305}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.007241126
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-3576141394984483750
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -283,6 +355,28 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &-3167136598363264049
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -1068572555509609370}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.092187166
+  m_TransitionOffset: 0.14120115
+  m_ExitTime: 0.9456005
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!206 &-2485547222415692489
 BlendTree:
   m_ObjectHideFlags: 1
@@ -367,6 +461,33 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1102 &-1450812080402980878
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BossAttack2
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -4824461529854540857}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: -998496362607748373, guid: 2115c4661f55eff45a5a0f91fc0a12f0, type: 3}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1102 &-1068572555509609370
 AnimatorState:
   serializedVersion: 6
@@ -379,6 +500,8 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -5603320215398779609}
+  - {fileID: -3976680793195450479}
+  - {fileID: -4912089196091370847}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -442,73 +565,85 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Speed
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Attack1
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
+  - m_Name: BossAttack1
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: BossAttack2
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
   - m_Name: HitReact1
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: FallDown
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: BeginRevive
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Dead
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: StandUp
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: FallDown
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: BeginRevive
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Dead
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: StandUp
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -587,6 +722,33 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1102 &3506148273302275305
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BossAttack1
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -3167136598363264049}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 3193645972815305343, guid: 2115c4661f55eff45a5a0f91fc0a12f0, type: 3}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1107 &3532665691827284609
 AnimatorStateMachine:
   serializedVersion: 6
@@ -845,15 +1007,21 @@ AnimatorStateMachine:
     m_Position: {x: 240, y: 90, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 6299315480180736668}
-    m_Position: {x: 250, y: 240, z: 0}
+    m_Position: {x: 10, y: 230, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 3506148273302275305}
+    m_Position: {x: 230, y: 220, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -1450812080402980878}
+    m_Position: {x: 440, y: 200, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
   m_AnyStatePosition: {x: 50, y: 20, z: 0}
-  m_EntryPosition: {x: 50, y: 120, z: 0}
-  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_EntryPosition: {x: 20, y: 100, z: 0}
+  m_ExitPosition: {x: 260, y: 40, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: -1068572555509609370}
 --- !u!1102 &8314685060882719794

--- a/Assets/BossRoom/Prefabs/GameDataSource.prefab
+++ b/Assets/BossRoom/Prefabs/GameDataSource.prefab
@@ -59,3 +59,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 88ae789c31d8b3e478eb38b11b1fd56a, type: 2}
   - {fileID: 11400000, guid: 17fb2e0ae2dc88f41afde117bdafd832, type: 2}
   - {fileID: 11400000, guid: 11ae5510e51fb2844992d75fdf15994b, type: 2}
+  - {fileID: 11400000, guid: 591b7e6bec2ce374687041254fa6d347, type: 2}

--- a/Assets/BossRoom/Scripts/Server/Game/Action/MeleeAction.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Action/MeleeAction.cs
@@ -76,7 +76,7 @@ namespace BossRoom.Server
             //If the action data has a direction, pass the face matching the 
             if (Description.HitStartDirection != HitDirection.NoDirection)
             {
-                direction = ActionUtils.ComputeDirectionPoint(collider, Description.HitStartDirection);
+                direction = ActionUtils.ComputeDirectionPoint(collider, Description.HitStartDirection, Description.Range);
             }
 
             RaycastHit[] results;

--- a/Assets/BossRoom/Scripts/Shared/Data/ActionDescription.cs
+++ b/Assets/BossRoom/Scripts/Shared/Data/ActionDescription.cs
@@ -2,6 +2,18 @@ using UnityEngine;
 
 namespace BossRoom
 {
+
+    /// <summary>
+    /// An enum representing a direction relative to the entity playing the action. It can represent where an attack is beginning to detect the first target hit,
+    /// or a direction to have an attack move towards.
+    /// </summary>
+    public enum HitDirection
+    {
+        NoDirection,
+        Left,
+        Right,
+    }
+
     /// <summary>
     /// Data description of a single Action, including the information to visualize it (animations etc), and the information
     /// to play it back on the server. 
@@ -35,6 +47,9 @@ namespace BossRoom
 
         [Tooltip("The primary Animation action that gets played when visualizing this Action")]
         public string Anim;
+
+        [Tooltip("A designation for where the Action starts playing relative to the performer. This can be used for having certain attacks organize who should get hit first in the attack")]
+        public HitDirection HitStartDirection;
     }
 
 

--- a/Assets/BossRoom/Scripts/Shared/Game/Action/ActionRequestData.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/Action/ActionRequestData.cs
@@ -15,6 +15,7 @@ namespace BossRoom
         RogueBaseAttack,
         ImpBaseAttack,
         ImpBossBaseAttack,
+        ImpBossBaseAttack2,
         GeneralChase,
         GeneralRevive,
     }

--- a/Assets/BossRoom/Scripts/Shared/Game/Action/ActionUtils.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/Action/ActionUtils.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace BossRoom
@@ -14,12 +15,13 @@ namespace BossRoom
         /// <param name="attacker">The collider of the attacking GameObject.</param>
         /// <param name="description">The Description of the Action being played (containing things like Range that control the physics query.</param>
         /// <param name="results">Place an uninitialized RayCastHit[] ref in here. It will be set to the results array. </param>
+        /// <param name="favoreddir">optional param that when set, will sort the results from the collision to be clos</param>
         /// <remarks>
         /// This method does not alloc. It returns a maximum of 4 results. Consume the results immediately, as the array will be overwritten with
         /// the next similar query. 
         /// </remarks>
         /// <returns>Total number of foes encountered. </returns>
-        public static int DetectMeleeFoe(bool isNPC, Collider attacker, ActionDescription description, out RaycastHit[] results)
+        public static int DetectMeleeFoe(bool isNPC, Collider attacker, ActionDescription description, out RaycastHit[] results, Vector3? favorPoint)
         {
             //this simple detect just does a boxcast out from our position in the direction we're facing, out to the range of the attack. 
 
@@ -32,7 +34,66 @@ namespace BossRoom
                 attacker.transform.forward, s_Hits, Quaternion.identity, description.Range, mask);
 
             results = s_Hits;
+
+
+            if (numResults > 0)
+            {
+                if (favorPoint.HasValue)
+                {
+                    //The sort here gets a tad tricky because we don't allocate a new array, meaning there can be empty entries here.
+                    //To fix this in the sort we just need to push all the nulled entries to the back of the list.
+                    Array.Sort(results, (x, y) =>
+                    {
+                        if (x.collider == null)
+                        {
+                            return 1;
+                        }
+                        else if (y.collider == null)
+                        {
+                            return -1;
+                        }
+                        else
+                        {
+                            Debug.Log(Vector3.Distance(x.transform.position, favorPoint.Value) - Vector3.Distance(y.transform.position, favorPoint.Value));
+                            return Vector3.Distance(x.transform.position, favorPoint.Value).CompareTo(Vector3.Distance(y.transform.position, favorPoint.Value));
+                        }
+                    });
+                }
+            }
+
+
             return numResults;
+        }
+
+        /// <summary>
+        /// Calculates the relative point for the collider based on the given hit direction.  This essentially gets the desired face of the collider in world coordinates
+        /// </summary>
+        /// <param name="col"></param>
+        /// <param name="dir"></param>
+        /// <returns></returns>
+        public static Vector3 ComputeDirectionPoint(Collider col, HitDirection dir)
+        {
+            var position = col.transform.position;
+            switch (dir)
+            {
+                //This really shouldn't be called if given no direction, but we'll return the collider's transform.
+                case HitDirection.NoDirection:
+                    {
+                        return position;
+                    }
+                case HitDirection.Left:
+                    {
+                        return position - col.transform.right * col.bounds.extents.x;
+                    }
+                case HitDirection.Right:
+                    {
+                        return position + col.transform.right * col.bounds.extents.x;
+                    }
+                default:
+                    {
+                        return position;
+                    }
+            }
         }
     }
 

--- a/Assets/BossRoom/Scripts/Shared/Game/Action/ActionUtils.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/Action/ActionUtils.cs
@@ -54,7 +54,6 @@ namespace BossRoom
                         }
                         else
                         {
-                            Debug.Log(Vector3.Distance(x.transform.position, favorPoint.Value) - Vector3.Distance(y.transform.position, favorPoint.Value));
                             return Vector3.Distance(x.transform.position, favorPoint.Value).CompareTo(Vector3.Distance(y.transform.position, favorPoint.Value));
                         }
                     });
@@ -68,10 +67,11 @@ namespace BossRoom
         /// <summary>
         /// Calculates the relative point for the collider based on the given hit direction.  This essentially gets the desired face of the collider in world coordinates
         /// </summary>
-        /// <param name="col"></param>
-        /// <param name="dir"></param>
+        /// <param name="col">The Collider to use as the base point</param>
+        /// <param name="dir">The direction to place the point relative to the collider</param>
+        /// <param name="range"> the range to pass in to offset the point by</param>
         /// <returns></returns>
-        public static Vector3 ComputeDirectionPoint(Collider col, HitDirection dir)
+        public static Vector3 ComputeDirectionPoint(Collider col, HitDirection dir, float range)
         {
             var position = col.transform.position;
             switch (dir)
@@ -83,11 +83,11 @@ namespace BossRoom
                     }
                 case HitDirection.Left:
                     {
-                        return position - col.transform.right * col.bounds.extents.x;
+                        return position - col.transform.right * (range/2);
                     }
                 case HitDirection.Right:
                     {
-                        return position + col.transform.right * col.bounds.extents.x;
+                        return position + col.transform.right * (range/2);
                     }
                 default:
                     {
@@ -96,6 +96,4 @@ namespace BossRoom
             }
         }
     }
-
-
 }


### PR DESCRIPTION
- Adds a second attack for the imp boss where he swings his left hand hammer after his initial swing
- This required an update to AIAttackState to know if the boss is playing a skill in its character data rather than just its skill 1
- Also added a Hit Direction enum for the melee attack specifically-  When calculating who to hit for the basic attack, it a) sorts the hit list from the raycast by distance to an offset set by the enum, and then prioritizes closest enemy hit over the originally targetted enemy

