### PR TITLE
Feature: archer volley (special attack)

### DIFF
--- a/Assets/BossRoom/GameData/Action/Archer/ArcherBaseAttack.asset
+++ b/Assets/BossRoom/GameData/Action/Archer/ArcherBaseAttack.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:285dfffa4248b0b12ceb1ee0a2c7893f6b42076a3f0f2b8cdf39c5f0cc802f35
+oid sha256:224ce23e842627d7abb46c0daac1ea1210c25dbfaf6c98862dbe82d89f5786b4
 size 1106

--- a/Assets/BossRoom/GameData/Action/Archer/ArcherVolley.asset
+++ b/Assets/BossRoom/GameData/Action/Archer/ArcherVolley.asset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:998273feff4776bba54d84096227d3b8f6e8e638889863dd1640de95677fff16
+size 1615

--- a/Assets/BossRoom/GameData/Action/Archer/ArcherVolley.asset.meta
+++ b/Assets/BossRoom/GameData/Action/Archer/ArcherVolley.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0626aa2c2ce0d3a4ab4cad814432c2e5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/BossRoom/GameData/Character/Archer.asset
+++ b/Assets/BossRoom/GameData/Character/Archer.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:19d72a03b21dc9a274ca02c249d1751bcab9ea44741fc68f3352eb983097e438
-size 792
+oid sha256:5e17431079a1a4fd50ea285753900e1aeb0a7bad2894880d09567f0654147dfa
+size 793

--- a/Assets/BossRoom/Models/Animation Controlers/CharacterSetController.controller
+++ b/Assets/BossRoom/Models/Animation Controlers/CharacterSetController.controller
@@ -1293,7 +1293,7 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
-    m_ConditionEvent: ArcherAttack1
+    m_ConditionEvent: Attack2
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 4401103057488639788}
@@ -1504,139 +1504,139 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Attack1
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: HitReact1
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: FallDown
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: StandUp
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: BeginRevive
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Dead
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
-  - m_Name: ArcherAttack1
+    m_Controller: {fileID: 0}
+  - m_Name: Attack2
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Emote1
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Emote2
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Emote3
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Emote4
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Trample
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: SkillHeal
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Stunned
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Unstunned
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: ShieldBuffStart
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: ShieldBuffEnd
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: ChargedShotStart
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: ChargedShotEnd
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: EntryFainted
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: EntryDead
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Buff1
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Assets/BossRoom/Prefabs/Actions/ClientAoeInput.prefab
+++ b/Assets/BossRoom/Prefabs/Actions/ClientAoeInput.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 6459207307567452869}
   - component: {fileID: 8447158110562487606}
   m_Layer: 0
-  m_Name: ClientAoEInput
+  m_Name: ClientAoeInput
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -29,6 +29,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 519043390440476}
+  - {fileID: 7786310081837396287}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -44,6 +45,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac4ff8d8a5ac140ebb52e6a89c92cc27, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_InRangeVisualization: {fileID: 4372974839826446078}
+  m_OutOfRangeVisualization: {fileID: 3023808054957408081}
 --- !u!1 &3023808054957408081
 GameObject:
   m_ObjectHideFlags: 0
@@ -57,7 +60,7 @@ GameObject:
   - component: {fileID: 427162388993190056}
   - component: {fileID: 1445103948864770558}
   m_Layer: 0
-  m_Name: TMPVisualization
+  m_Name: OutOfRange
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -104,7 +107,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 0}
+  - {fileID: 2100000, guid: 8dd4d04a8c6ef414688e7935de53b536, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -133,6 +136,101 @@ SphereCollider:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3023808054957408081}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &4372974839826446078
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7786310081837396287}
+  - component: {fileID: 5292373250812076600}
+  - component: {fileID: 7585886372521509736}
+  - component: {fileID: 1692538361283364185}
+  m_Layer: 0
+  m_Name: InRange
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7786310081837396287
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4372974839826446078}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6459207307567452869}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5292373250812076600
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4372974839826446078}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7585886372521509736
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4372974839826446078}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 3ec090889f8bc8e4194146dce20fdf1a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &1692538361283364185
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4372974839826446078}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1

