### PR TITLE
Feature/fix for multipie manifest address

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -8,7 +8,7 @@
     "com.unity.ide.vscode": "1.2.3",
     "com.unity.multiplayer.mlapi": "https://github.com/Unity-Technologies/com.unity.multiplayer.mlapi.git?path=/com.unity.multiplayer.mlapi#27263d3da3138ff7fd02db5aacf4e82d34f4a647",
     "com.unity.ai.navigation.components": "https://github.com/Unity-Technologies/NavMeshComponents.git#package",
-    "com.unity.multiplayer.multipie": "ssh://git@github.com/Unity-Technologies/com.unity.multiplayer.multipie.git#2e972fb",
+    "com.unity.multiplayer.multipie": "ssh://git@github.com/Unity-Technologies/com.unity.multiplayer.multipie.git#ec513520a8bba970366c572e88613664a2054353",
     "com.unity.postprocessing": "2.3.0",
     "com.unity.test-framework": "1.1.19",
     "com.unity.textmeshpro": "3.0.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -80,11 +80,11 @@
       "hash": "27263d3da3138ff7fd02db5aacf4e82d34f4a647"
     },
     "com.unity.multiplayer.multipie": {
-      "version": "ssh://git@github.com/Unity-Technologies/com.unity.multiplayer.multipie.git#2e972fb",
+      "version": "ssh://git@github.com/Unity-Technologies/com.unity.multiplayer.multipie.git#ec513520a8bba970366c572e88613664a2054353",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "2e972fb8bc802a4070d6f5d282210a2bfb8e8480"
+      "hash": "ec513520a8bba970366c572e88613664a2054353"
     },
     "com.unity.multiplayer.samples.coop": {
       "version": "file:com.unity.multiplayer.samples.coop",


### PR DESCRIPTION
current multipie setup requires auth setup for our github keys which isn't included in the rnd onboarding. Updating the URL so it's easier for new people coming on the team who have followed that onboarding.