### PR TITLE
removed GC allocs inside of AIBrain

### DIFF
--- a/Assets/BossRoom/Scripts/Server/Game/Character/AIBrain.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/AIBrain.cs
@@ -17,7 +17,7 @@ namespace BossRoom.Server
             IDLE,
         }
 
-        static readonly AIStateType[] k_AIStates = { AIStateType.ATTACK , AIStateType.IDLE};
+        static readonly AIStateType[] k_AIStates = (AIStateType[])Enum.GetValues(typeof(AIStateType));
 
         private ServerCharacter m_ServerCharacter;
         private ActionPlayer m_ActionPlayer;
@@ -71,12 +71,11 @@ namespace BossRoom.Server
         {
             // for now we assume the AI states are in order of appropriateness,
             // which may be nonsensical when there are more states
-            for (int i = 0; i < k_AIStates.Length; i++)
+            foreach (AIStateType aiStateType in k_AIStates)
             {
-                var aiState = k_AIStates[i];
-                if (m_Logics[aiState].IsEligible())
+                if (m_Logics[aiStateType].IsEligible())
                 {
-                    return aiState;
+                    return aiStateType;
                 }
             }
 


### PR DESCRIPTION
Jira task [here](https://unity3d.atlassian.net/browse/GOMPS-218?atlOrigin=eyJpIjoiOWM5YTBmMmNlZmNjNDNmOGFjNjI5NmQwYjYwYmJiMDUiLCJwIjoiaiJ9). You can consider this as part 1 of more optimization PRs.

For this PR, I took a look at just the GC allocs while in the Boss Room scene. So as far as allocs go, there's none anymore. The two screenshots of the profiler are taken right after spawning.

Pre:
![pre-optimization](https://user-images.githubusercontent.com/75813458/112514932-30d23900-8d6c-11eb-941d-67074f239d1e.PNG)

Post:
![post-optimization](https://user-images.githubusercontent.com/75813458/112514953-36c81a00-8d6c-11eb-9be5-96173bd72b2f.PNG)

Effectively, this kills all of the 20kb per frame of allocs. The highlighted 60B in the post png is just an Assert so we're at 0B of GC allocs in builds (at this part of the level).

Stay tuned for the next optimization pass.
