### PR TITLE
Feature/remove unused work-around function (trivial)

### DIFF
--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerBossRoomState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerBossRoomState.cs
@@ -121,7 +121,6 @@ namespace BossRoom.Server
             if( sceneIndex == serverScene )
             {
                 Debug.Log($"client={clientId} now in scene {sceneIndex}, server_scene={serverScene}, all players in server scene={m_ServerNetPortal.AreAllClientsInServerScene()}");
-                //StartCoroutine(CoroTryToDoInitialSpawnAfterAWhile(clientId));
                 
                 bool didSpawn = DoInitialSpawnIfPossible();
 
@@ -134,21 +133,6 @@ namespace BossRoom.Server
                     SpawnPlayer(clientId);
                 }
                 
-            }
-        }
-
-        private IEnumerator CoroTryToDoInitialSpawnAfterAWhile(ulong clientId)
-        {
-            yield return new WaitForSeconds(3);
-            bool didSpawn = DoInitialSpawnIfPossible();
-
-            if (!didSpawn && InitialSpawnDone && NetworkSpawnManager.GetPlayerNetworkObject(clientId) == null)
-            {
-                //somebody joined after the initial spawn. This is a Late Join scenario. This player may have issues
-                //(either because multiple people are late-joining at once, or because some dynamic entities are
-                //getting spawned while joining. But that's not something we can fully address by changes in
-                //ServerBossRoomState.
-                SpawnPlayer(clientId);
             }
         }
 


### PR DESCRIPTION
The comments about this hacky function have already been removed, but the function itself remained (but was un-called). Since this is the MLAPI initialization code path, we want that to be as unambiguous as possible.