### PR TITLE
Fix for T_Perlin_Noise_M.TGA and T_Ceramic_Tile_M.TGA read errors, Archer Skill 1 impact FX

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -45,7 +45,7 @@
 *.pict filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.psd filter=lfs diff=lfs merge=lfs -text
-*.tga filter=lfs diff=lfs merge=lfs -text
+*.[tT][gG][aA] filter=lfs diff=lfs merge=lfs -text
 *.tif filter=lfs diff=lfs merge=lfs -text
 *.tiff filter=lfs diff=lfs merge=lfs -text
 

--- a/Assets/BossRoom/VFX/Prefabs/Archer/FX_Archer_skill1_hit_1.prefab
+++ b/Assets/BossRoom/VFX/Prefabs/Archer/FX_Archer_skill1_hit_1.prefab
@@ -14602,8 +14602,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ParticleSystemsToTurnOffOnShutdown: []
-  m_PostShutdownSelfDestructTime: -1
   m_AutoShutdownTime: 1
+  m_PostShutdownSelfDestructTime: -1
 --- !u!1 &5258964564490418881
 GameObject:
   m_ObjectHideFlags: 0
@@ -14621,7 +14621,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &5258964564490418880
 Transform:
   m_ObjectHideFlags: 0
@@ -29243,7 +29243,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &5258964565526710723
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/BossRoom/VFX/Prefabs/Archer/FX_Archer_skill1_hit_2.prefab
+++ b/Assets/BossRoom/VFX/Prefabs/Archer/FX_Archer_skill1_hit_2.prefab
@@ -14593,8 +14593,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ParticleSystemsToTurnOffOnShutdown: []
-  m_PostShutdownSelfDestructTime: -1
   m_AutoShutdownTime: 1
+  m_PostShutdownSelfDestructTime: -1
 --- !u!1 &2196541489356617610
 GameObject:
   m_ObjectHideFlags: 0
@@ -19495,7 +19495,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &2196541489448644139
 Transform:
   m_ObjectHideFlags: 0
@@ -24369,7 +24369,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &2196541489980804988
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/BossRoom/VFX/Prefabs/Archer/FX_Archer_skill1_hit_3.prefab
+++ b/Assets/BossRoom/VFX/Prefabs/Archer/FX_Archer_skill1_hit_3.prefab
@@ -9810,7 +9810,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &2267207081835916265
 Transform:
   m_ObjectHideFlags: 0
@@ -34154,7 +34154,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &2267207082965088738
 Transform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
**Fix for T_Perlin_Noise_M.TGA and T_Ceramic_Tile_M.TGA read errors, Archer Skill 1 impact FX_**

The TGAs above were essentially corrupted due to an LFS issue where case sensitivity was the cause.  The .gitattributes were adjusted to include uppercase letters for 'TGA' extension.  Once these tga's get repacked the issue should go away.

Archer FX adjusted temporarily to remove the square halo effects but keeps the other aspects of the hit effects.