--- a/Assets/BossRoom/Prefabs/CharGFX/PlayerGraphics.prefab
+++ b/Assets/BossRoom/Prefabs/CharGFX/PlayerGraphics.prefab
@@ -1371,6 +1371,15 @@ MonoBehaviour:
     m_SoundStartDelaySeconds: 0
     m_VolumeMultiplier: 1
     m_LoopSound: 0
+  - m_AnimatorNodeName: Attack2
+    m_AnimatorNodeNameHash: 1680125592
+    m_Prefab: {fileID: 5031766593922921982, guid: 916fc51d2167e1f42a14e1fb9cd224a8, type: 3}
+    m_PrefabSpawnDelaySeconds: 0
+    m_PrefabCanBeAbortedUntilSecs: 0
+    m_SoundEffect: {fileID: 8300000, guid: 142f526f026d1c241b01ebb524d19903, type: 3}
+    m_SoundStartDelaySeconds: 0
+    m_VolumeMultiplier: 1
+    m_LoopSound: 0
   m_EventsOnNodeExit: []
   m_AudioSources:
   - {fileID: -674663276945163795}
@@ -1696,7 +1705,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5c3f9e26dccb0cd45bc3a5d28abc3a39, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Animator: {fileID: 4199396739699390757, guid: 6c2070a53a468ea4e9c1885abed4fea6, type: 3}
+  m_Animator: {fileID: 4199396739699390757}
   m_AnimatorVariable: Speed
   m_AnimatorVariableHash: -823668238
   m_AudioSource: {fileID: 3410014739571049847}
@@ -1704,6 +1713,8 @@ MonoBehaviour:
   m_WalkFootstepVolume: 1
   m_RunFootstepAudioClip: {fileID: 8300000, guid: 6ad4d1d63bc70494bbc9172ae70bcdd0, type: 3}
   m_RunFootstepVolume: 1
+  m_WalkingPoint: 0.6
+  m_SilentPoint: 0.3
 --- !u!82 &3410014739571049847
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/BossRoom/Prefabs/GameDataSource.prefab
+++ b/Assets/BossRoom/Prefabs/GameDataSource.prefab
@@ -71,3 +71,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: f070d58e9f56a94429492e257e60e70d, type: 2}
   - {fileID: 11400000, guid: 90a7c42b138147742a5ef0e724143a74, type: 2}
   - {fileID: 11400000, guid: c8770f39d4807a842bea85cfb3b8a649, type: 2}
+  - {fileID: 11400000, guid: 0626aa2c2ce0d3a4ab4cad814432c2e5, type: 2}

--- a/Assets/BossRoom/Scripts/Client/Game/Action/AoeActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/AoeActionFX.cs
@@ -12,9 +12,7 @@ namespace BossRoom.Visual
         public override bool Start()
         {
             m_Parent.OurAnimator.SetTrigger(Description.Anim);
-            var actionDescription = GameDataSource.Instance.ActionDataByType[m_Data.ActionTypeEnum];
-            var vfxObject = GameObject.Instantiate(actionDescription.Spawns[0], m_Data.Position, Quaternion.identity);
-            vfxObject.transform.localScale = new Vector3(actionDescription.Radius * 2, actionDescription.Radius * 2, actionDescription.Radius * 2);
+            GameObject.Instantiate(Description.Spawns[0], m_Data.Position, Quaternion.identity);
             return ActionConclusion.Stop;
         }
 

