### PR TITLE
(Cleanup) Isolate testing commands

### DIFF
--- a/Assets/BossRoom/Prefabs/State/BossRoomState.prefab
+++ b/Assets/BossRoom/Prefabs/State/BossRoomState.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: -1764033382396218637}
   - component: {fileID: 3608714310874968837}
   - component: {fileID: 5762482089640033414}
+  - component: {fileID: 2113376856512980659}
   m_Layer: 0
   m_Name: BossRoomState
   m_TagString: Untagged
@@ -83,8 +84,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_PlayerPrefab: {fileID: 6009713983291384767, guid: 8237adf32a9b6de4892e6febe6b4bdef, type: 3}
-  m_EnemyPrefab: {fileID: 3713729372785093435, guid: 6cdd52f1fa2ed34469a487ae6477eded, type: 3}
-  m_BossPrefab: {fileID: 3688950541947916326, guid: 365e94337fd10fe4ebde1906df413ac7, type: 3}
   m_PlayerSpawnPoints:
   - {fileID: 6319832178442273571}
   - {fileID: 374135395555381814}
@@ -94,6 +93,23 @@ MonoBehaviour:
   - {fileID: 6314369147267609336}
   - {fileID: 8725901042666772653}
   - {fileID: 7239491272522478247}
+--- !u!114 &2113376856512980659
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 297185343939699586}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ab1e76745edfc434ab8154ad27efc5fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EnemyPrefab: {fileID: 3713729372785093435, guid: 6cdd52f1fa2ed34469a487ae6477eded, type: 3}
+  m_BossPrefab: {fileID: 3688950541947916326, guid: 365e94337fd10fe4ebde1906df413ac7, type: 3}
+  m_SpawnEnemyKeyCode: 101
+  m_SpawnBossKeyCode: 98
+  m_InstantQuitKeyCode: 113
 --- !u!1 &1088799320945899822
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerBossRoomState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerBossRoomState.cs
@@ -15,21 +15,11 @@ namespace BossRoom.Server
         [Tooltip("Make sure this is included in the NetworkManager's list of prefabs!")]
         private NetworkObject m_PlayerPrefab;
 
-        // note: this is temporary, for testing!
-        [SerializeField]
-        [Tooltip("Make sure this is included in the NetworkManager's list of prefabs!")]
-        private NetworkObject m_EnemyPrefab;
-
-        // note: this is temporary, for testing!
-        [SerializeField]
-        [Tooltip("Make sure this is included in the NetworkManager's list of prefabs!")]
-        private NetworkObject m_BossPrefab;
-
         [SerializeField] [Tooltip("A collection of locations for spawning players")]
         private Transform[] m_PlayerSpawnPoints;
+
         private List<Transform> m_PlayerSpawnPointsList = null;
 
-        // note: this is temporary, for testing!
         public override GameState ActiveState { get { return GameState.BossRoom; } }
 
         /// <summary>
@@ -215,28 +205,6 @@ namespace BossRoom.Server
 
             GameStateRelay.SetRelayObject(gameWon);
             MLAPI.SceneManagement.NetworkSceneManager.SwitchScene("PostGame");
-        }
-
-        /// <summary>
-        /// Temp code to spawn an enemy
-        /// </summary>
-        private void Update()
-        {
-            if (Input.GetKeyDown(KeyCode.E))
-            {
-                var newEnemy = Instantiate(m_EnemyPrefab);
-                newEnemy.SpawnWithOwnership(NetworkManager.Singleton.LocalClientId);
-            }
-            if (Input.GetKeyDown(KeyCode.B))
-            {
-                var newEnemy = Instantiate(m_BossPrefab);
-                newEnemy.SpawnWithOwnership(NetworkManager.Singleton.LocalClientId);
-            }
-            if (Input.GetKeyDown(KeyCode.Q))
-            {
-                GameStateRelay.SetRelayObject(false);
-                MLAPI.SceneManagement.NetworkSceneManager.SwitchScene("PostGame");
-            }
         }
     }
 }

