### PR TITLE
[GOMPS-270] bossroom should let users specify connection port#

### DIFF
--- a/Assets/BossRoom/Prefabs/UI/PopupPanel.prefab
+++ b/Assets/BossRoom/Prefabs/UI/PopupPanel.prefab
@@ -497,8 +497,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 5.4901123}
-  m_SizeDelta: {x: -131.89911, y: -10.980476}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20.000002}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &458666890132928493
 CanvasRenderer:
@@ -580,7 +580,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -209.3999, y: -21.8}
+  m_AnchoredPosition: {x: -331, y: -21.8}
   m_SizeDelta: {x: 260, y: 95.1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2236248490323379053
@@ -612,7 +612,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: 21300000, guid: 41948b4cc6087644b983dce55b466d50, type: 3}
-  m_Type: 0
+  m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -678,6 +678,149 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_AlphaFadeSpeed: 0.15
+--- !u!1 &1801715322484230032
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2706160503418871213}
+  - component: {fileID: 5274622682025789011}
+  - component: {fileID: 4806063275483277531}
+  - component: {fileID: 1086460939974644440}
+  m_Layer: 5
+  m_Name: Port
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2706160503418871213
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1801715322484230032}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3819431325707803815}
+  - {fileID: 3995368619530485341}
+  m_Father: {fileID: 6702871171647363811}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -136.8, y: -255.52797}
+  m_SizeDelta: {x: 200, y: 95.1}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &5274622682025789011
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1801715322484230032}
+  m_CullTransparentMesh: 1
+--- !u!114 &4806063275483277531
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1801715322484230032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 298518cc35452404bbec1592572f23eb, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1086460939974644440
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1801715322484230032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d199490a83bb2b844b9695cbf13b01ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4806063275483277531}
+  m_TextComponent: {fileID: 5030219918351354159}
+  m_Placeholder: {fileID: 1243391925784967669}
+  m_ContentType: 0
+  m_InputType: 0
+  m_AsteriskChar: 42
+  m_KeyboardType: 0
+  m_LineType: 0
+  m_HideMobileInput: 0
+  m_CharacterValidation: 0
+  m_CharacterLimit: 0
+  m_OnEndEdit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_CustomCaretColor: 0
+  m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
+  m_Text: 
+  m_CaretBlinkRate: 0.85
+  m_CaretWidth: 1
+  m_ReadOnly: 0
+  m_ShouldActivateOnSelect: 1
 --- !u!1 &2576556376710765410
 GameObject:
   m_ObjectHideFlags: 0
@@ -753,6 +896,85 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2588038460876068370
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3819431325707803815}
+  - component: {fileID: 267750692968176180}
+  - component: {fileID: 1243391925784967669}
+  m_Layer: 5
+  m_Name: InputBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3819431325707803815
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2588038460876068370}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2706160503418871213}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20.000002}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &267750692968176180
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2588038460876068370}
+  m_CullTransparentMesh: 1
+--- !u!114 &1243391925784967669
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2588038460876068370}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9215687, g: 0.8196079, b: 0.24705884, a: 0.5}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 50
+    m_FontStyle: 3
+    m_BestFit: 1
+    m_MinSize: 0
+    m_MaxSize: 50
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Port#
 --- !u!1 &3724444898306361848
 GameObject:
   m_ObjectHideFlags: 0
@@ -1014,7 +1236,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6702871171647363811}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -1395,6 +1617,7 @@ RectTransform:
   - {fileID: 3244282122257790102}
   - {fileID: 6659754052889446194}
   - {fileID: 2254836287538418807}
+  - {fileID: 2706160503418871213}
   - {fileID: 3521129445966426109}
   - {fileID: 4392523060882783041}
   - {fileID: 4279823075853654326}
@@ -1460,13 +1683,93 @@ MonoBehaviour:
   m_MainText: {fileID: 617165807119984440}
   m_SubText: {fileID: 4548918475643758070}
   m_ReconnectingImage: {fileID: 8861405945138489867}
-  m_InputFieldParent: {fileID: 6953157192866993146}
-  m_InputBox: {fileID: 1315234412834876569}
+  m_InputField: {fileID: 3390070430270844082}
+  m_InputFieldPlaceholderText: {fileID: 7725811636295053124}
+  m_PortInputField: {fileID: 1086460939974644440}
   m_ConfirmationButton: {fileID: 6793055150678174106}
   m_ConfirmationText: {fileID: 8309750053309177991}
   m_CancelButton: {fileID: 562483524736970639}
-  m_NameDisplayGO: {fileID: 6487815535561920378}
+  m_NameDisplay: {fileID: 5969994396107504951}
   m_OnlineModeDropdown: {fileID: 203319813466524823}
