### PR TITLE
Bugfix/broken pieces should not be hit by attacks/projectiles [GOMPS-461]

### DIFF
--- a/Assets/BossRoom/Prefabs/Dungeon/Dungeon Pieces/crystal/DestroyedCrystal.prefab
+++ b/Assets/BossRoom/Prefabs/Dungeon/Dungeon Pieces/crystal/DestroyedCrystal.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1541629390887175354}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: DestroyedCrystal
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -199,6 +199,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: -5659141163140084603, guid: c4f463f134352e74fbcead59ab69cd0b, type: 3}
+      propertyPath: m_Layer
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: -5172141398949723459, guid: c4f463f134352e74fbcead59ab69cd0b, type: 3}
+      propertyPath: m_Layer
+      value: 11
+      objectReference: {fileID: 0}
     - target: {fileID: -2088346993707834735, guid: c4f463f134352e74fbcead59ab69cd0b, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
@@ -206,6 +214,10 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: c4f463f134352e74fbcead59ab69cd0b, type: 3}
       propertyPath: m_Name
       value: FX_crystal_fractured
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: c4f463f134352e74fbcead59ab69cd0b, type: 3}
+      propertyPath: m_Layer
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 3290009304433194289, guid: c4f463f134352e74fbcead59ab69cd0b, type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -215,10 +227,18 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 5dc79f6519261e547a9d31b0de849df7, type: 2}
+    - target: {fileID: 4776845662628537640, guid: c4f463f134352e74fbcead59ab69cd0b, type: 3}
+      propertyPath: m_Layer
+      value: 11
+      objectReference: {fileID: 0}
     - target: {fileID: 5252780467383862430, guid: c4f463f134352e74fbcead59ab69cd0b, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 5dc79f6519261e547a9d31b0de849df7, type: 2}
+    - target: {fileID: 5561462458993163771, guid: c4f463f134352e74fbcead59ab69cd0b, type: 3}
+      propertyPath: m_Layer
+      value: 11
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c4f463f134352e74fbcead59ab69cd0b, type: 3}
 --- !u!4 &249462584427040044 stripped
@@ -253,9 +273,33 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1541629390887175354}
     m_Modifications:
+    - target: {fileID: 1140103133073429911, guid: 522ed1e5449e13b43a80542aba5f44b0, type: 3}
+      propertyPath: m_Layer
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140103133826660496, guid: 522ed1e5449e13b43a80542aba5f44b0, type: 3}
+      propertyPath: m_Layer
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1191045743090379605, guid: 522ed1e5449e13b43a80542aba5f44b0, type: 3}
+      propertyPath: m_Layer
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199304498559288796, guid: 522ed1e5449e13b43a80542aba5f44b0, type: 3}
+      propertyPath: m_Layer
+      value: 11
+      objectReference: {fileID: 0}
     - target: {fileID: 1288506294775531400, guid: 522ed1e5449e13b43a80542aba5f44b0, type: 3}
       propertyPath: m_Name
       value: FX_CrystalBreak
+      objectReference: {fileID: 0}
+    - target: {fileID: 1288506294775531400, guid: 522ed1e5449e13b43a80542aba5f44b0, type: 3}
+      propertyPath: m_Layer
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 2380265202133969754, guid: 522ed1e5449e13b43a80542aba5f44b0, type: 3}
+      propertyPath: m_Layer
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 8154881980970276200, guid: 522ed1e5449e13b43a80542aba5f44b0, type: 3}
       propertyPath: m_RootOrder

