### PR TITLE
Bugfix: testing commands created monsters that were not destroyed on new scene

### DIFF
--- a/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs
+++ b/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs
@@ -50,12 +50,12 @@ namespace BossRoom.Server
             if (m_SpawnEnemyKeyCode != KeyCode.None && Input.GetKeyDown(m_SpawnEnemyKeyCode))
             {
                 var newEnemy = Instantiate(m_EnemyPrefab);
-                newEnemy.SpawnWithOwnership(NetworkManager.Singleton.LocalClientId);
+                newEnemy.SpawnWithOwnership(NetworkManager.Singleton.LocalClientId, null, false);
             }
             if (m_SpawnBossKeyCode != KeyCode.None && Input.GetKeyDown(m_SpawnBossKeyCode))
             {
                 var newEnemy = Instantiate(m_BossPrefab);
-                newEnemy.SpawnWithOwnership(NetworkManager.Singleton.LocalClientId);
+                newEnemy.SpawnWithOwnership(NetworkManager.Singleton.LocalClientId, null, false);
             }
             if (m_InstantQuitKeyCode != KeyCode.None && Input.GetKeyDown(m_InstantQuitKeyCode))
             {

--- a/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs
+++ b/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs
@@ -50,12 +50,12 @@ namespace BossRoom.Server
             if (m_SpawnEnemyKeyCode != KeyCode.None && Input.GetKeyDown(m_SpawnEnemyKeyCode))
             {
                 var newEnemy = Instantiate(m_EnemyPrefab);
-                newEnemy.SpawnWithOwnership(NetworkManager.Singleton.LocalClientId, null, false);
+                newEnemy.SpawnWithOwnership(NetworkManager.Singleton.LocalClientId, null, true);
             }
             if (m_SpawnBossKeyCode != KeyCode.None && Input.GetKeyDown(m_SpawnBossKeyCode))
             {
                 var newEnemy = Instantiate(m_BossPrefab);
-                newEnemy.SpawnWithOwnership(NetworkManager.Singleton.LocalClientId, null, false);
+                newEnemy.SpawnWithOwnership(NetworkManager.Singleton.LocalClientId, null, true);
             }
             if (m_InstantQuitKeyCode != KeyCode.None && Input.GetKeyDown(m_InstantQuitKeyCode))
             {

--- a/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs
+++ b/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs
@@ -5,13 +5,11 @@ namespace BossRoom.Server
 {
     /// <summary>
     /// Provides various special commands that the Host can use while developing and
-    /// debugging the game. These are not compiled into release builds. (If you want
-    /// to disable them for debug builds, disable or remove this component from the
-    /// BossRoomState prefab.)
+    /// debugging the game. To disable them, just disable or remove this component from the
+    /// BossRoomState prefab.
     /// </summary>
     public class ServerTestingHotkeys : NetworkBehaviour
     {
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
         [SerializeField]
         [Tooltip("Enemy to spawn. Make sure this is included in the NetworkManager's list of prefabs!")]
         private NetworkObject m_EnemyPrefab;
@@ -63,6 +61,5 @@ namespace BossRoom.Server
                 MLAPI.SceneManagement.NetworkSceneManager.SwitchScene("PostGame");
             }
         }
-#endif
     }
 }


### PR DESCRIPTION
Change the testing commands to explicitly spawn test entities with the "don't destroy on load" parameter set to true.

(This fixes null-ref exceptions when you have a test-spawned monster selected when the game switches to the game over scene.)