### PR TITLE
Feature/fix for exception forgetting about breakable pillars in network manager

### DIFF
--- a/Assets/BossRoom/Prefabs/NetworkingManager.prefab
+++ b/Assets/BossRoom/Prefabs/NetworkingManager.prefab
@@ -238,7 +238,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_IpHostTransport: {fileID: 7898291372908163337}
-  m_RelayTransport: {fileID: 0}
+  m_RelayTransport: {fileID: 409269882}
 --- !u!1 &6889060209805043266
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Had an exception when starting a client in editor connecting to a build host. Someone forgot to add the breakable pillar as a prefab to the network manager.