### PR TITLE
revive adds max character health to a player

### DIFF
--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
@@ -31,7 +31,7 @@ namespace BossRoom.Server
         [SerializeField]
         [Tooltip("Setting negative value disables destroying object after it is killed.")]
         private float m_KilledDestroyDelaySeconds = 3.0f;
-		
+
         [SerializeField]
         [Tooltip("If set, the ServerCharacter will automatically play the StartingAction when it is created. ")]
         private ActionType m_StartingAction = ActionType.None;
@@ -144,7 +144,7 @@ namespace BossRoom.Server
         }
 
         /// <summary>
-        /// Clear all active Actions. 
+        /// Clear all active Actions.
         /// </summary>
         public void ClearActions()
         {
@@ -167,7 +167,7 @@ namespace BossRoom.Server
         }
 
         /// <summary>
-        /// Receive an HP change from somewhere. Could be healing or damage. 
+        /// Receive an HP change from somewhere. Could be healing or damage.
         /// </summary>
         /// <param name="inflicter">Person dishing out this damage/healing. Can be null. </param>
         /// <param name="HP">The HP to receive. Positive value is healing. Negative is damage.  </param>
@@ -186,10 +186,10 @@ namespace BossRoom.Server
                 float damageMod = m_ActionPlayer.GetBuffedValue(Action.BuffableValue.PercentDamageReceived);
                 HP = (int)(HP * damageMod);
             }
-            
+
             NetState.HitPoints = Mathf.Min(NetState.CharacterData.BaseHP.Value, NetState.HitPoints+HP);
-            
-            //we can't currently heal a dead character back to Alive state. 
+
+            //we can't currently heal a dead character back to Alive state.
             //that's handled by a separate function.
             if (NetState.HitPoints <= 0)
             {
@@ -231,7 +231,7 @@ namespace BossRoom.Server
         {
             if (NetState.NetworkLifeState.Value == LifeState.Fainted)
             {
-                NetState.HitPoints = HP;
+                NetState.HitPoints = NetState.CharacterData.BaseHP.Value;
                 NetState.NetworkLifeState.Value = LifeState.Alive;
             }
         }

--- a/Assets/BossRoom/Scripts/Shared/Game/UI/UIStateDisplayHandler.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/UI/UIStateDisplayHandler.cs
@@ -185,7 +185,6 @@ namespace BossRoom
             yield return new WaitForSeconds(k_DurationSeconds);
 
             m_UIState.HideHealth();
-            m_UIStateActive = false;
         }
 
         void LateUpdate()
@@ -199,7 +198,7 @@ namespace BossRoom
 
         void OnDestroy()
         {
-            if (m_UIState)
+            if (m_UIState != null)
             {
                 Destroy(m_UIState.gameObject);
             }


### PR DESCRIPTION
Jira bug [here](https://unity3d.atlassian.net/browse/GOMPS-290?atlOrigin=eyJpIjoiMGE2NGQ5MjJjN2QzNDBmNjhmN2E5MjdmMmMxMTBiMWQiLCJwIjoiaiJ9).

A revive action applies a change of a character's max health (was just 0 previously).

Also addressed in this PR is the floating name bug on death. It does not float on screen anymore (as in it's still translated while a character is fainted).