### PR TITLE
added windows 7zip workaround in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Platforms : Windows, Mac
 ## Getting the project
  - A release version can be downloaded from the [Releases](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/releases) page. 
  - Alternatively: click the green `Code` button and then choose to download the zip archive. Remember, that you would download the branch that you are currently viewing in Github.
- - For Windows users: Using Windows' built-in extracting tool may generate a "Error 0x80010135: Path too long" error window which can invalidate the extraction process. The workaround for this issue is to extract the downloaded zip file using 7zip.
+ - For Windows users: Using Windows' built-in extracting tool may generate a "Error 0x80010135: Path too long" error window which can invalidate the extraction process. A workaround for this is to shorten the zip file to a single character (eg. "c.zip") and move it to the shortest path on your computer (most often right at C:\\) and retry. If that solution fails, another workaround is to extract the downloaded zip file using 7zip.
 
 
 ## Installing Git LFS


### PR DESCRIPTION
Jira bug [here](https://unity3d.atlassian.net/browse/GOMPS-365?atlOrigin=eyJpIjoiMTIxMWM0YjZiMTc5NDFhYTg2M2Y4OGNhY2JhNzRmZWMiLCJwIjoiaiJ9).

Added the 7zip workaround to our readme for Windows users encountering the "path too long" error message. Did not include registry workaround since that did not fix the issue either.