### PR TITLE
[GOMPS-355] Bugfix/multiple sessions fail

### DIFF
--- a/Assets/BossRoom/Scripts/Client/UI/PostGameUI.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/PostGameUI.cs
@@ -82,8 +82,9 @@ namespace BossRoom.Visual
         public void OnMainMenuClicked()
         {
             // Player is leaving this group - leave current network connection first
-            MLAPI.NetworkManager.Singleton.StopClient();
-            MLAPI.NetworkManager.Singleton.Shutdown();
+            var gameNetPortal = GameObject.FindGameObjectWithTag("GameNetPortal").GetComponent<GameNetPortal>();
+            gameNetPortal.RequestDisconnect();
+
             SceneManager.LoadScene("MainMenu");
         }
     }

--- a/Assets/BossRoom/Scripts/Shared/Net/GameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/GameNetPortal.cs
@@ -72,6 +72,8 @@ namespace BossRoom
         /// </summary>
         public event Action<ulong, int> ClientSceneChanged;
 
+        public event Action UserDisconnectRequested;
+
         public NetworkManager NetManager { get; private set; }
 
         /// <summary>
@@ -234,6 +236,14 @@ namespace BossRoom
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// This will disconnect (on the client) or shutdown the server (on the host). 
+        /// </summary>
+        public void RequestDisconnect()
+        {
+            UserDisconnectRequested?.Invoke();
         }
     }
 }


### PR DESCRIPTION
If you hit "Return to Main Menu" in the post-game scene, you couldn't reliably play again. This was because GameNetPortal wasn't properly cleaning up its state (either ServerGameNetPortal or ClientGameNetPortal, but Server was more serious, because it was tracking a bunch of dictionaries that needed to get wiped between sessions). 

I've done a pretty strenuous test with two clients and host, having one player be host multiple times, then having them alternate. I could consistently play and re-enter the match. 