### PR TITLE
Bugfix: Fix mage-bolt friendly fire [GOMPS-299]

### DIFF
--- a/Assets/BossRoom/Scripts/Client/Game/Action/FXProjectileTargetedActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/FXProjectileTargetedActionFX.cs
@@ -102,10 +102,16 @@ namespace BossRoom.Visual
                 return null;
             }
 
-            NetworkObject obj;
-            if (NetworkSpawnManager.SpawnedObjects.TryGetValue(Data.TargetIds[0], out obj) && obj != null)
+            if (NetworkSpawnManager.SpawnedObjects.TryGetValue(Data.TargetIds[0], out NetworkObject targetObject) && targetObject != null)
             {
-                return obj;
+                // make sure this isn't a friend (or if it is, make sure this is a friendly-fire action)
+                var targetable = targetObject.GetComponent<ITargetable>();
+                if (targetable != null && targetable.IsNpc == (Description.IsFriendly ^ IsParentAnNPC()))
+                {
+                    // not a valid target
+                    return null;
+                }
+                return targetObject;
             }
             else
             {
@@ -114,6 +120,16 @@ namespace BossRoom.Visual
                 return null;
             }
         }
+
+        /// <summary>
+        /// Determines if the character playing this Action is an NPC (as opposed to a player)
+        /// </summary>
+        private bool IsParentAnNPC()
+        {
+            var targetable = m_Parent.Parent.GetComponent<ITargetable>();
+            return targetable.IsNpc;
+        }
+
 
         private FXProjectile SpawnAndInitializeProjectile()
         {

--- a/Assets/BossRoom/Scripts/Client/Game/Action/FXProjectileTargetedActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/FXProjectileTargetedActionFX.cs
@@ -28,17 +28,12 @@ namespace BossRoom.Visual
             bool wasAnticipated = Anticipated;
             base.Start();
             m_Target = GetTarget();
-            if (HasTarget() && m_Target == null)
-            {
-                // target has disappeared! Abort.
-                return false;
-            }
 
             if (Description.Projectiles.Length < 1 || Description.Projectiles[0].ProjectilePrefab == null)
                 throw new System.Exception($"Action {Description.ActionTypeEnum} has no valid ProjectileInfo!");
 
             // animate shooting the projectile
-            if( !wasAnticipated )
+            if (!wasAnticipated)
             {
                 PlayFireAnim();
             }
@@ -56,7 +51,7 @@ namespace BossRoom.Visual
             if (TimeRunning >= Description.ExecTimeSeconds && m_Projectile == null)
             {
                 // figure out how long the pretend-projectile will be flying to the target
-                Vector3 targetPos = HasTarget() ? m_Target.transform.position : m_Data.Position;
+                Vector3 targetPos = m_Target ? m_Target.transform.position : m_Data.Position;
                 float initialDistance = Vector3.Distance(targetPos, m_Parent.transform.position);
                 m_ProjectileDuration = initialDistance / Description.Projectiles[0].Speed_m_s;
 
@@ -98,14 +93,6 @@ namespace BossRoom.Visual
                 var hitReact = !string.IsNullOrEmpty(Description.ReactAnim) ? Description.ReactAnim : k_DefaultHitReact;
                 clientCharacter.ChildVizObject.OurAnimator.SetTrigger(hitReact);
             }
-        }
-
-        /// <summary>
-        /// Do we even have a target? (If false, it means player clicked on nothing, and we're rendering a "missed" fake bolt.)
-        /// </summary>
-        private bool HasTarget()
-        {
-            return Data.TargetIds != null && Data.TargetIds.Length > 0;
         }
 
         private NetworkObject GetTarget()

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
@@ -322,7 +322,7 @@ namespace BossRoom.Client
                     resultData.CancelMovement = true;
                     return;
                 case ActionLogic.RangedFXTargeted:
-                    if (resultData.TargetIds == null) { resultData.Position = hitPoint; }
+                    resultData.Position = hitPoint;
                     return;
             }
         }

--- a/Assets/BossRoom/Scripts/Server/Game/Action/FXProjectileTargetedAction.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Action/FXProjectileTargetedAction.cs
@@ -22,14 +22,9 @@ namespace BossRoom.Server
         public override bool Start()
         {
             m_Target = GetTarget();
-            if (m_Target == null && HasTarget())
-            {
-                // target has disappeared! Abort.
-                return false;
-            }
 
             // figure out where the player wants us to aim at...
-            Vector3 targetPos = HasTarget() ? m_Target.transform.position : m_Data.Position;
+            Vector3 targetPos = m_Target != null ? m_Target.transform.position : m_Data.Position;
 
             // then make sure we can actually see that point!
             if (!ActionUtils.HasLineOfSight(m_Parent.transform.position, targetPos, out Vector3 collidePos))
@@ -77,14 +72,6 @@ namespace BossRoom.Server
         }
 
         /// <summary>
-        /// Are we even supposed to have a target? (If not, we're representing a "missed" bolt that just hits nothing.)
-        /// </summary>
-        private bool HasTarget()
-        {
-            return Data.TargetIds != null && Data.TargetIds.Length > 0;
-        }
-
-        /// <summary>
         /// Returns our intended target, or null if not found/no target.
         /// </summary>
         private IDamageable GetTarget()
@@ -97,6 +84,13 @@ namespace BossRoom.Server
             NetworkObject obj;
             if (NetworkSpawnManager.SpawnedObjects.TryGetValue(Data.TargetIds[0], out obj) && obj != null)
             {
+                // make sure this isn't a friend (or if it is, make sure this is a friendly-fire action)
+                var serverChar = obj.GetComponent<ServerCharacter>();
+                if (serverChar && serverChar.IsNpc == (Description.IsFriendly ^ m_Parent.IsNpc))
+                {
+                    // not a valid target
+                    return null;
+                }
                 return obj.GetComponent<IDamageable>();
             }
             else


### PR DESCRIPTION
Many actions can cause the player to "look like" they're hitting another player (e.g. selecting an ally and clicking the Attack button will make your ally play a hit-react animation) but that's just amusing fluff... the problem is that mage bolt did actual damage to other players. This is fixed.

Also fixed: if the target of the mage bolt had disappeared since the attack was queued, it was simply aborted because it had no target. Now, the attack is not aborted, and turns into a "missed" bolt. (To do this, the client sends the click-position along with all mage-bolt attacks.)