### PR TITLE
docs: Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: stat:awaiting triage, type:bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Windows 10]
+ - Unity Version: [e.g. 2019.1]
+ - BossRoom Version: [e.g. v0.1.0] (If you don't know tell us where you got BossRoom from)
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: True
+contact_links:
+  - name: Documentation
+    url: https://github.com/Unity-Technologies/com.unity.multiplayer.docs/issues
+    about: Create a documentation issue in our docs repository.
+  - name: Discord
+    url: https://discord.gg/buMxnnPvTb
+    about: Join us on Discord for questions, support and discussions.
+  - name: Unity Multiplayer Forum
+    url: https://forum.unity.com/forums/multiplayer.26/
+    about: Create a thread in the Unity Multiplayer Forum.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: stat:awaiting triage, type:feature
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -1,0 +1,14 @@
+---
+name: Feedback
+about: Provide feedback to the MLAPI Samples team
+title: ''
+labels: stat:awaiting triage, type:feedback
+assignees: ''
+
+---
+
+**Feedback**
+Enter your feedback to the MLAPI Samples team here. Please keep in mind that our teams focus is on multiplayer sample games development. For other not related feedback towards Unity please use the Forums.
+
+**Suggested Changes**
+If you think we could do something better, please let us know here what you would like us to change. Concrete and constructive suggestions are welcome and will help us to prioritize and act on feedback.

--- a/.github/ISSUE_TEMPLATE/other-issues.md
+++ b/.github/ISSUE_TEMPLATE/other-issues.md
@@ -1,0 +1,10 @@
+---
+name: Other Issues
+about: Use this template for any other non-support related issues
+title: ''
+labels: stat:awaiting triage
+assignees: ''
+
+---
+
+This template is for issues not covered by the other issue categories.

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,0 +1,12 @@
+---
+name: Support
+about: Have a question or need help with anything?
+title: ''
+labels: stat:awaiting triage, type:support
+assignees: ''
+
+---
+
+Post your questions or problems here.
+
+For general questions, networking advice or discussions about MLAPI, you can also reach us on our [Discord Community](https://discord.gg/FM8SE9E) or create a post in the [Unity Multiplayer Forum](https://forum.unity.com/forums/multiplayer.26/).


### PR DESCRIPTION
Adds issue templates to our repository. These are pretty much copy pasted from MLAPI. Just did some renaming to refer to the samples team and the BossRoom repository.

The feature template is something which we still need to discuss but we might want to get this in for now to be ready for the bug bash and can improve on it later? I saw your comment [here](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/pull/101#discussion_r586564120) @SamuelBellomo so lets discuss 😃 