--- a/Assets/BossRoom/Scripts/Client/Game/Action/AoeActionInput.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/AoeActionInput.cs
@@ -2,15 +2,24 @@ using UnityEngine;
 
 namespace BossRoom.Visual
 {
+    /// <summary>
     /// This class is the first step in AoE ability. It will update the initial input visuals' position and will be in charge
     /// of tracking the user inputs. Once the ability
     /// is confirmed and the mouse is clicked, it'll send the appropriate RPC to the server, triggering the AoE serer side gameplay logic.
     /// The server side gameplay action will then trigger the client side resulting FX.
     /// This action's flow is this: (Client) AoEActionInput --> (Server) AoEAction --> (Client) AoEActionFX
+    /// </summary>
     public class AoeActionInput : BaseActionInput
     {
+        [SerializeField]
+        private GameObject m_InRangeVisualization;
+
+        [SerializeField]
+        private GameObject m_OutOfRangeVisualization;
+
         Camera m_Camera;
         int m_GroundLayerMask;
+        Vector3 m_Origin;
 
         RaycastHit[] m_UpdateResult = new RaycastHit[1];
 
@@ -20,23 +29,11 @@ namespace BossRoom.Visual
             transform.localScale = new Vector3(radius * 2, radius * 2, radius * 2);
             m_Camera = Camera.main;
             m_GroundLayerMask = LayerMask.GetMask("Ground");
+            m_Origin = m_PlayerOwner.transform.position;
         }
 
         void Update()
         {
-            if (Input.GetMouseButtonUp(0))
-            {
-                var data = new ActionRequestData
-                {
-                    Position = transform.position,
-                    ActionTypeEnum = m_ActionType,
-                    ShouldQueue = false,
-                    TargetIds = null
-                };
-                m_PlayerOwner.RecvDoActionServerRPC(data);
-                Destroy(gameObject);
-                return;
-            }
             if (Physics.RaycastNonAlloc(
                 ray: m_Camera.ScreenPointToRay(Input.mousePosition),
                 results: m_UpdateResult,
@@ -44,6 +41,28 @@ namespace BossRoom.Visual
                 layerMask: m_GroundLayerMask) > 0)
             {
                 transform.position = m_UpdateResult[0].point;
+            }
+
+            float range = GameDataSource.Instance.ActionDataByType[m_ActionType].Range;
+            bool isInRange = (m_Origin - transform.position).sqrMagnitude <= range * range;
+            m_InRangeVisualization.SetActive(isInRange);
+            m_OutOfRangeVisualization.SetActive(!isInRange);
+
+            if (Input.GetMouseButtonUp(0))
+            {
+                if (isInRange)
+                {
+                    var data = new ActionRequestData
+                    {
+                        Position = transform.position,
+                        ActionTypeEnum = m_ActionType,
+                        ShouldQueue = false,
+                        TargetIds = null
+                    };
+                    m_PlayerOwner.RecvDoActionServerRPC(data);
+                }
+                Destroy(gameObject);
+                return;
             }
         }
     }

--- a/Assets/BossRoom/Scripts/Client/Game/Action/ChargedActionInput.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/ChargedActionInput.cs
@@ -6,7 +6,6 @@ namespace BossRoom.Visual
     public class ChargedActionInput : BaseActionInput
     {
         protected float m_StartTime;
-        protected bool m_HasStoppedCharging;
 
         private void Start()
         {
@@ -24,6 +23,21 @@ namespace BossRoom.Visual
                 TargetIds = null
             };
             m_PlayerOwner.RecvDoActionServerRPC(data);
+        }
+
+        private void Update()
+        {
+            // FIXME: this is necessary to ensure the GameObject is destroyed, because clicking on the buttons
+            // in the UI only sends one event, onClick. The buttons need to send separate "button down" and
+            // "button up" events, like we use for keyboard keypresses, to make it possible to "charge up" an
+            // attack via keyboard. (When this is done, OnReleaseKey() will reliably be called, so it can
+            // destroy the GameObject, and this entire Update() function can be removed.)
+            var description = GameDataSource.Instance.ActionDataByType[m_ActionType];
+            if (Time.time - m_StartTime > description.DurationSeconds &&
+                Time.time - m_StartTime > description.ExecTimeSeconds) // this check handles theoretical cases where Duration is 0 (indeterminate) but we still have a fixed wind-up time
+            {
+                Destroy(gameObject);
+            }
         }
 
         public override void OnReleaseKey()

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
@@ -342,6 +342,14 @@ namespace BossRoom.Client
             {
                 RequestAction(CharacterData.Skill2, SkillTriggerStyle.KeyboardRelease);
             }
+            if (Input.GetKeyDown(KeyCode.Alpha2))
+            {
+                RequestAction(CharacterData.Skill3, SkillTriggerStyle.Keyboard);
+            }
+            else if (Input.GetKeyUp(KeyCode.Alpha2))
+            {
+                RequestAction(CharacterData.Skill3, SkillTriggerStyle.KeyboardRelease);
+            }
 
             if (Input.GetKeyDown(KeyCode.Alpha4))
             {
@@ -360,9 +368,9 @@ namespace BossRoom.Client
                 RequestAction(ActionType.Emote4, SkillTriggerStyle.Keyboard);
             }
 
