### PR TITLE
Feature/Spawner Improvements

### DIFF
--- a/Assets/BossRoom/Prefabs/Game/EnemySpawner.prefab
+++ b/Assets/BossRoom/Prefabs/Game/EnemySpawner.prefab
@@ -60,6 +60,36 @@ Transform:
   m_Father: {fileID: 8727022540156222958}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!1 &1898120149362029613
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 894520739242503044}
+  m_Layer: 0
+  m_Name: SpawnPoint (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &894520739242503044
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1898120149362029613}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: -0.87499994, y: 0, z: 1.73}
+  m_LocalScale: {x: 1.3539857, y: 1.1857388, z: 1.2418212}
+  m_Children: []
+  m_Father: {fileID: 8727022540156222958}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1 &2091269911110589480
 GameObject:
   m_ObjectHideFlags: 0
@@ -119,6 +149,36 @@ Transform:
   m_Children: []
   m_Father: {fileID: 8727022540156222958}
   m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!1 &3496698763770893301
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5949595974590154644}
+  m_Layer: 0
+  m_Name: SpawnPoint (9)
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5949595974590154644
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3496698763770893301}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: -1.722057, y: 0, z: 2.298}
+  m_LocalScale: {x: 1.3539857, y: 1.1857388, z: 1.2418212}
+  m_Children: []
+  m_Father: {fileID: 8727022540156222958}
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1 &3529278057740772152
 GameObject:
@@ -302,6 +362,11 @@ Transform:
   - {fileID: 7959506842896624360}
   - {fileID: 5974522673422337960}
   - {fileID: 1274569494783434218}
+  - {fileID: 894520739242503044}
+  - {fileID: 7124730538960977854}
+  - {fileID: 2077514793330709529}
+  - {fileID: 3127061543440710862}
+  - {fileID: 5949595974590154644}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -341,17 +406,26 @@ MonoBehaviour:
   - {fileID: 7959506842896624360}
   - {fileID: 5974522673422337960}
   - {fileID: 1274569494783434218}
+  - {fileID: 894520739242503044}
+  - {fileID: 7124730538960977854}
+  - {fileID: 2077514793330709529}
+  - {fileID: 3127061543440710862}
+  - {fileID: 5949595974590154644}
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 1
   m_PlayerProximityValidationTimestep: 2
+  m_SpawnedEntityDetectDistance: 30
+  m_DetectStealthyPlayers: 1
   m_NumberOfWaves: 2
   m_SpawnsPerWave: 2
   m_TimeBetweenSpawns: 0.5
   m_TimeBetweenWaves: 5
   m_RestartDelay: 10
   m_ProximityDistance: 30
