### PR TITLE
init client door with server's current value for IsOpen

### DIFF
--- a/Assets/BossRoom/Scripts/Client/ClientDoorVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/ClientDoorVisualization.cs
@@ -37,8 +37,8 @@ public class ClientDoorVisualization : NetworkBehaviour
         {
             m_DoorState.IsOpen.OnValueChanged += OnDoorStateChanged;
 
-            // sanity-check that the physics object is active in the scene (because we default to "closed")
-            m_PhysicsObject.SetActive(true);
+            // initialize visuals based on current server state (or else we default to "closed")
+            OnDoorStateChanged(false, m_DoorState.IsOpen.Value);
         }
     }
 


### PR DESCRIPTION
Jira task [here](https://unity3d.atlassian.net/browse/GOMPS-409?atlOrigin=eyJpIjoiNzRkZjdjYjVmY2YxNDg1MTkxYjkwMmJhNDhhYTEwZTAiLCJwIjoiaiJ9).

Just needed to initialize the door visuals on the client with the server's most up to date value for `IsOpen`. 