### PR TITLE
(Cleanup) (feedback needed) Remove redundant list of ServerCharacters

### DIFF
--- a/Assets/BossRoom/Prefabs/Character/Player.prefab
+++ b/Assets/BossRoom/Prefabs/Character/Player.prefab
@@ -13,6 +13,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_FeedbackPrefab: {fileID: 9137928905311479176, guid: 5d22c1d86e0e5604cbe14004bf924827, type: 3}
+--- !u!114 &-4877982356580531930
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6009713983291384756}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a46d628dbb19f12449867d14fa5268b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_CachedServerCharacter: {fileID: 6012286037226018870}
 --- !u!114 &2576537793715222015
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -61,18 +74,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Name:
     m_InternalValue: 
---- !u!114 &-4877982356580531930
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6009713983291384756}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a46d628dbb19f12449867d14fa5268b0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &3097905377639811107
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -222,6 +223,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4600110157238723791, guid: 0d2d836e2e83b754fa1a1c4022d6d65d, type: 3}
   m_PrefabInstance: {fileID: 7831782662127126385}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &6012286037226018870 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4602672899881656135, guid: 0d2d836e2e83b754fa1a1c4022d6d65d, type: 3}
+  m_PrefabInstance: {fileID: 7831782662127126385}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6009713983291384756}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 920a440eb254ba348915767fd046027a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &7751377510591478590 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 514105321093282895, guid: 0d2d836e2e83b754fa1a1c4022d6d65d, type: 3}

--- a/Assets/BossRoom/Prefabs/Character/Player.prefab
+++ b/Assets/BossRoom/Prefabs/Character/Player.prefab
@@ -61,6 +61,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Name:
     m_InternalValue: 
+--- !u!114 &-4877982356580531930
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6009713983291384756}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a46d628dbb19f12449867d14fa5268b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &3097905377639811107
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
@@ -33,11 +33,18 @@ namespace BossRoom.Server
             float detectionRangeSqr = detectionRange * detectionRange;
             Vector3 position = m_Brain.GetMyServerCharacter().transform.position;
 
-            foreach (ServerCharacter character in ServerCharacter.GetAllActiveServerCharacters())
+            foreach (var spawnedObject in MLAPI.Spawning.NetworkSpawnManager.SpawnedObjectsList)
             {
-                if (m_Brain.IsAppropriateFoe(character) && (character.transform.position - position).sqrMagnitude <= detectionRangeSqr)
+                if (!spawnedObject) { continue; } // must have been Destroy()ed very recently
+                if ((spawnedObject.transform.position - position).sqrMagnitude <= detectionRangeSqr)
                 {
-                    m_Brain.Hate(character);
+                    // they're within range... are they an appropriate foe?
+                    ServerCharacter serverChar = spawnedObject.GetComponent<ServerCharacter>();
+                    if (!serverChar) { continue; } // not even a character at all...
+                    if (m_Brain.IsAppropriateFoe(serverChar))
+                    {
+                        m_Brain.Hate(serverChar);
+                    }
                 }
             }
         }

--- a/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
@@ -34,23 +34,12 @@ namespace BossRoom.Server
             float detectionRangeSqr = detectionRange * detectionRange;
             Vector3 myPosition = m_Brain.GetMyServerCharacter().transform.position;
 
-            // in this game, NPCs only attack players (and never other NPCs), so we can just iterate over the connected players to see if any are nearby
-            foreach (var networkClient in NetworkManager.Singleton.ConnectedClientsList)
+            // in this game, NPCs only attack players (and never other NPCs), so we can just iterate over the players to see if any are nearby
+            foreach (var serverCharacter in PlayerServerCharacter.GetPlayerServerCharacters())
             {
-                if (networkClient.PlayerObject == null)
+                if (m_Brain.IsAppropriateFoe(serverCharacter) && (serverCharacter.transform.position - myPosition).sqrMagnitude <= detectionRangeSqr)
                 {
-                    // skip over any connection that doesn't have a PlayerObject yet
-                    continue;
-                }
-
-                if ((networkClient.PlayerObject.transform.position - myPosition).sqrMagnitude <= detectionRangeSqr)
-                {
-                    // they're in range! Make sure that they're actually an enemy
-                    var serverCharacter = networkClient.PlayerObject.GetComponent<ServerCharacter>();
-                    if (serverCharacter && m_Brain.IsAppropriateFoe(serverCharacter))
-                    {
-                        m_Brain.Hate(serverCharacter);
-                    }
+                    m_Brain.Hate(serverCharacter);
                 }
             }
         }

--- a/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
@@ -1,6 +1,4 @@
 using MLAPI;