--- a/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs
+++ b/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs
@@ -11,7 +11,7 @@ namespace BossRoom.Server
     /// </summary>
     public class ServerTestingHotkeys : NetworkBehaviour
     {
-#if DEBUG
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
         [SerializeField]
         [Tooltip("Enemy to spawn. Make sure this is included in the NetworkManager's list of prefabs!")]
         private NetworkObject m_EnemyPrefab;

--- a/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs
+++ b/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs
@@ -1,0 +1,67 @@
+using System.Collections;
+using System.Collections.Generic;
+using MLAPI;
+using UnityEngine;
+
+namespace BossRoom.Server
+{
+    /// <summary>
+    /// Provides various special commands that the Host can use while developing and
+    /// debugging the game. Remove this component before releasing your game! (So that
+    /// regular players can't spawn extra bosses etc.)
+    /// </summary>
+    public class ServerTestingHotkeys : NetworkBehaviour
+    {
+        [SerializeField]
+        [Tooltip("Enemy to spawn. Make sure this is included in the NetworkManager's list of prefabs!")]
+        private NetworkObject m_EnemyPrefab;
+
+        [SerializeField]
+        [Tooltip("Boss to spawn. Make sure this is included in the NetworkManager's list of prefabs!")]
+        private NetworkObject m_BossPrefab;
+
+        [SerializeField]
+        [Tooltip("Key that the Host can press to spawn an extra enemy")]
+        KeyCode m_SpawnEnemyKeyCode = KeyCode.E;
+
+        [SerializeField]
+        [Tooltip("Key that the Host can press to spawn an extra boss")]
+        KeyCode m_SpawnBossKeyCode = KeyCode.B;
+
+        [SerializeField]
+        [Tooltip("Key that the Host can press to quit the game")]
+        KeyCode m_InstantQuitKeyCode = KeyCode.Q;
+
+        public override void NetworkStart()
+        {
+            base.NetworkStart();
+
+            if (!IsServer)
+            {
+                // these commands don't work on the client
+                enabled = false;
+            }
+        }
+
+        private void Update()
+        {
+            if (!IsServer) { return; } // not initialized yet
+
+            if (m_SpawnEnemyKeyCode != KeyCode.None && Input.GetKeyDown(m_SpawnEnemyKeyCode))
+            {
+                var newEnemy = Instantiate(m_EnemyPrefab);
+                newEnemy.SpawnWithOwnership(NetworkManager.Singleton.LocalClientId);
+            }
+            if (m_SpawnBossKeyCode != KeyCode.None && Input.GetKeyDown(m_SpawnBossKeyCode))
+            {
+                var newEnemy = Instantiate(m_BossPrefab);
+                newEnemy.SpawnWithOwnership(NetworkManager.Singleton.LocalClientId);
+            }
+            if (m_InstantQuitKeyCode != KeyCode.None && Input.GetKeyDown(m_InstantQuitKeyCode))
+            {
+                GameStateRelay.SetRelayObject(false); // indicate to the post-game screen that the game was lost
+                MLAPI.SceneManagement.NetworkSceneManager.SwitchScene("PostGame");
+            }
+        }
+    }
+}

--- a/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs
+++ b/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using MLAPI;
 using UnityEngine;
 
@@ -7,11 +5,13 @@ namespace BossRoom.Server
 {
     /// <summary>
     /// Provides various special commands that the Host can use while developing and
-    /// debugging the game. Remove this component before releasing your game! (So that
-    /// regular players can't spawn extra bosses etc.)
+    /// debugging the game. These are not compiled into release builds. (If you want
+    /// to disable them for debug builds, disable or remove this component from the
+    /// BossRoomState prefab.)
     /// </summary>
     public class ServerTestingHotkeys : NetworkBehaviour
     {
+#if DEBUG
         [SerializeField]
         [Tooltip("Enemy to spawn. Make sure this is included in the NetworkManager's list of prefabs!")]
         private NetworkObject m_EnemyPrefab;
@@ -63,5 +63,6 @@ namespace BossRoom.Server
                 MLAPI.SceneManagement.NetworkSceneManager.SwitchScene("PostGame");
             }
         }
+#endif
     }
 }

--- a/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs.meta
+++ b/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ab1e76745edfc434ab8154ad27efc5fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Moves the testing commands that were hacked into `ServerBossRoomState` into their own separate component on the same prefab.