--- a/Assets/BossRoom/Prefabs/Dungeon/Dungeon Pieces/pillar/env_pillar2_break_parent.prefab
+++ b/Assets/BossRoom/Prefabs/Dungeon/Dungeon Pieces/pillar/env_pillar2_break_parent.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 766550571898993353}
   - component: {fileID: 8388815557714725565}
   - component: {fileID: 3091520393029845584}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece18
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -125,7 +125,7 @@ GameObject:
   - component: {fileID: 5351541862114366288}
   - component: {fileID: 5271794033111800885}
   - component: {fileID: 6388211216152783374}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece13
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -237,7 +237,7 @@ GameObject:
   - component: {fileID: 6732769893413350319}
   - component: {fileID: 6171719622084367254}
   - component: {fileID: 5903738699012741128}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece23
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -349,7 +349,7 @@ GameObject:
   - component: {fileID: 6278122754136073799}
   - component: {fileID: 4310947341030800116}
   - component: {fileID: 6895069026363135586}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece22
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -461,7 +461,7 @@ GameObject:
   - component: {fileID: 6931091892735717695}
   - component: {fileID: 4530522426999143201}
   - component: {fileID: 4457567631889887269}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece06
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -573,7 +573,7 @@ GameObject:
   - component: {fileID: 7373713575333315781}
   - component: {fileID: 4246325097704593059}
   - component: {fileID: 4872163304228815242}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece12
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -685,7 +685,7 @@ GameObject:
   - component: {fileID: 6939234079247399316}
   - component: {fileID: 7679475131515571257}
   - component: {fileID: 6135766826560991988}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece17
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -797,7 +797,7 @@ GameObject:
   - component: {fileID: 1980646940342091043}
   - component: {fileID: 2179182727441519536}
   - component: {fileID: 5756351256016087417}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece07
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -909,7 +909,7 @@ GameObject:
   - component: {fileID: 6210679743554296508}
   - component: {fileID: 3070229933226231648}
   - component: {fileID: 6013081685500744881}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece04
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1021,7 +1021,7 @@ GameObject:
   - component: {fileID: 3174326371273471258}
   - component: {fileID: 3983720254146561870}
   - component: {fileID: 1945111652094448781}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece10
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1133,7 +1133,7 @@ GameObject:
   - component: {fileID: 5219130022772017147}
   - component: {fileID: 2126847441983864459}
   - component: {fileID: 8144627485816933536}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece01
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1245,7 +1245,7 @@ GameObject:
   - component: {fileID: 876295173137480230}
   - component: {fileID: 1097854648914449292}
   - component: {fileID: 6722119293014332982}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece15
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1357,7 +1357,7 @@ GameObject:
   - component: {fileID: 4149954566340455695}
   - component: {fileID: 6367289201669496255}
   - component: {fileID: 3780002655779221053}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece16
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1469,7 +1469,7 @@ GameObject:
   - component: {fileID: 657646280235621760}
   - component: {fileID: 4016566254551677506}
   - component: {fileID: 5549371333446589982}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece03
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1577,8 +1577,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 645693218498745049}
-  m_Layer: 6
-  m_Name: pillar2_break_parent
+  m_Layer: 11
+  m_Name: env_pillar2_break_parent
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1634,7 +1634,7 @@ GameObject:
   - component: {fileID: 4176182893125062045}
   - component: {fileID: 1154566088424568772}
   - component: {fileID: 7723735711054789922}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece11
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1746,7 +1746,7 @@ GameObject:
   - component: {fileID: 7493059939477915940}
   - component: {fileID: 6221418560066543074}
   - component: {fileID: 6302066847460757972}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece19
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1858,7 +1858,7 @@ GameObject:
   - component: {fileID: 3617879467464149818}
   - component: {fileID: 4665564740468183295}
   - component: {fileID: 7716830877621916730}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece14
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1970,7 +1970,7 @@ GameObject:
   - component: {fileID: 7119136482252253848}
   - component: {fileID: 8506839465442166565}
   - component: {fileID: 6630734593269059683}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece21
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2082,7 +2082,7 @@ GameObject:
   - component: {fileID: 8155426716073630590}
   - component: {fileID: 7285333388452339472}
   - component: {fileID: 6739770276377484038}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece02
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2194,7 +2194,7 @@ GameObject:
   - component: {fileID: 3947630497076214824}
   - component: {fileID: 7493818606072768269}
   - component: {fileID: 2360440197977878298}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece08
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2306,7 +2306,7 @@ GameObject:
   - component: {fileID: 1051479651921137141}
   - component: {fileID: 1208164841125817010}
   - component: {fileID: 7341289363569178142}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece20
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2418,7 +2418,7 @@ GameObject:
   - component: {fileID: 2723778106583055956}
   - component: {fileID: 6552484169009333784}
   - component: {fileID: 6851330780935724548}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece05
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2530,7 +2530,7 @@ GameObject:
   - component: {fileID: 6591564587712671407}
   - component: {fileID: 488374372761486461}
   - component: {fileID: 2488816291287111823}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: Pillar2_piece09
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/BossRoom/Prefabs/Dungeon/Dungeon Pieces/pots/env_pot_break_parent.prefab
+++ b/Assets/BossRoom/Prefabs/Dungeon/Dungeon Pieces/pots/env_pot_break_parent.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8468211178320996434}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: env_pot_break_parent
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -56,7 +56,7 @@ GameObject:
   - component: {fileID: 5102031322573347077}
   - component: {fileID: 7316400396496880022}
   - component: {fileID: 7316400396496880023}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: pot_piece02
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -168,7 +168,7 @@ GameObject:
   - component: {fileID: 4284841184029010151}
   - component: {fileID: 7030181784247546204}
   - component: {fileID: 7030181784247546205}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: pot_piece03
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -280,7 +280,7 @@ GameObject:
   - component: {fileID: 1564840416498919607}
   - component: {fileID: 5654591369161803064}
   - component: {fileID: 5654591369161803065}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: pot_piece10
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -392,7 +392,7 @@ GameObject:
   - component: {fileID: 4642817318826410789}
   - component: {fileID: 5502483849794461408}
   - component: {fileID: 5502483849794461409}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: pot_piece13
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -504,7 +504,7 @@ GameObject:
   - component: {fileID: 3232500743808386206}
   - component: {fileID: 4475943091721427540}
   - component: {fileID: 4475943091721427541}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: pot_piece07
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -616,7 +616,7 @@ GameObject:
   - component: {fileID: 625183139435398373}
   - component: {fileID: 4066725310200487071}
   - component: {fileID: 4066725310200487072}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: pot_piece09
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -728,7 +728,7 @@ GameObject:
   - component: {fileID: 125874915884235309}
   - component: {fileID: 4024810855340819945}
   - component: {fileID: 4024810855340819946}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: pot_piece12
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -840,7 +840,7 @@ GameObject:
   - component: {fileID: 8501642573400431748}
   - component: {fileID: 4014756192185213945}
   - component: {fileID: 4014756192185213946}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: pot_piece11
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -952,7 +952,7 @@ GameObject:
   - component: {fileID: 3942842255344410754}
   - component: {fileID: 3520790560474682876}
   - component: {fileID: 3520790560474682877}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: pot_piece04
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1064,7 +1064,7 @@ GameObject:
   - component: {fileID: 2746033278100512162}
   - component: {fileID: 2324344701996622366}
   - component: {fileID: 2324344701996622367}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: pot_piece01
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1176,7 +1176,7 @@ GameObject:
   - component: {fileID: 8328842720681741872}
   - component: {fileID: 1147113023832309412}
   - component: {fileID: 1147113023832309413}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: pot_piece08
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1288,7 +1288,7 @@ GameObject:
   - component: {fileID: 2126109533107805869}
   - component: {fileID: 146260849925775089}
   - component: {fileID: 146260849925775090}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: pot_piece05
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1400,7 +1400,7 @@ GameObject:
   - component: {fileID: 94611510085585439}
   - component: {fileID: 72387556096851665}
   - component: {fileID: 72387556096851666}
