### PR TITLE
removing duplicate prefabs from main menu scene

### DIFF
--- a/Assets/BossRoom/Scenes/MainMenu.unity
+++ b/Assets/BossRoom/Scenes/MainMenu.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb3cb49cb437750c9aac36521dcb84ded801db7c4300a21ff90ab4542951d95b
-size 53379
+oid sha256:5060647f2ae656c8a84051a839ff727d64afdd7194347967b5cd1c909f083681
+size 46738


### PR DESCRIPTION
This is GOMPS-474. Two separate GameObjects had been duplicated unnecessarily in the MainMenu scene. 