### PR TITLE
Fix for character type being stuck on clients

### DIFF
--- a/Assets/BossRoom/Scripts/Shared/Game/Entity/NetworkCharacterState.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/Entity/NetworkCharacterState.cs
@@ -97,7 +97,7 @@ namespace BossRoom
         NetworkCharacterTypeState m_NetworkCharacterTypeState;
 
         /// <summary>
-        /// Current HP. This value is populated at startup time from CharacterClass data.
+        /// Character Type. This value is populated during character selection.
         /// </summary>
         public CharacterTypeEnum CharacterType
         {

--- a/Assets/BossRoom/Scripts/Shared/NetworkCharacterTypeState.cs
+++ b/Assets/BossRoom/Scripts/Shared/NetworkCharacterTypeState.cs
@@ -1,13 +1,14 @@
 using System;
+using MLAPI;
 using MLAPI.NetworkedVar;
 using UnityEngine;
 
 namespace BossRoom
 {
     /// <summary>
-    /// MonoBehaviour containing only one NetworkedVar which represents this character's health.
+    /// NetworkedBehaviour containing only one NetworkedVar which represents this character's health.
     /// </summary>
-    public class NetworkCharacterTypeState : MonoBehaviour
+    public class NetworkCharacterTypeState : NetworkedBehaviour
     {
         [Tooltip("NPCs should set this value in their prefab. For players, this value is set at runtime.")]
         public NetworkedVar<CharacterTypeEnum> CharacterType = new NetworkedVar<CharacterTypeEnum>();


### PR DESCRIPTION
NetworkCharacterTypeState needed to inherit from NetworkedBehavior in order for it's NetVarto be synced.

