### PR TITLE
null guard added inside of target action for accessing a possibly destroyed reticule

### DIFF
--- a/Assets/BossRoom/Scripts/Client/Game/Action/TargetActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/TargetActionFX.cs
@@ -55,8 +55,12 @@ namespace BossRoom.Visual
                 }
                 else
                 {
-                    m_TargetReticule.transform.parent = null;
-                    m_TargetReticule.SetActive(false);
+                    // null check here in case the target was destroyed along with the target reticule
+                    if (m_TargetReticule != null)
+                    {
+                        m_TargetReticule.transform.parent = null;
+                        m_TargetReticule.SetActive(false);
+                    }
                 }
             }
 


### PR DESCRIPTION
Jira bug [here](https://unity3d.atlassian.net/browse/GOMPS-395?atlOrigin=eyJpIjoiMDg0ZTEwY2YzYWY0NDFjZDk4MGVmZTZmOTY5ZTFmZjgiLCJwIjoiaiJ9).

Special scenario occurred where a target `NetworkObject` was destroyed (along with the childed reticule) before TargetActionFX had been cancelled, accessing the reticule when said `NetworkObject` was not a part of MLAPI's spawned objects. Null guard is added here.