### PR TITLE
fix multiplayer crash with 3+ players

### DIFF
--- a/Assets/BossRoom/Prefabs/UI/PartyHUD.prefab
+++ b/Assets/BossRoom/Prefabs/UI/PartyHUD.prefab
@@ -515,12 +515,12 @@ MonoBehaviour:
   m_HeroPortrait: {fileID: 5210474332450112926}
   m_AllyPanel:
   - {fileID: 5210474332398139193}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
+  - {fileID: 6042862686332759618}
+  - {fileID: 3759591257053709494}
+  - {fileID: 6428511468958896844}
+  - {fileID: 8094401296900619990}
+  - {fileID: 3517950856442431943}
+  - {fileID: 5243745618188427346}
   m_PartyNames:
   - {fileID: 250046666732236924}
   - {fileID: 2163460391199144719}
@@ -1007,17 +1007,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
---- !u!114 &4497871128696616115 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2854038016992096615, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+--- !u!1 &8094401296900619990 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7612533173075622658, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
   m_PrefabInstance: {fileID: 1869048277445658068}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &2746177728441234144 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4606148437314926388, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
@@ -1029,11 +1023,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &8094401296900619991 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7612533173075622659, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+--- !u!114 &4497871128696616115 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2854038016992096615, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
   m_PrefabInstance: {fileID: 1869048277445658068}
   m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &8094401297039032692 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7612533173214069920, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
@@ -1045,6 +1045,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &8094401296900619991 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7612533173075622659, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+  m_PrefabInstance: {fileID: 1869048277445658068}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2405098457727327056
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1170,6 +1175,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+--- !u!224 &5243745618188427347 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7612533173075622659, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+  m_PrefabInstance: {fileID: 2405098457727327056}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &5243745618326724592 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7612533173214069920, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
@@ -1179,6 +1189,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &503053204761307703 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2854038016992096615, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+  m_PrefabInstance: {fileID: 2405098457727327056}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &2201402412324695140 stripped
@@ -1192,22 +1213,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &5243745618188427347 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7612533173075622659, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+--- !u!1 &5243745618188427346 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7612533173075622658, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
   m_PrefabInstance: {fileID: 2405098457727327056}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &503053204761307703 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2854038016992096615, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
-  m_PrefabInstance: {fileID: 2405098457727327056}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &2443893677897878587
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1321,27 +1331,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
---- !u!1 &5210474332398139193 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7612533173075622658, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
-  m_PrefabInstance: {fileID: 2443893677897878587}
-  m_PrefabAsset: {fileID: 0}
---- !u!224 &5210474332398139192 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7612533173075622659, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
-  m_PrefabInstance: {fileID: 2443893677897878587}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &2163460391199144719 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4606148437314926388, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
-  m_PrefabInstance: {fileID: 2443893677897878587}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &464398727078690140 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2854038016992096615, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
@@ -1364,6 +1353,27 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &2163460391199144719 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4606148437314926388, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+  m_PrefabInstance: {fileID: 2443893677897878587}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &5210474332398139192 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7612533173075622659, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+  m_PrefabInstance: {fileID: 2443893677897878587}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5210474332398139193 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7612533173075622658, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+  m_PrefabInstance: {fileID: 2443893677897878587}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3500299156316842446
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1489,17 +1499,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
---- !u!114 &6428511468820376942 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7612533173214069920, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+--- !u!1 &6428511468958896844 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7612533173075622658, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
   m_PrefabInstance: {fileID: 3500299156316842446}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+--- !u!224 &6428511468958896845 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7612533173075622659, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+  m_PrefabInstance: {fileID: 3500299156316842446}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1116853197768302330 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4606148437314926388, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
@@ -1511,11 +1520,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &6428511468958896845 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7612533173075622659, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
-  m_PrefabInstance: {fileID: 3500299156316842446}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1659607236287879337 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2854038016992096615, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
@@ -1525,6 +1529,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6428511468820376942 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7612533173214069920, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+  m_PrefabInstance: {fileID: 3500299156316842446}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &4213584805106750784
@@ -1652,22 +1667,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
---- !u!224 &6042862686332759619 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7612533173075622659, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
-  m_PrefabInstance: {fileID: 4213584805106750784}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &402503268967604852 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4606148437314926388, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
-  m_PrefabInstance: {fileID: 4213584805106750784}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &2153351169271473191 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2854038016992096615, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
@@ -1690,6 +1689,27 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &402503268967604852 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4606148437314926388, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+  m_PrefabInstance: {fileID: 4213584805106750784}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &6042862686332759619 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7612533173075622659, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+  m_PrefabInstance: {fileID: 4213584805106750784}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &6042862686332759618 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7612533173075622658, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+  m_PrefabInstance: {fileID: 4213584805106750784}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6446730504065839813
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1815,6 +1835,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+--- !u!1 &3517950856442431943 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7612533173075622658, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+  m_PrefabInstance: {fileID: 6446730504065839813}
+  m_PrefabAsset: {fileID: 0}
 --- !u!224 &3517950856442431942 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7612533173075622659, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
@@ -2014,5 +2039,10 @@ MonoBehaviour:
 --- !u!224 &3759591257053709495 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7612533173075622659, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
+  m_PrefabInstance: {fileID: 6740172041578971060}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &3759591257053709494 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7612533173075622658, guid: 1782ae3289c756b469d350bb8a554592, type: 3}
   m_PrefabInstance: {fileID: 6740172041578971060}
   m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
PartyHUD prefab had gotten messed up, so that if you had 3 or more players, you would hit an unassigned entry in the array on startup, causing an NRE on all clients. This happened at a vulnerable time on the host, as well, causing the game to completely fail to initialize (no dynamic entities spawned).

For some reason, Unity shuffled the prefab a good bit, but the only actual change is to the `m_AllyPanel` serialized array. 