-  m_MaxActiveSpawns: 5
+  m_MinSpawnCap: 2
+  m_MaxSpawnCap: 10
+  m_SpawnCapIncreasePerPlayer: 1
 --- !u!114 &2847004539442057774
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -495,6 +569,96 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &6585344981094142531
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7124730538960977854}
+  m_Layer: 0
+  m_Name: SpawnPoint (6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7124730538960977854
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6585344981094142531}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: -0.875, y: 0, z: 3.167}
+  m_LocalScale: {x: 1.3539857, y: 1.1857388, z: 1.2418212}
+  m_Children: []
+  m_Father: {fileID: 8727022540156222958}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!1 &8845616318696809149
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2077514793330709529}
+  m_Layer: 0
+  m_Name: SpawnPoint (7)
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2077514793330709529
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8845616318696809149}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: -0.8760569, y: 0, z: 4.495}
+  m_LocalScale: {x: 1.3539857, y: 1.1857388, z: 1.2418212}
+  m_Children: []
+  m_Father: {fileID: 8727022540156222958}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!1 &9017715703642230324
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3127061543440710862}
+  m_Layer: 0
+  m_Name: SpawnPoint (8)
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3127061543440710862
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9017715703642230324}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: -1.722057, y: 0, z: 3.961}
+  m_LocalScale: {x: 1.3539857, y: 1.1857388, z: 1.2418212}
+  m_Children: []
+  m_Father: {fileID: 8727022540156222958}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1001 &1263729836617029720
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
@@ -29,7 +29,7 @@ namespace BossRoom.Server
 
         protected void DetectFoes()
         {
-            float detectionRange = m_Brain.CharacterData.DetectRange;
+            float detectionRange = m_Brain.GetMyServerCharacter().GetDetectRadius();
             // we are doing this check every Update, so we'll use square-magnitude distance to avoid the expensive sqrt (that's implicit in Vector3.magnitude)
             float detectionRangeSqr = detectionRange * detectionRange;
             Vector3 position = m_Brain.GetMyServerCharacter().transform.position;

--- a/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
@@ -29,9 +29,8 @@ namespace BossRoom.Server
 
         protected void DetectFoes()
         {
-            float detectionRange = m_Brain.GetMyServerCharacter().GetDetectRadius();
             // we are doing this check every Update, so we'll use square-magnitude distance to avoid the expensive sqrt (that's implicit in Vector3.magnitude)
-            float detectionRangeSqr = detectionRange * detectionRange;
+            float detectionRangeSqr = m_Brain.DetectRange * m_Brain.DetectRange;
             Vector3 position = m_Brain.GetMyServerCharacter().transform.position;
 
             // in this game, NPCs only attack players (and never other NPCs), so we can just iterate over the players to see if any are nearby

--- a/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/AIState/IdleAIState.cs
@@ -29,8 +29,9 @@ namespace BossRoom.Server
 
         protected void DetectFoes()
         {
+            float detectionRange = m_Brain.DetectRange;
             // we are doing this check every Update, so we'll use square-magnitude distance to avoid the expensive sqrt (that's implicit in Vector3.magnitude)
-            float detectionRangeSqr = m_Brain.DetectRange * m_Brain.DetectRange;
+            float detectionRangeSqr = detectionRange * detectionRange;
             Vector3 position = m_Brain.GetMyServerCharacter().transform.position;
 
             // in this game, NPCs only attack players (and never other NPCs), so we can just iterate over the players to see if any are nearby

--- a/Assets/BossRoom/Scripts/Server/Game/Character/AIBrain.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/AIBrain.cs
@@ -25,6 +25,12 @@ namespace BossRoom.Server
         private Dictionary<AIStateType, AIState> m_Logics;
         private List<ServerCharacter> m_HatedEnemies;
 
+        /// <summary>
+        /// If we are created by a spawner, the spawner might override our detection radius
+        /// -1 is a sentinel value meaning "no override"
+        /// </summary>
+        private float m_DetectRangeOverride = -1;
+
         public AIBrain(ServerCharacter me, ActionPlayer myActionPlayer)
         {
             m_ServerCharacter = me;
@@ -145,6 +151,24 @@ namespace BossRoom.Server
             get
             {
                 return GameDataSource.Instance.CharacterDataByType[m_ServerCharacter.NetState.CharacterType];
+            }
+        }
+
+        /// <summary>
+        /// The range at which this character can detect enemies, in meters.
+        /// This is usually the same value as is indicated by our game data, but it
+        /// can be dynamically overridden.
+        /// </summary>
+        public float DetectRange
+        {
+            get
+            {
+                return (m_DetectRangeOverride == -1) ? CharacterData.DetectRange : m_DetectRangeOverride;
+            }
+
+            set
+            {
+                m_DetectRangeOverride = value;
             }
         }
 

--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
@@ -42,6 +42,12 @@ namespace BossRoom.Server
         // Cached component reference
         private ServerCharacterMovement m_Movement;
 
+        /// <summary>
+        /// If we are created by a spawner, the spawner might override our detection radius
+        /// -1 is a sentinel value meaning "no override"
+        /// </summary>
+        private float m_DetectRadiusOverride = -1;
+
         private void Awake()
         {
             m_Movement = GetComponent<ServerCharacterMovement>();
@@ -212,6 +218,33 @@ namespace BossRoom.Server
         public float GetBuffedValue(Action.BuffableValue buffType)
         {
             return m_ActionPlayer.GetBuffedValue(buffType);
+        }
+
+        /// <summary>
+        /// Returns the range at which this character can detect enemies. Only applicable to NPCs.
+        /// This is usually the same value as is indicated by our game data, but it can be
+        /// dynamically overridden.
+        /// </summary>
+        /// <returns>our entity detection range (in meters)</returns>
+        public float GetDetectRadius()
+        {
+            if (m_DetectRadiusOverride == -1)
+            {
+                return GameDataSource.Instance.CharacterDataByType[NetState.CharacterType].DetectRange;
+            }
+            else
+            {
+                return m_DetectRadiusOverride;
+            }
+        }
+
+        /// <summary>
+        /// Changes this creature's detection radius. Only meaningful for NPCs.
+        /// </summary>
+        /// <param name="radius">new detection radius for this entity (in meters)</param>
+        public void SetDetectRadius(float radius)
+        {
+            m_DetectRadiusOverride = radius;
         }
 
         /// <summary>

--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
@@ -256,7 +256,7 @@ namespace BossRoom.Server
         }
 
         /// <summary>
-        /// This character's AIBrain. Will be null if this is not an NPC, or if this NPC has no "brain".
+        /// This character's AIBrain. Will be null if this is not an NPC.
         /// </summary>
         public AIBrain AIBrain { get { return m_AIBrain; } }
     }

--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
@@ -42,12 +42,6 @@ namespace BossRoom.Server
         // Cached component reference
         private ServerCharacterMovement m_Movement;
 
-        /// <summary>
-        /// If we are created by a spawner, the spawner might override our detection radius
-        /// -1 is a sentinel value meaning "no override"
-        /// </summary>
-        private float m_DetectRadiusOverride = -1;
-
         private void Awake()
         {
             m_Movement = GetComponent<ServerCharacterMovement>();
@@ -221,33 +215,6 @@ namespace BossRoom.Server
         }
 
         /// <summary>
-        /// Returns the range at which this character can detect enemies. Only applicable to NPCs.
-        /// This is usually the same value as is indicated by our game data, but it can be
-        /// dynamically overridden.
-        /// </summary>
-        /// <returns>our entity detection range (in meters)</returns>
-        public float GetDetectRadius()
-        {
-            if (m_DetectRadiusOverride == -1)
-            {
-                return GameDataSource.Instance.CharacterDataByType[NetState.CharacterType].DetectRange;
-            }
-            else
-            {
-                return m_DetectRadiusOverride;
-            }
-        }
-
-        /// <summary>
-        /// Changes this creature's detection radius. Only meaningful for NPCs.
-        /// </summary>
-        /// <param name="radius">new detection radius for this entity (in meters)</param>
-        public void SetDetectRadius(float radius)
-        {
-            m_DetectRadiusOverride = radius;
-        }
-
-        /// <summary>
         /// Receive a Life State change that brings Fainted characters back to Alive state.
         /// </summary>
         /// <param name="inflicter">Person reviving the character.</param>
@@ -287,5 +254,10 @@ namespace BossRoom.Server
         {
             return IDamageable.SpecialDamageFlags.None;
         }
+
+        /// <summary>
+        /// This character's AIBrain. Will be null if this is not an NPC, or if this NPC has no "brain".
+        /// </summary>
+        public AIBrain AIBrain { get { return m_AIBrain; } }
     }
 }

