### PR TITLE
Feature/Show full particle on imp death

### DIFF
--- a/Assets/BossRoom/Prefabs/CharGFX/ImpGraphics.prefab
+++ b/Assets/BossRoom/Prefabs/CharGFX/ImpGraphics.prefab
@@ -389,8 +389,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2305735426247598617}
-  m_LocalRotation: {x: -0.000000066579034, y: -0.000000043711385, z: -0.00000011029043,
-    w: 1}
+  m_LocalRotation: {x: -0.000000066579034, y: -0.000000043711385, z: -0.00000011029043, w: 1}
   m_LocalPosition: {x: -15.063482, y: -0.56256866, z: -0.0000076293945}
   m_LocalScale: {x: 100, y: 99.999985, z: 100}
   m_Children: []
@@ -1153,40 +1152,48 @@ MonoBehaviour:
   m_EventsOnNodeEntry:
   - m_AnimatorNodeName: Attack1
     m_AnimatorNodeNameHash: -47317214
-    m_Prefab: {fileID: 1652666497380707034, guid: abf9f7de0d4eb4941a1b17568597deb2,
-      type: 3}
+    m_Prefab: {fileID: 1652666497380707034, guid: abf9f7de0d4eb4941a1b17568597deb2, type: 3}
     m_PrefabSpawnDelaySeconds: 0.8
     m_PrefabCanBeAbortedUntilSecs: 0
+    m_PrefabParent: {fileID: 0}
+    m_PrefabParentOffset: {x: 0, y: 0, z: 0}
+    m_DeParentPrefab: 0
     m_SoundEffect: {fileID: 8300000, guid: 714700a9be690ab4ab62c7cad766e9ee, type: 3}
     m_SoundStartDelaySeconds: 0
     m_VolumeMultiplier: 1
     m_LoopSound: 0
   - m_AnimatorNodeName: Dead Loop
     m_AnimatorNodeNameHash: -1573871441
-    m_Prefab: {fileID: -1487195197790481162, guid: 9537f4739c7bc2f4e8d6b2d49bfcc97e,
-      type: 3}
+    m_Prefab: {fileID: -1487195197790481162, guid: 9537f4739c7bc2f4e8d6b2d49bfcc97e, type: 3}
     m_PrefabSpawnDelaySeconds: 0
     m_PrefabCanBeAbortedUntilSecs: 0
+    m_PrefabParent: {fileID: 0}
+    m_PrefabParentOffset: {x: 0, y: 0, z: 0}
+    m_DeParentPrefab: 1
     m_SoundEffect: {fileID: 8300000, guid: 7fbc6b32425f98840b339a705b4a28cb, type: 3}
     m_SoundStartDelaySeconds: 0
     m_VolumeMultiplier: 1
     m_LoopSound: 0
   - m_AnimatorNodeName: HitReact1
     m_AnimatorNodeNameHash: -1747783153
-    m_Prefab: {fileID: -2843690008440830094, guid: de5b665e7f32274419072e7bf4c3eff8,
-      type: 3}
+    m_Prefab: {fileID: -2843690008440830094, guid: de5b665e7f32274419072e7bf4c3eff8, type: 3}
     m_PrefabSpawnDelaySeconds: 0
     m_PrefabCanBeAbortedUntilSecs: 0
+    m_PrefabParent: {fileID: 0}
+    m_PrefabParentOffset: {x: 0, y: 0, z: 0}
+    m_DeParentPrefab: 0
     m_SoundEffect: {fileID: 8300000, guid: 5ef809d665d13b245b559cd6170f5794, type: 3}
     m_SoundStartDelaySeconds: 0
     m_VolumeMultiplier: 1
     m_LoopSound: 0
   - m_AnimatorNodeName: WalkRun
     m_AnimatorNodeNameHash: -1624701500
-    m_Prefab: {fileID: -8608552164340512473, guid: 9336eb30e2a836544bfd5b5985fd0573,
-      type: 3}
+    m_Prefab: {fileID: -8608552164340512473, guid: 9336eb30e2a836544bfd5b5985fd0573, type: 3}
     m_PrefabSpawnDelaySeconds: 0
     m_PrefabCanBeAbortedUntilSecs: 0
+    m_PrefabParent: {fileID: 0}
+    m_PrefabParentOffset: {x: 0, y: 0, z: 0}
+    m_DeParentPrefab: 0
     m_SoundEffect: {fileID: 0}
     m_SoundStartDelaySeconds: 0
     m_VolumeMultiplier: 1
@@ -1204,8 +1211,7 @@ AudioSource:
   m_GameObject: {fileID: 6839301660383890230}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: -6199682581367681880, guid: e39f39bfdfb22b541bbc115192fc2809,
