### PR TITLE
Refactor for stealth state, should use bool, not byte

### DIFF
--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientCharacterVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientCharacterVisualization.cs
@@ -252,7 +252,7 @@ namespace BossRoom.Visual
             SetAppearanceSwap();
         }
 
-        private void OnStealthyChanged(byte oldValue, byte newValue)
+        private void OnStealthyChanged(bool oldValue, bool newValue)
         {
             SetAppearanceSwap();
         }
@@ -261,7 +261,7 @@ namespace BossRoom.Visual
         {
             if (m_CharacterSwapper)
             {
-                if (m_NetState.IsStealthy.Value != 0 && !m_NetState.IsOwner)
+                if (m_NetState.IsStealthy.Value && !m_NetState.IsOwner)
                 {
                     // this character is in "stealth mode", so other players can't see them!
                     m_CharacterSwapper.SwapAllOff();

--- a/Assets/BossRoom/Scripts/Server/Game/Action/StealthModeAction.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Action/StealthModeAction.cs
@@ -25,7 +25,7 @@ namespace BossRoom.Server
             if (!movement.IsPerformingForcedMovement())
             {
                 movement.CancelMove();
-            }    
+            }
             return true;
         }
 
@@ -40,7 +40,7 @@ namespace BossRoom.Server
             {
                 // start actual stealth-mode... NOW!
                 m_IsStealthStarted = true;
-                m_Parent.NetState.IsStealthy.Value = 1;
+                m_Parent.NetState.IsStealthy.Value = true;
             }
             return !m_IsStealthEnded;
         }
@@ -66,7 +66,7 @@ namespace BossRoom.Server
                 m_IsStealthEnded = true;
                 if (m_IsStealthStarted)
                 {
-                    m_Parent.NetState.IsStealthy.Value = 0;
+                    m_Parent.NetState.IsStealthy.Value = false;
                 }
 
                 // note that we cancel the ActionFX here, and NOT in Cancel(). That's to handle the case where someone

--- a/Assets/BossRoom/Scripts/Server/Game/Character/AIBrain.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/AIBrain.cs
@@ -91,7 +91,7 @@ namespace BossRoom.Server
             if (potentialFoe == null ||
                 potentialFoe.IsNpc ||
                 potentialFoe.NetState.NetworkLifeState.Value != LifeState.Alive ||
-                potentialFoe.NetState.IsStealthy.Value != 0)
+                potentialFoe.NetState.IsStealthy.Value)
             {
                 return false;
             }

--- a/Assets/BossRoom/Scripts/Shared/Game/Entity/NetworkCharacterState.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/Entity/NetworkCharacterState.cs
@@ -51,11 +51,7 @@ namespace BossRoom
         /// <summary>
         /// Indicates whether this character is in "stealth mode" (invisible to monsters and other players).
         /// </summary>
-        /// <remarks>
-        /// FIXME: this should be a bool, but NetworkedVarBool doesn't work at the moment! It's serialized
-        /// as a bit, but deserialized as a byte, which corrupts the whole network-var stream.
-        /// </remarks>
-        public NetworkVariableByte IsStealthy { get; } = new NetworkVariableByte(0);
+        public NetworkVariableBool IsStealthy { get; } = new NetworkVariableBool();
 
         [SerializeField]
         NetworkHealthState m_NetworkHealthState;


### PR DESCRIPTION
This missing fix slipped through and gives the wrong message that NetworkVariableBool is broken (which is not the case). Removing that usage now to not mislead users.