### PR TITLE
Feature/Fix anticipation for mage-bolts through walls

### DIFF
--- a/Assets/BossRoom/Scripts/Client/Game/Action/FXProjectileTargetedActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/FXProjectileTargetedActionFX.cs
@@ -152,8 +152,7 @@ namespace BossRoom.Visual
             // we change our data in the same way that the server will (changing our target point to the spot on the wall)
             if (Data.TargetIds != null && Data.TargetIds.Length > 0)
             {
-                var targetId = Data.TargetIds[0];
-                NetworkObject targetObj = MLAPI.Spawning.NetworkSpawnManager.SpawnedObjects[targetId];
+                var targetObj = NetworkSpawnManager.SpawnedObjects[Data.TargetIds[0]];
                 if (targetObj != null && !ActionUtils.HasLineOfSight(m_Parent.transform.position, targetObj.transform.position, out Vector3 collidePos))
                 {
                     // we do not have line of sight to the target point. So our target instead becomes the obstruction point

--- a/Assets/BossRoom/Scripts/Client/Game/Action/FXProjectileTargetedActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/FXProjectileTargetedActionFX.cs
@@ -150,15 +150,21 @@ namespace BossRoom.Visual
 
             // see if this is going to be a "miss" because the player tried to click through a wall. If so,
             // we change our data in the same way that the server will (changing our target point to the spot on the wall)
+            Vector3 targetSpot = Data.Position;
             if (Data.TargetIds != null && Data.TargetIds.Length > 0)
             {
                 var targetObj = NetworkSpawnManager.SpawnedObjects[Data.TargetIds[0]];
-                if (targetObj != null && !ActionUtils.HasLineOfSight(m_Parent.transform.position, targetObj.transform.position, out Vector3 collidePos))
+                if (targetObj)
                 {
-                    // we do not have line of sight to the target point. So our target instead becomes the obstruction point
-                    Data.TargetIds = null;
-                    Data.Position = collidePos;
+                    targetSpot = targetObj.transform.position;
                 }
+            }
+
+            if (!ActionUtils.HasLineOfSight(m_Parent.transform.position, targetSpot, out Vector3 collidePos))
+            {
+                // we do not have line of sight to the target point. So our target instead becomes the obstruction point
+                Data.TargetIds = null;
+                Data.Position = collidePos;
             }
         }
     }

--- a/Assets/BossRoom/Scripts/Client/Game/Action/FXProjectileTargetedActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/FXProjectileTargetedActionFX.cs
@@ -147,6 +147,20 @@ namespace BossRoom.Visual
         {
             base.AnticipateAction();
             PlayFireAnim();
+
+            // see if this is going to be a "miss" because the player tried to click through a wall. If so,
+            // we change our data in the same way that the server will (changing our target point to the spot on the wall)
+            if (Data.TargetIds != null && Data.TargetIds.Length > 0)
+            {
+                var targetId = Data.TargetIds[0];
+                NetworkObject targetObj = MLAPI.Spawning.NetworkSpawnManager.SpawnedObjects[targetId];
+                if (targetObj != null && !ActionUtils.HasLineOfSight(m_Parent.transform.position, targetObj.transform.position, out Vector3 collidePos))
+                {
+                    // we do not have line of sight to the target point. So our target instead becomes the obstruction point
+                    Data.TargetIds = null;
+                    Data.Position = collidePos;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
After the recent mage-bolt PR, mage-bolts can no longer go through walls. The action-anticipation system was merged separately and did not take this scenario into account, so mages can still see their mage-bolts going through walls (harmlessly) although other players will see the correct action.

This PR adds the needed Anticipation logic for `FXProjectileTargetedActionFX` so that it can properly predict when a mage-bolt is going to slam into a wall.