-    type: 2}
+  OutputAudioMixerGroup: {fileID: -6199682581367681880, guid: e39f39bfdfb22b541bbc115192fc2809, type: 2}
   m_audioClip: {fileID: 0}
   m_PlayOnAwake: 0
   m_Volume: 1
@@ -1328,8 +1334,7 @@ AudioSource:
   m_GameObject: {fileID: 6839301660383890230}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: -6199682581367681880, guid: e39f39bfdfb22b541bbc115192fc2809,
-    type: 2}
+  OutputAudioMixerGroup: {fileID: -6199682581367681880, guid: e39f39bfdfb22b541bbc115192fc2809, type: 2}
   m_audioClip: {fileID: 0}
   m_PlayOnAwake: 0
   m_Volume: 1
@@ -1459,11 +1464,9 @@ MonoBehaviour:
   m_AnimatorVariable: Speed
   m_AnimatorVariableHash: -823668238
   m_AudioSource: {fileID: -8995571906845300287}
-  m_WalkFootstepAudioClip: {fileID: 8300000, guid: 6fd6fb49b9fc5324a8baf1de798388fa,
-    type: 3}
+  m_WalkFootstepAudioClip: {fileID: 8300000, guid: 6fd6fb49b9fc5324a8baf1de798388fa, type: 3}
   m_WalkFootstepVolume: 0.8
-  m_RunFootstepAudioClip: {fileID: 8300000, guid: 6ad4d1d63bc70494bbc9172ae70bcdd0,
-    type: 3}
+  m_RunFootstepAudioClip: {fileID: 8300000, guid: 6ad4d1d63bc70494bbc9172ae70bcdd0, type: 3}
   m_RunFootstepVolume: 0.8
   m_WalkingPoint: 0.6
   m_SilentPoint: 0.3
@@ -1476,8 +1479,7 @@ AudioSource:
   m_GameObject: {fileID: 6839301660383890230}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: -4341177700643628062, guid: e39f39bfdfb22b541bbc115192fc2809,
-    type: 2}
+  OutputAudioMixerGroup: {fileID: -4341177700643628062, guid: e39f39bfdfb22b541bbc115192fc2809, type: 2}
   m_audioClip: {fileID: 0}
   m_PlayOnAwake: 0
   m_Volume: 1

--- a/Assets/BossRoom/Scripts/Client/AnimationCallbacks/AnimatorTriggeredSpecialFX.cs
+++ b/Assets/BossRoom/Scripts/Client/AnimationCallbacks/AnimatorTriggeredSpecialFX.cs
@@ -42,6 +42,8 @@ namespace BossRoom.Visual
             public Transform m_PrefabParent;
             [Tooltip("Prefab will be spawned with this local offset from the parent (Remember, it's a LOCAL offset, so it's affected by the parent transform's scale and rotation!)")]
             public Vector3 m_PrefabParentOffset;
+            [Tooltip("Should we disconnect the prefab from the character? (So the prefab's transform has no parent)")]
+            public bool m_DeParentPrefab;
 
             [Header("Sound Effect")]
             [Tooltip("If we want to use a sound effect that's not in the prefab, specify it here")]
@@ -148,6 +150,13 @@ namespace BossRoom.Visual
             Transform parent = eventInfo.m_PrefabParent != null ? eventInfo.m_PrefabParent : m_Animator.transform;
             var instantiatedFX = Instantiate(eventInfo.m_Prefab, parent);
             instantiatedFX.transform.localPosition += eventInfo.m_PrefabParentOffset;
+
+            // should we have no parent transform at all? (Note that we're de-parenting AFTER applying
+            // the PrefabParent, so that PrefabParent can still be used to determine the initial position/rotation/scale.)
+            if (eventInfo.m_DeParentPrefab)
+            {
+                instantiatedFX.transform.SetParent(null);
+            }
 
             // now we just need to watch and see if we end up needing to prematurely end these new graphics
             if (eventInfo.m_PrefabCanBeAbortedUntilSecs > 0)


### PR DESCRIPTION
Imp monsters' GameObjects are being destroyed before their full "poof" particle can play. (This results in the particle looking like a "splat" rather than cool purple smoke as intended.)

To address this, I added a new boolean that lets a particle be de-parented from the character. This option is enabled on the imp's death particle. I double-checked that the particle's `SpecialFXGraphics` has a timeout, so that it will self-destruct itself.

(At the moment, This is the only planned use of this new bool.)

Merging note:: the only actual change to `ImpGraphics.prefab` was to enable the new bool. All other changes shown here were automatic