### PR TITLE
Adding Discord Server details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Banner](Documentation/Images/Banner.png)
-# BossRoom - co-op multiplayer RPG built with Unity MLAPI
+# BossRoom - Co-op multiplayer RPG built with Unity MLAPI
 
 >**IMPORTANT**: This project is currently experimental.
 
@@ -84,3 +84,7 @@ git clone https://github.com/Unity-Technologies/com.unity.multiplayer.samples.co
 ```
 
 Please check out [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on submitting issues and PRs to BossRoom!
+
+For futher discussion points and to connect with the team, join us on the MLAPI by Unity Discord Server - Channel #dev-samples
+
+[![Discord](https://img.shields.io/discord/449263083769036810.svg?label=discord&logo=discord&color=informational)](https://discord.gg/FM8SE9E)


### PR DESCRIPTION
Thought it would be beneficial to add the Discord Server and #dev-samples channel information in the readme to bring awareness to the community this exists.
Should help users with regards to connecting with Unity for informal chats/discussions/questions.