### PR TITLE
fixing NRE in RoomNameBox

### DIFF
--- a/Assets/BossRoom/Scripts/Client/UI/RoomNameBox.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/RoomNameBox.cs
@@ -41,7 +41,10 @@ public class RoomNameBox : MonoBehaviour
         {
             var transport = NetworkManager.Singleton.NetworkConfig.NetworkTransport;
 
-            if (transport is PhotonRealtimeTransport realtimeTransport && string.IsNullOrEmpty(realtimeTransport.Client.CloudRegion) == false)
+            if (transport != null &&
+                transport is PhotonRealtimeTransport realtimeTransport &&
+                realtimeTransport.Client != null && 
+                string.IsNullOrEmpty(realtimeTransport.Client.CloudRegion) == false)
             {
                 string roomName = $"{realtimeTransport.Client.CloudRegion.ToUpper()}_{realtimeTransport.RoomName}";
                 m_RoomNameText.text = $"Room Name: {roomName}";


### PR DESCRIPTION
We didn't have a repro for this, but I'm sure it's some odd boundary condition either on starting or stopping. We also didn't have exact knowledge of which object was null, but the line number showed it happening on the if statement I modified, so I changed the statement to be very conservative. 
fixing: GOMPS-458