+--- !u!1 &6909543335581182716
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3995368619530485341}
+  - component: {fileID: 1437297789190830641}
+  - component: {fileID: 5030219918351354159}
+  m_Layer: 5
+  m_Name: InputText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3995368619530485341
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6909543335581182716}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2706160503418871213}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20.000002}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1437297789190830641
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6909543335581182716}
+  m_CullTransparentMesh: 1
+--- !u!114 &5030219918351354159
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6909543335581182716}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9215687, g: 0.8196079, b: 0.24705884, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 50
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 0
+    m_MaxSize: 50
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 0
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
 --- !u!1 &6953157192866993146
 GameObject:
   m_ObjectHideFlags: 0
@@ -1502,10 +1805,10 @@ RectTransform:
   m_Father: {fileID: 6702871171647363811}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.29333335, y: 0.37500003}
-  m_AnchorMax: {x: 0.7133335, y: 0.55600005}
-  m_AnchoredPosition: {x: 149.1, y: -6}
-  m_SizeDelta: {x: 9, y: -3.75}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 31.2, y: 25.47203}
+  m_SizeDelta: {x: 440.6335, y: 95.1}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &4401179467636351219
 CanvasRenderer:
@@ -1536,8 +1839,8 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: 21300000, guid: 298518cc35452404bbec1592572f23eb, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 1
+  m_Type: 1
+  m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1
@@ -1609,6 +1912,7 @@ MonoBehaviour:
   m_CaretBlinkRate: 0.85
   m_CaretWidth: 1
   m_ReadOnly: 0
+  m_ShouldActivateOnSelect: 1
 --- !u!1 &7019167506905954160
 GameObject:
   m_ObjectHideFlags: 0
@@ -1685,7 +1989,7 @@ MonoBehaviour:
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
+    m_VerticalOverflow: 1
     m_LineSpacing: 1
   m_Text: Sub Text
 --- !u!1 &7844480942438631411
@@ -1722,8 +2026,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 5.4901123}
-  m_SizeDelta: {x: -131.89911, y: -10.980476}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20.000002}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3499041363254022569
 CanvasRenderer:
@@ -1878,7 +2182,7 @@ RectTransform:
   m_Children:
   - {fileID: 5717539780397104107}
   m_Father: {fileID: 6702871171647363811}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.404, y: 0}
   m_AnchorMax: {x: 0.6007507, y: 0.10055374}
@@ -1914,7 +2218,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: 21300000, guid: 41948b4cc6087644b983dce55b466d50, type: 3}
-  m_Type: 0
+  m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -2188,7 +2492,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1438005041722192374, guid: c3f6a30a7d785ef41a47b0cfd0c8b26d, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 1438005041722192374, guid: c3f6a30a7d785ef41a47b0cfd0c8b26d, type: 3}
       propertyPath: m_AnchorMax.x
@@ -2248,7 +2552,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1438005041722192374, guid: c3f6a30a7d785ef41a47b0cfd0c8b26d, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 75
+      value: 68.2
       objectReference: {fileID: 0}
     - target: {fileID: 1438005041722192374, guid: c3f6a30a7d785ef41a47b0cfd0c8b26d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -2304,13 +2608,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c3f6a30a7d785ef41a47b0cfd0c8b26d, type: 3}
---- !u!1 &6487815535561920378 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8728003287376236913, guid: c3f6a30a7d785ef41a47b0cfd0c8b26d, type: 3}
-  m_PrefabInstance: {fileID: 2533628164130561547}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &3521129445966426109 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 1438005041722192374, guid: c3f6a30a7d785ef41a47b0cfd0c8b26d, type: 3}
   m_PrefabInstance: {fileID: 2533628164130561547}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &5969994396107504951 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8210325049482289980, guid: c3f6a30a7d785ef41a47b0cfd0c8b26d, type: 3}