-  m_Layer: 6
+  m_Layer: 11
   m_Name: pot_piece06
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/BossRoom/Scenes/BossRoom.unity
+++ b/Assets/BossRoom/Scenes/BossRoom.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c124dd06d084ec3631cd7bde6137ff5c8a75f63a7ebb424941be33a8c84d493a
-size 193670
+oid sha256:25fcb94e98f9470a59b250ec37a0866b0f6026c49c7c6cf70db69ab923d76d1e
+size 201172

--- a/Assets/BossRoom/Scenes/BossRoom.unity
+++ b/Assets/BossRoom/Scenes/BossRoom.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:25fcb94e98f9470a59b250ec37a0866b0f6026c49c7c6cf70db69ab923d76d1e
-size 201172
+oid sha256:c124dd06d084ec3631cd7bde6137ff5c8a75f63a7ebb424941be33a8c84d493a
+size 193670

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd98f6f2c43732be288a6ea3709f3f35b2cb5a720c64f605b322798373557c8b
-size 549
+oid sha256:6f4df3f9fcac2a8ac2bdc1e46ee5a4e94890abba5c68b36ccc3ef4c888275a5e
+size 555


### PR DESCRIPTION
Adds a new Layer to the project, "Debris". The "broken" versions of pots, pillars, and crystals are now in the Debris layer. Since projectiles and attacks check for the "PC" "NPC" and "Ground" layers, this fixes the issue. 

(Previously these "broken versions" were using the NPCs layer.)