### PR TITLE
fix for mid game connection callback error

### DIFF
--- a/Assets/BossRoom/Scripts/Shared/Game/State/CharSelectData.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/State/CharSelectData.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 namespace BossRoom
 {
     /// <summary>
-    /// Common data and RPCs for the CharSelect stage. 
+    /// Common data and RPCs for the CharSelect stage.
     /// </summary>
     public class CharSelectData : NetworkedBehaviour
     {
@@ -91,9 +91,14 @@ namespace BossRoom
             }
         }
 
+        void OnDestroy()
+        {
+            m_LobbyPlayers.Cleanup();
+        }
+
         /// <summary>
         /// TEMP! This is substitute for NetworkedVarList<>. It will be replaced by a NetworkedVarList<LobbyPlayerState> when those are once again
-        /// supported. 
+        /// supported.
         /// </summary>
         public class LobbyPlayerArray
         {
@@ -101,7 +106,7 @@ namespace BossRoom
             private CharSelectData m_CharSelectData;
 
             /// <summary>
-            /// Event that gets raised when the array has changed somehow. 
+            /// Event that gets raised when the array has changed somehow.
             /// </summary>
             public event Action<LobbyPlayerArray> ArrayChangedEvent;
 
@@ -110,13 +115,15 @@ namespace BossRoom
                 m_LobbyPlayers = new List<LobbyPlayerState>();
                 m_CharSelectData = data;
 
-                if( NetworkingManager.Singleton.IsServer )
+                if (NetworkingManager.Singleton.IsServer)
                 {
-                    NetworkingManager.Singleton.OnClientConnectedCallback += (ulong clientId) =>
-                    {
-                        m_CharSelectData.StartCoroutine(CoroClientConnected(clientId));
-                    };
+                    NetworkingManager.Singleton.OnClientConnectedCallback += ClientConnected;
                 }
+            }
+
+            void ClientConnected(ulong clientId)
+            {
+                m_CharSelectData.StartCoroutine(CoroClientConnected(clientId));
             }
 
             private IEnumerator CoroClientConnected(ulong clientId)
@@ -134,7 +141,7 @@ namespace BossRoom
                 m_LobbyPlayers.Add(state);
                 ArrayChangedEvent?.Invoke(this);
 
-                if(NetworkingManager.Singleton.IsServer )
+                if (NetworkingManager.Singleton.IsServer )
                 {
                     m_CharSelectData.LobbyPlayerUpdateArrayClientRpc(m_LobbyPlayers.ToArray());
                 }
@@ -178,7 +185,7 @@ namespace BossRoom
             }
 
             /// <summary>
-            /// Updates a single element. For use only be the CharSelectData class. 
+            /// Updates a single element. For use only be the CharSelectData class.
             /// </summary>
             public void ClientSyncUpdate(LobbyPlayerState[] playerArray )
             {
@@ -190,6 +197,14 @@ namespace BossRoom
                     ArrayChangedEvent?.Invoke(this);
                 }
             }
+
+            public void Cleanup()
+            {
+                if (NetworkingManager.Singleton.IsServer)
+                {
+                    NetworkingManager.Singleton.OnClientConnectedCallback -= ClientConnected;
+                }
+            }
         }
 
         /// <summary>
@@ -197,7 +212,7 @@ namespace BossRoom
         /// is because it's tricky to send incremental array updates right now. You can't just send an initial state on client connection, and then
         /// subsequent incremental updates, because you don't know exactly when the client's connection is going to be open for transmission. If you send
         /// a client an incremental update while it still has its inital state message pending, it will get confused.
-        /// In any case, this system is meant to be temporary, and will be replaced when NetworkedVarList<T> is supported again. 
+        /// In any case, this system is meant to be temporary, and will be replaced when NetworkedVarList<T> is supported again.
         /// </summary>
         [ClientRpc]
         private void LobbyPlayerUpdateArrayClientRpc(LobbyPlayerState[] playerArray )
@@ -211,7 +226,6 @@ namespace BossRoom
         {
             m_LobbyPlayers = new LobbyPlayerArray(this, 8);
         }
-
 
         /// <summary>
         /// Current state of all players in the lobby.


### PR DESCRIPTION
As I was testing [this](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/pull/96) PR, I ran into an issue where the server hadn't cleaned up client connection callback that was subscribed to in the player lobby by a server player. 

So, anytime a new player joined mid-game on the server, MLAPI would try to invoke a method on a gameobject that was already destroyed. Now, when CharSelectData gameobject is destroyed, we unsubscribe from this event if we're a host.