+  m_PrefabInstance: {fileID: 2533628164130561547}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 55aeec10c1bda27448c176abb6615c0f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/BossRoom/Scripts/Client/UI/MainMenuUI.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/MainMenuUI.cs
@@ -38,7 +38,7 @@ namespace BossRoom.Visual
         public void OnHostClicked()
         {
             m_ResponsePopup.SetupEnterGameDisplay(true, "Host Game", "Input the IP to host on", "Input the room name to host on", "iphost", "Confirm",
-                (string connectInput, string playerName, OnlineMode onlineMode) =>
+                (string connectInput, int connectPort, string playerName, OnlineMode onlineMode) =>
             {
                 m_GameNetPortal.PlayerName = playerName;
                 switch (onlineMode)
@@ -48,16 +48,16 @@ namespace BossRoom.Visual
                         break;
 
                     case OnlineMode.IpHost:
-                        m_GameNetPortal.StartHost(PostProcessIpInput(connectInput), k_ConnectPort);
+                        m_GameNetPortal.StartHost(PostProcessIpInput(connectInput), connectPort);
                         break;
                 }
-            }, k_DefaultIP);
+            }, k_DefaultIP, k_ConnectPort);
         }
 
         public void OnConnectClicked()
         {
             m_ResponsePopup.SetupEnterGameDisplay(false, "Join Game", "Input the host IP below", "Input the room name below", "iphost", "Join",
-                (string connectInput, string playerName, OnlineMode onlineMode) =>
+                (string connectInput, int connectPort, string playerName, OnlineMode onlineMode) =>
             {
                 m_GameNetPortal.PlayerName = playerName;
 
@@ -68,11 +68,11 @@ namespace BossRoom.Visual
                         break;
 
                     case OnlineMode.IpHost:
-                        ClientGameNetPortal.StartClient(m_GameNetPortal, connectInput, k_ConnectPort);
+                        ClientGameNetPortal.StartClient(m_GameNetPortal, connectInput, connectPort);
                         break;
                 }
                 m_ResponsePopup.SetupNotifierDisplay("Connecting", "Attempting to Join...", true, false);
-            }, k_DefaultIP);
+            }, k_DefaultIP, k_ConnectPort);
         }
 
         private string PostProcessIpInput(string ipInput)

--- a/Assets/BossRoom/Scripts/Client/UI/PopupPanel.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/PopupPanel.cs
@@ -22,10 +22,14 @@ namespace BossRoom.Visual
         [Tooltip("The Animating \"Connecting\" Image you want to animate to show the client is doing something")]
         private GameObject m_ReconnectingImage;
         [SerializeField]
-        [Tooltip("The GameObject holding the Input field for the panel")]
-        private GameObject m_InputFieldParent;
+        [Tooltip("The GameObject holding the \"Generic\" Input field (for IP address or other address forms)")]
+        private InputField m_InputField;
         [SerializeField]
-        private GameObject m_InputBox;
+        [Tooltip("The nested Text component of m_InputField, where we stick the placeholder text")]
+        private Text m_InputFieldPlaceholderText;
+        [SerializeField]
+        [Tooltip("The Port-number input field for the panel")]
+        private InputField m_PortInputField;
         [SerializeField]
         private Button m_ConfirmationButton;
         [SerializeField]
@@ -34,7 +38,7 @@ namespace BossRoom.Visual
         [Tooltip("This Button appears for popups that ask for player inputs")]
         private Button m_CancelButton;
         [SerializeField]
-        private GameObject m_NameDisplayGO;
+        private NameDisplay m_NameDisplay;
         [SerializeField]
         private Dropdown m_OnlineModeDropdown;
 
@@ -44,12 +48,13 @@ namespace BossRoom.Visual
         string m_RelayMainText;
 
         string m_DefaultIpInput;
+        int m_DefaultPort;
 
         /// <summary>
         /// Confirm function invoked when confirm is hit on popup. The meaning of the arguments may vary by popup panel, but
-        /// in the initial case of the login popup, they represent the IP Address input, and the Player Name.
+        /// in the initial case of the login popup, they represent the IP Address, port, the Player Name, and the connection mode
         /// </summary>
-        private System.Action<string, string, OnlineMode> m_ConfirmFunction;
+        private System.Action<string, int, string, OnlineMode> m_ConfirmFunction;
 
         private const string k_DefaultConfirmText = "OK";
 
@@ -66,8 +71,9 @@ namespace BossRoom.Visual
         /// <param name="confirmationText"> Text to display on the confirmation button</param>
         /// <param name="confirmCallback">  The delegate to invoke when the player confirms.  It sends what the player input.</param>
         /// <param name="defaultIpInput">The default Ip value to show in the input field.</param>