-            if ( !EventSystem.current.IsPointerOverGameObject())
+            if ( !EventSystem.current.IsPointerOverGameObject() && m_CurrentSkillInput == null)
             {
-                //this is a simple way to determine if the mouse is over a UI element. If it is, we don't perform mouse input logic,
+                //IsPointerOverGameObject() is a simple way to determine if the mouse is over a UI element. If it is, we don't perform mouse input logic,
                 //to model the button "blocking" mouse clicks from falling through and interacting with the world.
 
                 if (Input.GetMouseButtonDown(1))

--- a/Assets/BossRoom/Scripts/Server/Game/Action/AOEAction.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Action/AOEAction.cs
@@ -1,39 +1,80 @@
 using BossRoom;
 using BossRoom.Server;
+using MLAPI;
+using MLAPI.Spawning;
+using System.Collections.Generic;
 using UnityEngine;
 
+/// <summary>
+/// Area-of-effect attack Action. The attack is centered on a point provided by the client.
+/// </summary>
 public class AoeAction : Action
 {
+    /// <summary>
+    /// Cheat prevention: to ensure that players don't perform AoEs outside of their attack range,
+    /// we ensure that the target is less than Range meters away from the player, plus this "fudge
+    /// factor" to accomodate miscellaneous minor movement.
+    /// </summary>
+    const float k_MaxDistanceDivergence = 1;
+
+    bool m_DidAoE;
+
     public AoeAction(ServerCharacter parent, ref ActionRequestData data)
         : base(parent, ref data) { }
 
     public override bool Start()
     {
-        var actionDescription = GameDataSource.Instance.ActionDataByType[m_Data.ActionTypeEnum];
+        float distanceAway = Vector3.Distance(m_Parent.transform.position, Data.Position);
+        if (distanceAway > Description.Range+k_MaxDistanceDivergence)
+        {
+            Debug.LogError($"Hacking detected?! (Object ID {m_Parent.NetworkObjectId}) {Description.ActionTypeEnum}'s AoE range is {Description.Range} but we were given a point that's {distanceAway} away from us. Canceling AoE");
+            return ActionConclusion.Stop;
+        }
 
+        // broadcasting to all players including myself.
+        // We don't know our actual targets for this attack until it triggers, so the client can't use the TargetIds list (and we clear it out for clarity).
+        // This means we are responsible for triggering reaction-anims ourselves, which we do in PerformAoe()
+        Data.TargetIds = new ulong[0];
+        m_Parent.NetState.RecvDoActionClientRPC(Data);
+        return ActionConclusion.Continue;
+    }
+
+    public override bool Update()
+    {
+        if (TimeRunning >= Description.ExecTimeSeconds && !m_DidAoE)
+        {
+            // actually perform the AoE attack
+            m_DidAoE = true;
+            PerformAoE();
+        }
+        return ActionConclusion.Continue;
+    }
+
+    private void PerformAoE()
+    {
         // Note: could have a non alloc version of this overlap sphere where we statically store our collider array, but since this is a self
         // destroyed object, the complexity added to have a static pool of colliders that could be called by multiplayer players at the same time
         // doesn't seem worth it for now.
-        var colliders = Physics.OverlapSphere(m_Data.Position, actionDescription.Radius, LayerMask.GetMask("NPCs"));
-        m_Data.TargetIds = new ulong[colliders.Length]; // Security: We can't trust users! We reset target IDs here, so clients
-                                                        // can't set their own target ID list.
+        var colliders = Physics.OverlapSphere(m_Data.Position, Description.Radius, LayerMask.GetMask("NPCs"));
         for (var i = 0; i < colliders.Length; i++)
         {
             var enemy = colliders[i].GetComponent<IDamageable>();
             if (enemy != null)
             {
-                enemy.ReceiveHP(m_Parent, -actionDescription.Amount);
-                m_Data.TargetIds[i] = enemy.NetworkObjectId;
+                // make the target "flinch", assuming they're a living enemy
+                var networkObject = NetworkSpawnManager.SpawnedObjects[enemy.NetworkObjectId];
+                if (networkObject)
+                {
+                    var state = networkObject.GetComponent<NetworkCharacterState>();
+                    if (state)
+                    {
+                        state.RecvPerformHitReactionClientRPC();
+                    }
+                }
+
+                // actually deal the damage
+                enemy.ReceiveHP(m_Parent, -Description.Amount);
             }
         }
-
-        // broadcasting to all players including myself. Client is authoritative on input, but not on the actual gameplay effect of that input.
-        m_Parent.NetState.RecvDoActionClientRPC(Data);
-        return ActionConclusion.Stop;
-    }
-
-    public override bool Update()
-    {
-        return ActionConclusion.Stop;
     }
 }

--- a/Assets/BossRoom/Scripts/Shared/Game/Action/ActionRequestData.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/Action/ActionRequestData.cs
@@ -32,6 +32,7 @@ namespace BossRoom
         MageHeal,
         ArcherChargedShot,
         RogueStealthMode,
+        ArcherVolley,
     }
 
 