-using MLAPI.Connection;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace BossRoom.Server

--- a/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
@@ -32,14 +32,14 @@ namespace BossRoom.Server
             float detectionRange = m_Brain.CharacterData.DetectRange;
             // we are doing this check every Update, so we'll use square-magnitude distance to avoid the expensive sqrt (that's implicit in Vector3.magnitude)
             float detectionRangeSqr = detectionRange * detectionRange;
-            Vector3 myPosition = m_Brain.GetMyServerCharacter().transform.position;
+            Vector3 position = m_Brain.GetMyServerCharacter().transform.position;
 
             // in this game, NPCs only attack players (and never other NPCs), so we can just iterate over the players to see if any are nearby
-            foreach (var serverCharacter in PlayerServerCharacter.GetPlayerServerCharacters())
+            foreach (var character in PlayerServerCharacter.GetPlayerServerCharacters())
             {
-                if (m_Brain.IsAppropriateFoe(serverCharacter) && (serverCharacter.transform.position - myPosition).sqrMagnitude <= detectionRangeSqr)
+                if (m_Brain.IsAppropriateFoe(character) && (character.transform.position - position).sqrMagnitude <= detectionRangeSqr)
                 {
-                    m_Brain.Hate(serverCharacter);
+                    m_Brain.Hate(character);
                 }
             }
         }

--- a/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
@@ -1,4 +1,3 @@
-using MLAPI.Spawning;
 using UnityEngine;
 
 namespace BossRoom.Server
@@ -34,18 +33,11 @@ namespace BossRoom.Server
             float detectionRangeSqr = detectionRange * detectionRange;
             Vector3 position = m_Brain.GetMyServerCharacter().transform.position;
 
-            foreach (var spawnedObject in NetworkSpawnManager.SpawnedObjectsList)
+            foreach (ServerCharacter character in ServerCharacter.GetAllActiveServerCharacters())
             {
-                if (!spawnedObject) { continue; } // must have been Destroy()ed very recently
-                if ((spawnedObject.transform.position - position).sqrMagnitude <= detectionRangeSqr)
+                if (m_Brain.IsAppropriateFoe(character) && (character.transform.position - position).sqrMagnitude <= detectionRangeSqr)
                 {
-                    // they're within range... are they an appropriate foe?
-                    ServerCharacter serverChar = spawnedObject.GetComponent<ServerCharacter>();
-                    if (!serverChar) { continue; } // not even a character at all...
-                    if (m_Brain.IsAppropriateFoe(serverChar))
-                    {
-                        m_Brain.Hate(serverChar);
-                    }
+                    m_Brain.Hate(character);
                 }
             }
         }

--- a/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
@@ -1,3 +1,4 @@
+using MLAPI.Spawning;
 using UnityEngine;
 
 namespace BossRoom.Server
@@ -33,7 +34,7 @@ namespace BossRoom.Server
             float detectionRangeSqr = detectionRange * detectionRange;
             Vector3 position = m_Brain.GetMyServerCharacter().transform.position;
 
