### PR TITLE
Feature/Camera Shake for animation triggers

### DIFF
--- a/Assets/BossRoom/Prefabs/GameCam/CMCameraPrefab.prefab
+++ b/Assets/BossRoom/Prefabs/GameCam/CMCameraPrefab.prefab
@@ -145,7 +145,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1676734516695783277}
-  m_LocalRotation: {x: 0.3985757, y: 0.3097298, z: -0.14506967, w: 0.8509757}
+  m_LocalRotation: {x: 0.3985757, y: 0.3097298, z: -0.14506969, w: 0.8509757}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -281,6 +281,7 @@ GameObject:
   - component: {fileID: 1676734516866984542}
   - component: {fileID: 1676734516866984541}
   - component: {fileID: 1676734516866984540}
+  - component: {fileID: 1887487880748770804}
   m_Layer: 0
   m_Name: cm
   m_TagString: Untagged
@@ -395,6 +396,23 @@ MonoBehaviour:
   m_BiasX: 0
   m_BiasY: 0
   m_CenterOnActivate: 1
+--- !u!114 &1887487880748770804
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1676734516866984546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 68bb026fafb42b14791938953eaace77, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_NoiseProfile: {fileID: 11400000, guid: 69ce8388f6785dd4c8c39915efece2f4, type: 2}
+  m_PivotOffset: {x: 0, y: 0, z: 0}
+  m_AmplitudeGain: 0
+  m_FrequencyGain: 0
+  mNoiseOffsets: {x: 0, y: 0, z: 0}
 --- !u!1 &1676734517288307075
 GameObject:
   m_ObjectHideFlags: 0
@@ -542,6 +560,7 @@ GameObject:
   - component: {fileID: 1676734517587239787}
   - component: {fileID: 1676734517587239786}
   - component: {fileID: 1676734517587239785}
+  - component: {fileID: 840967009523070532}
   m_Layer: 0
   m_Name: cm
   m_TagString: Untagged
@@ -656,6 +675,23 @@ MonoBehaviour:
   m_BiasX: 0
   m_BiasY: 0
   m_CenterOnActivate: 1
+--- !u!114 &840967009523070532
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1676734517587239791}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 68bb026fafb42b14791938953eaace77, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_NoiseProfile: {fileID: 11400000, guid: 69ce8388f6785dd4c8c39915efece2f4, type: 2}
+  m_PivotOffset: {x: 0, y: 0, z: 0}
+  m_AmplitudeGain: 0
+  m_FrequencyGain: 0
+  mNoiseOffsets: {x: 0, y: 0, z: 0}
 --- !u!1 &1676734517611811566
 GameObject:
   m_ObjectHideFlags: 0
@@ -668,6 +704,7 @@ GameObject:
   - component: {fileID: 1676734517611811562}
   - component: {fileID: 1676734517611811561}
   - component: {fileID: 1676734517611811560}
+  - component: {fileID: 9162384486652272211}
   m_Layer: 0
   m_Name: cm
   m_TagString: Untagged
@@ -782,6 +819,23 @@ MonoBehaviour:
   m_BiasX: 0
   m_BiasY: 0
   m_CenterOnActivate: 1
+--- !u!114 &9162384486652272211
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1676734517611811566}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 68bb026fafb42b14791938953eaace77, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_NoiseProfile: {fileID: 11400000, guid: 69ce8388f6785dd4c8c39915efece2f4, type: 2}
+  m_PivotOffset: {x: 0, y: 0, z: 0}
+  m_AmplitudeGain: 0
+  m_FrequencyGain: 0
+  mNoiseOffsets: {x: 0, y: 0, z: 0}
 --- !u!1 &2167489802469618434
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/BossRoom/Scripts/Client/Game/Character/CameraController.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/CameraController.cs
@@ -1,4 +1,6 @@
 using Cinemachine;
+using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -6,7 +8,15 @@ namespace BossRoom.Visual
 {
     public class CameraController : MonoBehaviour
     {
+        public static CameraController Instance { get; private set; }
+
         private CinemachineFreeLook m_MainCamera;
+        private Coroutine m_CoroCameraShake;
+
+        void Awake()
+        {
+            Instance = this;
+        }
 
         void Start()
         {
@@ -28,5 +38,47 @@ namespace BossRoom.Visual
                 m_MainCamera.m_YAxis.Value = 0.5f;
             }
         }
+
+        public void ShakeCamera(float frequency, float amplitude, float durationSecs)
+        {
+            if (m_CoroCameraShake != null)
+            {
+                StopCoroutine(m_CoroCameraShake);
+            }
+            m_CoroCameraShake = StartCoroutine(CoroShakeCamera(frequency, amplitude, durationSecs));
+        }
+
+        private IEnumerator CoroShakeCamera(float frequency, float amplitude, float durationSecs)
+        {
+            // find the noise-generating components on each rig
+            var perlins = new List<CinemachineBasicMultiChannelPerlin>();
+            for (int i = 0; i < CinemachineFreeLook.RigNames.Length; ++i)
+            {
+                var rig = m_MainCamera.GetRig(i);
+                var component = rig.GetCinemachineComponent<CinemachineBasicMultiChannelPerlin>();
+                if (!component)
+                    Debug.LogError($"Virtual Camera's {CinemachineFreeLook.RigNames[i]} layer needs to have Noise set to Basic Multi Channel Perlin", m_MainCamera.gameObject);
+                else
+                    perlins.Add(component);
+            }
+
+            // make 'em shake
+            foreach (var perlin in perlins)
+            {
+                perlin.m_FrequencyGain = frequency;
+                perlin.m_AmplitudeGain = amplitude;
+            }
+
+            yield return new WaitForSeconds(durationSecs);
+
+            // turn shaking off
+            foreach (var perlin in perlins)
+            {
+                perlin.m_FrequencyGain = 0;
+                perlin.m_AmplitudeGain = 0;
+            }
+            m_CoroCameraShake = null;
+        }
+
     }
 }


### PR DESCRIPTION
Extends the animation-trigger callback script to support camera shake. This is pretty simple because we just use Cinemachine's built-in camera-shaking functionality.

- This is intended for quite short shakes (less than 1sec) so I didn't bother with any functionality to ramp-down the shaking; it just turns off after a fixed amount of time. We could trivially add ramping if needed.
- Only one camera-shake operation can happen at a time; trying to shake the camera twice causes the first shake to prematurely abort.

*Details*
- Changed the camera prefab to have `BasicMultiChannelPerlin` noise components on all rigs. (Previously had no noise component.) Set default noise levels to 0.
- Expanded on the existing `CameraController` class: added a singleton accessor and a public `ShakeCamera()` function.
- Added fields to `AnimatorTriggeredSpecialFX` to set the timing and intensity of the shake.