--- a/Assets/BossRoom/Scripts/Server/Game/Entity/ServerWaveSpawner.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Entity/ServerWaveSpawner.cs
@@ -20,6 +20,52 @@ namespace BossRoom.Server
         [Tooltip("Each spawned enemy appears at one of the points in this list")]
         List<Transform> m_SpawnPositions;
 
+        [Tooltip("Select which layers will block visibility.")]
+        [SerializeField]
+        LayerMask m_BlockingMask;
+
+        [Tooltip("Time between player distance & visibility scans, in seconds.")]
+        [SerializeField]
+        float m_PlayerProximityValidationTimestep = 2;
+
+        [SerializeField]
+        [Tooltip("The detection range of spawned entities. Only meaningful for NPCs (not breakables). -1 = \"use default for this NPC\"")]
+        float m_SpawnedEntityDetectDistance = -1;
+
+        [Header("Wave parameters")]
+        [Tooltip("Total number of waves.")]
+        [SerializeField]
+        int m_NumberOfWaves = 2;
+        [Tooltip("Number of spawns per wave.")]
+        [SerializeField]
+        int m_SpawnsPerWave = 2;
+        [Tooltip("Time between individual spawns, in seconds.")]
+        [SerializeField]
+        float m_TimeBetweenSpawns = 0.5f;
+        [Tooltip("Time between waves, in seconds.")]
+        [SerializeField]
+        float m_TimeBetweenWaves = 5;
+        [Tooltip("Once last wave is spawned, the spawner waits this long to restart wave spawns, in seconds.")]
+        [SerializeField]
+        float m_RestartDelay = 10;
+        [Tooltip("A player must be within this distance to commence first wave spawn.")]
+        [SerializeField]
+        float m_ProximityDistance = 30;
+        [SerializeField]
+        [Tooltip("When looking for players within proximity distance, should we count players in stealth mode?")]
+        bool m_DetectStealthyPlayers = true;
+
+        [Header("Spawn Cap (i.e. number of simultaneously spawned entities)")]
+        [SerializeField]
+        [Tooltip("The minimum number of entities this spawner will try to maintain (regardless of player count)")]
+        int m_MinSpawnCap = 2;
+        [SerializeField]
+        [Tooltip("The maximum number of entities this spawner will try to maintain (regardless of player count)")]
+        int m_MaxSpawnCap = 10;
+        [SerializeField]
+        [Tooltip("For each player in the game, the Spawn Cap is raised above the minimum by this amount. (Rounds up to nearest whole number.)")]
+        float m_SpawnCapIncreasePerPlayer = 1;
+
         // cache reference to our own transform
         Transform m_Transform;
 
