### PR TITLE
Bugfix: archer charged shot can be spammed

### DIFF
--- a/Assets/BossRoom/GameData/Action/Archer/ArcherChargedShot.asset
+++ b/Assets/BossRoom/GameData/Action/Archer/ArcherChargedShot.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:afabf49dab53bbbb8a34f457329a3d0d61e0a82164a97e209ddaa5d20ebe61f8
-size 1683
+oid sha256:a1b14b5de1e4049f6b7e621d26f511aa861fcb77c51092cf946b9231b804d743
+size 1733


### PR DESCRIPTION
(I'm not sure what the bug number for this is, sorry!)

Bug: if you play as an Archer and press the "1" key really fast, you can end up with the character stuck in the "charging up" animation permanently (well, until you use another charged shot).

This is caused by the animator triggers being reset at extreme speed, so that the stop and start triggers overlap. Rather than trying to change the trigger logic, though, I think the right fix is just to prevent you from firing so many charged shots! (Since pressing "1" really fast currently gives you an ultra death ray of infinite arrows.)

Now that we have the `ReuseTime` field this is easy. This PR changes Charged Shot's `ReuseTime` from 0 secs to a 0.7 secs