### PR TITLE
cleanup for downed player on late join (order of operations) & health…

### DIFF
--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientCharacterVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientCharacterVisualization.cs
@@ -74,10 +74,6 @@ namespace BossRoom.Visual
             m_NetState.OnPerformHitReaction += OnPerformHitReaction;
             m_NetState.OnStopChargingUpClient += OnStoppedChargingUp;
             m_NetState.IsStealthy.OnValueChanged += OnStealthyChanged;
-            // With this call, players connecting to a game with down imps will see all of them do the "dying" animation.
-            // we should investigate for a way to have the imps already appear as down when connecting.
-            // todo gomps-220
-            OnLifeStateChanged(m_NetState.NetworkLifeState.Value, m_NetState.NetworkLifeState.Value);
 
             //we want to follow our parent on a spring, which means it can't be directly in the transform hierarchy.
             Parent.GetComponent<ClientCharacter>().ChildVizObject = this;
@@ -88,9 +84,6 @@ namespace BossRoom.Visual
             transform.position = parentMovement.NetworkPosition.Value;
             transform.rotation = Quaternion.Euler(0, parentMovement.NetworkRotationY.Value, 0);
 
-            // sync our animator to the most up to date version received from server
-            SyncEntryAnimation(m_NetState.NetworkLifeState.Value);
-
             // listen for char-select info to change (in practice, this info doesn't
             // change, but we may not have the values set yet) ...
             m_NetState.CharacterAppearance.OnValueChanged += OnCharacterAppearanceChanged;
@@ -100,6 +93,9 @@ namespace BossRoom.Visual
 
             // ...and visualize the current char-select value that we know about
             SetAppearanceSwap();
+
+            // sync our animator to the most up to date version received from server
+            SyncEntryAnimation(m_NetState.NetworkLifeState.Value);
 
             if (!m_NetState.IsNpc)
             {

--- a/Assets/BossRoom/Scripts/Shared/Game/UI/UIStateDisplayHandler.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/UI/UIStateDisplayHandler.cs
@@ -78,6 +78,10 @@ namespace BossRoom
             }
 
             Assert.IsTrue(m_DisplayHealth || m_DisplayName, "Neither display fields are toggled on!");
+            if (m_DisplayHealth)
+                Assert.IsNotNull(m_NetworkHealthState, "A NetworkHealthState component needs to be attached!");
+            if (m_DisplayName)
+                Assert.IsNotNull(m_NetworkNameState, "A NetworkNameState component needs to be attached!");
             Assert.IsTrue(m_Camera != null && m_CanvasTransform != null);
 
             m_VerticalOffset = new Vector3(0f, m_VerticalScreenOffset, 0f);
@@ -109,6 +113,12 @@ namespace BossRoom
                     CharacterTypeChanged(m_NetworkCharacterTypeState.CharacterType.Value,
                         m_NetworkCharacterTypeState.CharacterType.Value);
                 }
+
+                if (m_NetworkHealthState != null)
+                {
+                    m_NetworkHealthState.HitPointsReplenished += DisplayUIHealth;
+                    m_NetworkHealthState.HitPointsDepleted += RemoveUIHealth;
+                }
             }
         }
 
@@ -137,7 +147,11 @@ namespace BossRoom
             if (characterClass)
             {
                 m_BaseHP = characterClass.BaseHP;
-                DisplayUIHealth();
+
+                if (m_NetworkHealthState != null && m_NetworkHealthState.HitPoints.Value > 0)
+                {
+                    DisplayUIHealth();
+                }
             }
         }
 
@@ -171,9 +185,6 @@ namespace BossRoom
 
             m_UIState.DisplayHealth(m_NetworkHealthState.HitPoints, m_BaseHP.Value);
             m_UIStateActive = true;
-
-            m_NetworkHealthState.HitPointsReplenished += DisplayUIHealth;
-            m_NetworkHealthState.HitPointsDepleted += RemoveUIHealth;
         }
 
         void SpawnUIState()


### PR DESCRIPTION
Jira bug [task](https://unity3d.atlassian.net/browse/GOMPS-366?atlOrigin=eyJpIjoiZjA5ZDVlYzE2N2U2NGFhNjlkNWQ2ZDQ5OGRkZjE4YTIiLCJwIjoiaiJ9).

Order of operations fix on fainted player on late join. Animator was swapped out after an animation trigger had been set. Similarly, health bar is only displayed if health above 0 on late join.