@@ -34,52 +80,6 @@ namespace BossRoom.Server
 
         // cache array of RaycastHit as it will be reused for player visibility
         RaycastHit[] m_Hit;
-
-        [Tooltip("Select which layers will block visibility.")]
-        [SerializeField]
-        LayerMask m_BlockingMask;
-
-        [Tooltip("Time between player distance & visibility scans, in seconds.")]
-        [SerializeField]
-        float m_PlayerProximityValidationTimestep;
-
-        [SerializeField]
-        [Tooltip("The detection range of spawned entities. Only meaningful for NPCs (not breakables). -1 = \"use default for this NPC\"")]
-        float m_SpawnedEntityDetectDistance = -1;
-
-        [Header("Wave parameters")]
-        [Tooltip("Total number of waves.")]
-        [SerializeField]
-        int m_NumberOfWaves;
-        [Tooltip("Number of spawns per wave.")]
-        [SerializeField]
-        int m_SpawnsPerWave;
-        [Tooltip("Time between individual spawns, in seconds.")]
-        [SerializeField]
-        float m_TimeBetweenSpawns;
-        [Tooltip("Time between waves, in seconds.")]
-        [SerializeField]
-        float m_TimeBetweenWaves;
-        [Tooltip("Once last wave is spawned, the spawner waits this long to restart wave spawns, in seconds.")]
-        [SerializeField]
-        float m_RestartDelay;
-        [Tooltip("A player must be within this distance to commence first wave spawn.")]
-        [SerializeField]
-        float m_ProximityDistance;
-        [SerializeField]
-        [Tooltip("When looking for players within proximity distance, should we count players in stealth mode?")]
-        bool m_DetectStealthyPlayers;
-
-        [Header("Spawn Cap (i.e. number of simultaneously spawned entities)")]
-        [SerializeField]
-        [Tooltip("The minimum number of entities this spawner will try to maintain (regardless of player count)")]
-        int m_MinSpawnCap;
-        [SerializeField]
-        [Tooltip("The maximum number of entities this spawner will try to maintain (regardless of player count)")]
-        int m_MaxSpawnCap;
-        [SerializeField]
-        [Tooltip("For each player in the game, the Spawn Cap is raised above the minimum by this amount. (Rounds up to nearest whole number.)")]
-        float m_SpawnCapIncreasePerPlayer;
 
         // indicates whether NetworkStart() has been called on us yet
         bool m_IsStarted;

--- a/Assets/BossRoom/Scripts/Server/Game/Entity/ServerWaveSpawner.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Entity/ServerWaveSpawner.cs
@@ -234,9 +234,9 @@ namespace BossRoom.Server
             {
                 // need to override the spawned creature's detection range (if they even have a detection range!)
                 var serverChar = clone.GetComponent<ServerCharacter>();
-                if (serverChar)
+                if (serverChar && serverChar.AIBrain != null)
                 {
-                    serverChar.SetDetectRadius(m_SpawnedEntityDetectDistance);
+                    serverChar.AIBrain.DetectRange = m_SpawnedEntityDetectDistance;
                 }
             }
 


### PR DESCRIPTION
Adds new settings to the ServerWaveSpawner. These new settings will be tuned and tweaked in the final "balance pass". This is just the code pass, so the values I entered are placeholders. 

(The ultimate goal is to make the spawners relevant to the demo! Right now you can simply ignore the spawners and attack the boss, because they're off in the corners and the imps don't aggro. This is also one of the places we can dynamically tune the game difficulty based on number of players, so we want to demonstrate that.)

*Feature Additions*
- The max # of simultaneous spawns is now determined based on the number of players
- Spawner can now override the spawned entity's detection range
- New option makes spawner's player-detector skip over players who are Stealthy

*Other*
- Added more spawn-positions to the prefab for a total of 10 (to allow a max of 10 spawned imps without any of them overlapping each other when they are all at idle)
- Removed the "unlimited spawns" option because it's dangerous (it could easily overwhelm the Host with infinite imps) and it's unlikely to be what is actually desired. (But if designers do want effectively unlimited spawns, they can just set the cap to a million!)