### PR TITLE
Bug fix: volume controller problems

### DIFF
--- a/Assets/BossRoom/Scripts/Client/UI/StartupUI.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/StartupUI.cs
@@ -10,7 +10,6 @@ namespace BossRoom.Client
     {
         void Start()
         {
-            AudioListener.volume = ClientPrefs.GetMasterVolume();
             SceneManager.LoadScene("MainMenu");
         }
     }


### PR DESCRIPTION
A leftover line caused max-volume to be capped at whatever it was when the game started up. (Volume is controlled by an `AudioMixer` now, and this old line was directly changing the `AudioListener` volume... but only at startup, since the other lines that directly change `AudioListener` volume have been correctly removed.)

Edit: previously thought this was a merge issue from the release->develop merge, but I realized it's a bug in both branches, so not a merge problem