+        /// <param name="defaultPortInput">The default Port# to show in the port-input field.</param>
         public void SetupEnterGameDisplay(bool enterAsHost, string titleText, string ipHostMainText, string relayMainText, string inputFieldText,
-            string confirmationText, System.Action<string, string, OnlineMode> confirmCallback, string defaultIpInput = "")
+            string confirmationText, System.Action<string, int, string, OnlineMode> confirmCallback, string defaultIpInput = "", int defaultPortInput = 0)
         {
             //Clear any previous settings of the Panel first
             ResetState();
@@ -75,13 +81,15 @@ namespace BossRoom.Visual
             m_EnterAsHost = enterAsHost;
 
             m_DefaultIpInput = defaultIpInput;
+            m_DefaultPort = defaultPortInput;
 
             m_IpHostMainText = ipHostMainText;
             m_RelayMainText = relayMainText;
 
             m_TitleText.text = titleText;
             m_SubText.text = string.Empty;
-            m_InputBox.GetComponent<Text>().text = inputFieldText;
+            m_InputFieldPlaceholderText.text = inputFieldText;
+            m_PortInputField.text = defaultPortInput.ToString();
             m_ConfirmFunction = confirmCallback;
 
             m_ConfirmationText.text = confirmationText;
@@ -96,18 +104,21 @@ namespace BossRoom.Visual
             m_CancelButton.onClick.AddListener(OnCancelClick);
             m_CancelButton.gameObject.SetActive(true);
 
-            m_InputFieldParent.SetActive(true);
+            m_InputField.gameObject.SetActive(true);
+            m_PortInputField.gameObject.SetActive(true);
 
-            m_NameDisplayGO.SetActive(true);
+            m_NameDisplay.gameObject.SetActive(true);
 
             gameObject.SetActive(true);
         }
 
         private void OnConfirmClick()
         {
-            var inputField = m_InputFieldParent.GetComponent<InputField>();
-            var nameDisplay = m_NameDisplayGO.GetComponent<NameDisplay>();
-            m_ConfirmFunction.Invoke(inputField.text, nameDisplay.GetCurrentName(), (OnlineMode)m_OnlineModeDropdown.value);
+            int portNum = 0;
+            int.TryParse(m_PortInputField.text, out portNum);
+            if (portNum <= 0)
+                portNum = m_DefaultPort;
+            m_ConfirmFunction.Invoke(m_InputField.text, portNum, m_NameDisplay.GetCurrentName(), (OnlineMode)m_OnlineModeDropdown.value);
         }
 
         /// <summary>
@@ -124,13 +135,13 @@ namespace BossRoom.Visual
         /// </summary>
         private void OnOnlineModeDropdownChanged(int value)
         {
-            var inputField = m_InputFieldParent.GetComponent<InputField>();
-
             if (value == 0)
             {
                 // Ip host
                 m_MainText.text = m_IpHostMainText;
-                inputField.text = m_DefaultIpInput;
+                m_InputField.text = m_DefaultIpInput;
+                m_PortInputField.gameObject.SetActive(true);
+                m_PortInputField.text = m_DefaultPort.ToString();
             }
             else
             {
@@ -146,12 +157,15 @@ namespace BossRoom.Visual
 
                 if (m_EnterAsHost)
                 {
-                    inputField.text = GenerateRandomRoomKey();
+                    m_InputField.text = GenerateRandomRoomKey();
                 }
                 else
                 {
-                    inputField.text = "";
+                    m_InputField.text = "";
                 }
+
+                m_PortInputField.gameObject.SetActive(false);
+                m_PortInputField.text = "";
             }
         }
 
@@ -180,12 +194,12 @@ namespace BossRoom.Visual
             m_TitleText.text = string.Empty;
             m_MainText.text = string.Empty;
             m_SubText.text = string.Empty;
-            var inputField = m_InputFieldParent.GetComponent<InputField>();
-            inputField.text = string.Empty;
+            m_InputField.text = string.Empty;
+            m_PortInputField.text = string.Empty;
             m_ReconnectingImage.SetActive(false);
             m_ConfirmationButton.gameObject.SetActive(false);
             m_CancelButton.gameObject.SetActive(false);
-            m_NameDisplayGO.gameObject.SetActive(false);
+            m_NameDisplay.gameObject.SetActive(false);
 
             m_OnlineModeDropdown.gameObject.SetActive(false);
             m_OnlineModeDropdown.onValueChanged.RemoveListener(OnOnlineModeDropdownChanged);
@@ -214,7 +228,8 @@ namespace BossRoom.Visual
             m_ReconnectingImage.SetActive(displayImage);
 
             m_ConfirmationButton.gameObject.SetActive(displayConfirmation);
-            m_InputFieldParent.gameObject.SetActive(false);
+            m_InputField.gameObject.SetActive(false);
+            m_PortInputField.gameObject.SetActive(false);
             gameObject.SetActive(true);
         }
     }

--- a/Assets/BossRoom/Textures/UI/button_Blank.png.meta
+++ b/Assets/BossRoom/Textures/UI/button_Blank.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 100
-  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteBorder: {x: 7, y: 7, z: 7, w: 7}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1

--- a/Assets/BossRoom/Textures/UI/inputfield_Blank.png.meta
+++ b/Assets/BossRoom/Textures/UI/inputfield_Blank.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 100
-  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteBorder: {x: 7, y: 7, z: 7, w: 7}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1


### PR DESCRIPTION
Added a port-number field to the popup window. The port field is hidden in Photon mode.

Notes:
- Added slicing to some background images so I could reuse them. (Previously they were used as "simple" sprites, so they looked wrong with the smaller Port-field input box.)
- Revised the PopupPanel variables to be their appropriate types, rather than generic `GameObject`s that we have to constantly call `GetComponent<>()` on.