--- a/Assets/BossRoom/VFX/Materials/FX_M_TargetingSphere_InRange.mat
+++ b/Assets/BossRoom/VFX/Materials/FX_M_TargetingSphere_InRange.mat
@@ -1,0 +1,52 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: FX_M_TargetingSphere_InRange
+  m_Shader: {fileID: 4800000, guid: 7886845fdd0f0a148b23f1e533e46533, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 0
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3500
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _NoiseFresnel:
+        m_Texture: {fileID: 2800000, guid: a225a619c91968049ba2bdbc44c812fb, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _T_NormalMap_2:
+        m_Texture: {fileID: 2800000, guid: 7653d661bb658e64aae075bcbd3bb8ec, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _T_NormalMap_3:
+        m_Texture: {fileID: 2800000, guid: 7653d661bb658e64aae075bcbd3bb8ec, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _texcoord:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Distortion: 0.058
+    - _Distortion1: 0.162
+    - _Fresnel: 2
+    - _FresnelPower: 2
+    - _NoiseIntencity: 0.467
+    - _Sneak: 1
+    - _TileNormalTexture: 0.05
+    - _TileNormalTexture1: 0.01
+    - __dirty: 0
+    m_Colors:
+    - _FresnelColor: {r: 0, g: 1.4142135, b: 0.054555554, a: 0}
+    - _NoiseTileSpeed: {r: 0.05, g: 0.01, b: 0, a: 0.5}
+    - _NotmalTileSpeed: {r: 0.05, g: 0.02, b: 0, a: 0.5}
+  m_BuildTextureStacks: []

--- a/Assets/BossRoom/VFX/Materials/FX_M_TargetingSphere_InRange.mat.meta
+++ b/Assets/BossRoom/VFX/Materials/FX_M_TargetingSphere_InRange.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ec090889f8bc8e4194146dce20fdf1a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/BossRoom/VFX/Materials/FX_M_TargetingSphere_OutOfRange.mat
+++ b/Assets/BossRoom/VFX/Materials/FX_M_TargetingSphere_OutOfRange.mat
@@ -1,0 +1,52 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: FX_M_TargetingSphere_OutOfRange
+  m_Shader: {fileID: 4800000, guid: 7886845fdd0f0a148b23f1e533e46533, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 0
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3500
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _NoiseFresnel:
+        m_Texture: {fileID: 2800000, guid: a225a619c91968049ba2bdbc44c812fb, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _T_NormalMap_2:
+        m_Texture: {fileID: 2800000, guid: 7653d661bb658e64aae075bcbd3bb8ec, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _T_NormalMap_3:
+        m_Texture: {fileID: 2800000, guid: 7653d661bb658e64aae075bcbd3bb8ec, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _texcoord:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Distortion: 0.058
+    - _Distortion1: 0.162
+    - _Fresnel: 2
+    - _FresnelPower: 2
+    - _NoiseIntencity: 0.467
+    - _Sneak: 1
+    - _TileNormalTexture: 0.05
+    - _TileNormalTexture1: 0.01
+    - __dirty: 0
+    m_Colors:
+    - _FresnelColor: {r: 1.4142135, g: 0.042409997, b: 0, a: 0}
+    - _NoiseTileSpeed: {r: 0.05, g: 0.01, b: 0, a: 0.5}
+    - _NotmalTileSpeed: {r: 0.05, g: 0.02, b: 0, a: 0.5}
+  m_BuildTextureStacks: []

--- a/Assets/BossRoom/VFX/Materials/FX_M_TargetingSphere_OutOfRange.mat.meta
+++ b/Assets/BossRoom/VFX/Materials/FX_M_TargetingSphere_OutOfRange.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8dd4d04a8c6ef414688e7935de53b536
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/BossRoom/VFX/Prefabs/Archer/FX_Archer_skill3_idle.prefab
+++ b/Assets/BossRoom/VFX/Prefabs/Archer/FX_Archer_skill3_idle.prefab
@@ -4894,6 +4894,7 @@ GameObject:
   - component: {fileID: 2232111375016834008}
   - component: {fileID: 2232111375016834011}
   - component: {fileID: 2232111375016834010}
+  - component: {fileID: 4316883201630075502}
   m_Layer: 0
   m_Name: FX_Archer_skill3_idle
   m_TagString: Untagged
@@ -4909,7 +4910,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2232111375016833989}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.17, y: 0, z: 8.51}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2232111376162317477}
@@ -9700,6 +9701,21 @@ ParticleSystemRenderer:
   m_Mesh2: {fileID: 0}
   m_Mesh3: {fileID: 0}
   m_MaskInteraction: 0
+--- !u!114 &4316883201630075502
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2232111375016833989}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e80714725b908940a76375b52b8d53b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ParticleSystemsToTurnOffOnShutdown: []
+  m_AutoShutdownTime: 5
+  m_PostShutdownSelfDestructTime: -1
 --- !u!1 &2232111375138000941
 GameObject:
   m_ObjectHideFlags: 0
@@ -19507,7 +19523,7 @@ ParticleSystem:
   cullingMode: 0
   ringBufferMode: 0
   ringBufferLoopRange: {x: 0, y: 1}
-  looping: 1
+  looping: 0
   prewarm: 0
   playOnAwake: 1
   useUnscaledTime: 0

--- a/Assets/BossRoom/VFX/Prefabs/Archer/FX_Archer_skill3_start.prefab
+++ b/Assets/BossRoom/VFX/Prefabs/Archer/FX_Archer_skill3_start.prefab
@@ -34228,6 +34228,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5670799466413109239}
+  - component: {fileID: 5031766593922921982}
   m_Layer: 0
   m_Name: FX_Archer_skill3_start
   m_TagString: Untagged
@@ -34250,3 +34251,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5031766593922921982
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5670799466413109232}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e80714725b908940a76375b52b8d53b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ParticleSystemsToTurnOffOnShutdown: []
+  m_AutoShutdownTime: 5
+  m_PostShutdownSelfDestructTime: -1


### PR DESCRIPTION
**Overview**
Fleshes out the existing AoE system and wires up the graphics for the archer's AoE attack. Note that while the arrow graphics are final, the "AoE targeting sphere" graphics are not finalized yet.

**Implementation Notes**
- Added the typical wait-for-ExecDuration logic to `AoeAction`
- Removed the particle-FX auto-scaling from `AoeActionFX` because it doesn't look good with the final particles. (And I'm not sure it would be possible to make a particle that works for that here, because a bigger radius needs MORE arrows, not BIGGER arrows.) I've set the ability's radius to look good with the current particles
- Added Range detection client-side, and validation server-side
- The `AoeInputAction` waits for mouse-clicks, but the `ClientInputManager` was ALSO consuming those clicks, which meant you always tried to walk to the place your arrows were landing. To fix this I just made `ClientInputManager` not allow clicks while an InputAction is active.
- That fix helped me see that we were leaking GameObjects with the other archer attack, Charged Shot. I fixed this by tweaking the `ChargedActionInput` to make sure it always destroys itself, and added a FIXME to remove it when UI button logic is fully in place. (Code comment has more details.)

**Merging Details (notes to self)**
- CharacterSetController: the only change was renaming the trigger "ArcherAttack1" to "Attack2"
- PlayerGraphics: added one new animator trigger to Archer. On animation "Attack2", plays prefab FX_Archer_skill3_start, and plays sound archer_volley
- GameDataSource: added new `ArcherVolley` action