-            foreach (var spawnedObject in MLAPI.Spawning.NetworkSpawnManager.SpawnedObjectsList)
+            foreach (var spawnedObject in NetworkSpawnManager.SpawnedObjectsList)
             {
                 if (!spawnedObject) { continue; } // must have been Destroy()ed very recently
                 if ((spawnedObject.transform.position - position).sqrMagnitude <= detectionRangeSqr)

--- a/Assets/BossRoom/Scripts/Server/Game/Character/PlayerServerCharacter.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/PlayerServerCharacter.cs
@@ -20,11 +20,19 @@ namespace BossRoom.Server
     {
         static List<ServerCharacter> s_ActivePlayers = new List<ServerCharacter>();
 
+        [SerializeField]
         ServerCharacter m_CachedServerCharacter;
+
+        public override void NetworkStart()
+        {
+            if( !IsServer )
+            {
+                enabled = false;
+            }
+        }
 
         void OnEnable()
         {
-            m_CachedServerCharacter = GetComponent<ServerCharacter>();
             s_ActivePlayers.Add(m_CachedServerCharacter);
         }
 
@@ -35,9 +43,11 @@ namespace BossRoom.Server
 
         /// <summary>
         /// Returns a list of all active players' ServerCharacters. Treat the list as read-only!
+        /// The list will be empty on the client.
         /// </summary>
         public static List<ServerCharacter> GetPlayerServerCharacters()
         {
+
             return s_ActivePlayers;
         }
     }

--- a/Assets/BossRoom/Scripts/Server/Game/Character/PlayerServerCharacter.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/PlayerServerCharacter.cs
@@ -1,0 +1,44 @@
+using System.Collections;
+using System.Collections.Generic;
+using MLAPI;
+using UnityEngine;
+
+namespace BossRoom.Server
+{
+    /// <summary>
+    /// Attached to the player-characters' prefab, this maintains a list of active ServerCharacter objects for players.
+    /// </summary>
+    /// <remarks>
+    /// This is an optimization. In server code you can already get a list of players' ServerCharacters by
+    /// iterating over the active connections and calling GetComponent() on their PlayerObject. But we need
+    /// to iterate over all players quite often -- the monsters' IdleAIState does so in every Update() --
+    /// and all those GetComponent() calls add up! So this optimization lets us iterate without calling
+    /// GetComponent().
+    /// </remarks>
+    [RequireComponent(typeof(ServerCharacter))]
+    public class PlayerServerCharacter : NetworkBehaviour
+    {
+        static List<ServerCharacter> s_ActivePlayers = new List<ServerCharacter>();
+
+        ServerCharacter m_CachedServerCharacter;
+
+        void OnEnable()
+        {
+            m_CachedServerCharacter = GetComponent<ServerCharacter>();
+            s_ActivePlayers.Add(m_CachedServerCharacter);
+        }
+
+        void OnDisable()
+        {
+            s_ActivePlayers.Remove(m_CachedServerCharacter);
+        }
+
+        /// <summary>
+        /// Returns a list of all active players' ServerCharacters. Treat the list as read-only!
+        /// </summary>
+        public static List<ServerCharacter> GetPlayerServerCharacters()
+        {
+            return s_ActivePlayers;
+        }
+    }
+}

--- a/Assets/BossRoom/Scripts/Server/Game/Character/PlayerServerCharacter.cs.meta
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/PlayerServerCharacter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a46d628dbb19f12449867d14fa5268b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
@@ -42,6 +42,11 @@ namespace BossRoom.Server
         // Cached component reference
         private ServerCharacterMovement m_Movement;
 
+        /// <summary>
+        /// Stores a list of all the active characters.
+        /// </summary>
+        private static List<ServerCharacter> s_ActiveServerCharacters = new List<ServerCharacter>();
+
         private void Awake()
         {
             m_Movement = GetComponent<ServerCharacterMovement>();
@@ -52,6 +57,32 @@ namespace BossRoom.Server
             {
                 m_AIBrain = new AIBrain(this, m_ActionPlayer);
             }
+        }
+
+        private void OnEnable()
+        {
+            s_ActiveServerCharacters.Add(this);
+        }
+
+        private void OnDisable()
+        {
+            s_ActiveServerCharacters.Remove(this);
+        }
+
+        /// <summary>
+        /// Retrieve a list of all active ServerCharacters. Treat the list as read-only!
+        /// </summary>
+        /// <remarks>
+        /// MLAPI also has a built-in list for this: you can just iterate over
+        /// MLAPI.Spawning.NetworkSpawnManager.SpawnedObjectsList. However, that's a list of
+        /// NetworkObjects, so we'd still still need to call GetComponent on those to get a
+        /// ServerCharacter reference. This function is an optimization for when we just need
+        /// to iterate on ServerCharacters.
+        /// </remarks>
+        /// <returns>list of all ServerCharacters which are active and enabled</returns>
+        public static List<ServerCharacter> GetAllActiveServerCharacters()
+        {
+            return s_ActiveServerCharacters;
         }
 
         public override void NetworkStart()

--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
@@ -42,11 +42,6 @@ namespace BossRoom.Server
         // Cached component reference
         private ServerCharacterMovement m_Movement;
 
-        /// <summary>
-        /// Stores a list of all the active characters.
-        /// </summary>
-        private static List<ServerCharacter> s_ActiveServerCharacters = new List<ServerCharacter>();
-
         private void Awake()
         {
             m_Movement = GetComponent<ServerCharacterMovement>();
@@ -57,32 +52,6 @@ namespace BossRoom.Server
             {
                 m_AIBrain = new AIBrain(this, m_ActionPlayer);
             }
-        }
-
-        private void OnEnable()
-        {
-            s_ActiveServerCharacters.Add(this);
-        }
-
-        private void OnDisable()
-        {
-            s_ActiveServerCharacters.Remove(this);
-        }
-
-        /// <summary>
-        /// Retrieve a list of all active ServerCharacters. Treat the list as read-only!
-        /// </summary>
-        /// <remarks>
-        /// MLAPI also has a built-in list for this: you can just iterate over
-        /// MLAPI.Spawning.NetworkSpawnManager.SpawnedObjectsList. However, that's a list of
-        /// NetworkObjects, so we'd still still need to call GetComponent on those to get a
-        /// ServerCharacter reference. This function is an optimization for when we just need
-        /// to iterate on ServerCharacters.
-        /// </remarks>
-        /// <returns>list of all ServerCharacters which are active and enabled</returns>
-        public static List<ServerCharacter> GetAllActiveServerCharacters()
-        {
-            return s_ActiveServerCharacters;
         }
 
         public override void NetworkStart()

--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
@@ -42,12 +42,6 @@ namespace BossRoom.Server
         // Cached component reference
         private ServerCharacterMovement m_Movement;
 
-        /// <summary>
-        /// Temp place to store all the active characters (to avoid having to
-        /// perform insanely-expensive GameObject.Find operations during Update)
-        /// </summary>
-        private static List<ServerCharacter> s_ActiveServerCharacters = new List<ServerCharacter>();
-
         private void Awake()
         {
             m_Movement = GetComponent<ServerCharacterMovement>();
@@ -58,21 +52,6 @@ namespace BossRoom.Server
             {
                 m_AIBrain = new AIBrain(this, m_ActionPlayer);
             }
-        }
-
-        private void OnEnable()
-        {
-            s_ActiveServerCharacters.Add(this);
-        }
-
-        private void OnDisable()
-        {
-            s_ActiveServerCharacters.Remove(this);
-        }
-
-        public static List<ServerCharacter> GetAllActiveServerCharacters()
-        {
-            return s_ActiveServerCharacters;
         }
 
         public override void NetworkStart()

--- a/Assets/BossRoom/Scripts/Server/Game/Entity/ServerWaveSpawner.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Entity/ServerWaveSpawner.cs
@@ -248,15 +248,9 @@ namespace BossRoom.Server
 
             // iterate through clients and only return true if a player is in range
             // and is not occluded by a blocking collider.
-            foreach (KeyValuePair<ulong, NetworkClient> idToClient in NetworkManager.Singleton.ConnectedClients)
+            foreach (var serverCharacter in PlayerServerCharacter.GetPlayerServerCharacters())
             {
-                if (idToClient.Value.PlayerObject == null)
-                {
-                    // skip over any connection that doesn't have a PlayerObject yet
-                    continue;
-                }
-
-                var playerPosition = idToClient.Value.PlayerObject.transform.position;
+                var playerPosition = serverCharacter.transform.position;
                 var direction = playerPosition - spawnerPosition;
 
                 if (direction.sqrMagnitude > squaredProximityDistance)

--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerBossRoomState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerBossRoomState.cs
@@ -184,12 +184,10 @@ namespace BossRoom.Server
             if (lifeState == LifeState.Fainted)
             {
                 // Check the life state of all players in the scene
-                foreach (var p in NetworkManager.Singleton.ConnectedClientsList )
+                foreach (var serverCharacter in PlayerServerCharacter.GetPlayerServerCharacters())
                 {
-                    if (p.PlayerObject == null) { continue; }
-                    // if any player is alive just retrun
-                    var netState = p.PlayerObject.GetComponent<NetworkCharacterState>();
-                    if ( netState.NetworkLifeState.Value == LifeState.Alive ) { return; }
+                    // if any player is alive just retun
+                    if (serverCharacter.NetState && serverCharacter.NetState.NetworkLifeState.Value == LifeState.Alive) { return; }
                 }
 
                 // If we made it this far, all players are down! switch to post game


### PR DESCRIPTION
Edit: moving the static list of `ServerCharacters` into a separate class that ONLY tracks the `ServerCharacters` for players. Refactored code that iterates players to use this new list.

---
`ServerCharacter` had a static list of all active `ServerCharacters`. This turns out to be basically redundant with MLAPI's `NetworkSpawnManager` which already provides a list of these. The static list had already been phased out in all but one place, so I've refactored the last remaining spot.

But note that this code is slower than before: `NetworkSpawnManager` gives us a listing of `NetworkObject`s, so we have to call `GetComponent<ServerCharacter>()` on each one to get the actual character info. And unfortunately the last remaining use of this list is in code that gets called many times every frame. 

So I refactored the code to do other checks first before calling `GetComponent<>()`, to minimize the number of calls needed. But even so, it's definitely not a performance improvement. But it does make the code cleaner, and this is supposed to be demo code, so that's important.

So feedback is needed! Should we go this route? Alternatively we could remove the comments that say the `ServerCharacter` list is "temporary" and commit to using it in the various places that the server needs a list of `ServerCharacter`s. (There are only a few other places.)