### PR TITLE
Feature/Imp health bars

### DIFF
--- a/Assets/BossRoom/Prefabs/Character/Imp.prefab
+++ b/Assets/BossRoom/Prefabs/Character/Imp.prefab
@@ -1,5 +1,26 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-4570750241117365215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3713729372785093424}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cead4253912fb1241be383143c5f3b59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_DisplayHealth: 1
+  m_DisplayName: 0
+  m_UIStatePrefab: {fileID: -1943162842029199943, guid: 2b07482491a17964380023240087ce16, type: 3}
+  m_NetworkNameState: {fileID: 0}
+  m_NetworkHealthState: {fileID: 827948680237315002}
+  m_BaseHP: {fileID: 11400000, guid: 95633dc134a4e654f863831b22b5681a, type: 2}
+  m_TransformToTrack: {fileID: 6486568539699693356}
+  m_VerticalWorldOffset: 2.2
+  m_VerticalScreenOffset: 20
 --- !u!1001 &1127359556114831008
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -61,6 +82,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1ffde884792e9a44a9fbe049ebb79c9f, type: 3}
+--- !u!4 &6486568539699693356 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6170428688339538316, guid: 1ffde884792e9a44a9fbe049ebb79c9f, type: 3}
+  m_PrefabInstance: {fileID: 1127359556114831008}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2173896227866280545
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -150,8 +176,24 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 64cfd098f62285f42918875fef849e88, type: 3}
+--- !u!1 &3713729372785093424 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3288448142974003537, guid: 64cfd098f62285f42918875fef849e88, type: 3}
+  m_PrefabInstance: {fileID: 2173896227866280545}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &3713729372785093434 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3288448142974003547, guid: 64cfd098f62285f42918875fef849e88, type: 3}
   m_PrefabInstance: {fileID: 2173896227866280545}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &827948680237315002 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1537501989561463259, guid: 64cfd098f62285f42918875fef849e88, type: 3}
+  m_PrefabInstance: {fileID: 2173896227866280545}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3713729372785093424}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6733907396f36c44891916e5c62f25a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/BossRoom/Scripts/Shared/Game/UI/UIHealth.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/UI/UIHealth.cs
@@ -28,6 +28,7 @@ namespace BossRoom
         void HealthChanged(int previousValue, int newValue)
         {
             m_HitPointsSlider.value = newValue;
+            // disable slider when we're at full health!
             m_HitPointsSlider.gameObject.SetActive(m_HitPointsSlider.value != m_HitPointsSlider.maxValue);
         }
 

--- a/Assets/BossRoom/Scripts/Shared/Game/UI/UIHealth.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/UI/UIHealth.cs
@@ -20,9 +20,7 @@ namespace BossRoom
 
             m_HitPointsSlider.minValue = 0;
             m_HitPointsSlider.maxValue = maxValue;
-            m_HitPointsSlider.value = networkedHealth.Value;
-            // disable slider when we're at full health!
-            m_HitPointsSlider.gameObject.SetActive(m_HitPointsSlider.value != m_HitPointsSlider.maxValue);
+            HealthChanged(maxValue, maxValue);
 
             m_NetworkedHealth.OnValueChanged += HealthChanged;
         }

--- a/Assets/BossRoom/Scripts/Shared/Game/UI/UIHealth.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/UI/UIHealth.cs
@@ -21,8 +21,8 @@ namespace BossRoom
             m_HitPointsSlider.minValue = 0;
             m_HitPointsSlider.maxValue = maxValue;
             m_HitPointsSlider.value = networkedHealth.Value;
-            // disable ourselves when we're at full health!
-            gameObject.SetActive(m_HitPointsSlider.value != m_HitPointsSlider.maxValue);
+            // disable slider when we're at full health!
+            m_HitPointsSlider.gameObject.SetActive(m_HitPointsSlider.value != m_HitPointsSlider.maxValue);
 
             m_NetworkedHealth.OnValueChanged += HealthChanged;
         }
@@ -30,7 +30,7 @@ namespace BossRoom
         void HealthChanged(int previousValue, int newValue)
         {
             m_HitPointsSlider.value = newValue;
-            gameObject.SetActive(m_HitPointsSlider.value != m_HitPointsSlider.maxValue);
+            m_HitPointsSlider.gameObject.SetActive(m_HitPointsSlider.value != m_HitPointsSlider.maxValue);
         }
 
         void OnDestroy()

--- a/Assets/BossRoom/Scripts/Shared/Game/UI/UIHealth.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/UI/UIHealth.cs
@@ -21,6 +21,8 @@ namespace BossRoom
             m_HitPointsSlider.minValue = 0;
             m_HitPointsSlider.maxValue = maxValue;
             m_HitPointsSlider.value = networkedHealth.Value;
+            // disable ourselves when we're at full health!
+            gameObject.SetActive(m_HitPointsSlider.value != m_HitPointsSlider.maxValue);
 
             m_NetworkedHealth.OnValueChanged += HealthChanged;
         }
@@ -28,6 +30,7 @@ namespace BossRoom
         void HealthChanged(int previousValue, int newValue)
         {
             m_HitPointsSlider.value = newValue;
+            gameObject.SetActive(m_HitPointsSlider.value != m_HitPointsSlider.maxValue);
         }
 
         void OnDestroy()


### PR DESCRIPTION
- Imps have health bars
- To reduce visual noise, ALL health bars (not just imps') are disabled when the creature is at full health

(I believe this has a GOMPS number but I don't have it, sorry!)