### PR TITLE
docs: License UCL update and changelog additions

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 Boss Room: Small Scale Co-op Sample © 2021 Unity Technologies
 
-Licensed under the Unity Companion License for Unity-dependent projects (see https://unity3d.com/legal/licenses/unity_companion_license); otherwise licensed under the Unity Package Distribution License (see https://unity3d.com/legal/licenses/Unity_Package_Distribution_License).
+Licensed under the Unity Companion License for Unity-dependent projects (see https://unity3d.com/legal/licenses/unity_companion_license).
 
 Unless expressly provided otherwise, the Software under this license is made available strictly on an “AS IS” BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. Please review the license for details on these and other terms and conditions.

--- a/Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md
+++ b/Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md
@@ -7,6 +7,24 @@ v0.1.2 is a hotfix for an Early Access release for Boss Room: Small Scale Co-op 
 ### Updates
 
 * License updated to [Unity Companion License (UCL)](https://unity3d.com/legal/licenses/unity_companion_license) for Unity-dependent projects. See LICENSE in package for details.
+* The GitHub repository `master` branch has been renamed to `main`. If you have local clones of the repository, you may need to perform the following steps or reclone the repo:
+
+```
+# Switch to the "master" branch:
+$ git checkout master
+
+# Rename it to "main":
+$ git branch -m master main
+
+# Get the latest commits (and branches!) from the remote:
+$ git fetch
+
+# Remove the existing tracking connection with "origin/master":
+$ git branch --unset-upstream
+
+# Create a new tracking connection with the new "origin/main" branch:
+$ git branch -u origin/main
+```
 
 ## [0.1.1] - 2021-04-09
 

--- a/Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md
+++ b/Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md
@@ -1,8 +1,25 @@
-# Multiplayer Samples Co-op Changelog
+# Boss Room: Small Scale Co-op Sample Changelog
+
+## [0.1.2] - 2021-04-22
+
+v0.1.2 is a hotfix for an Early Access release for Boss Room: Small Scale Co-op Sample.
+
+### Updates
+
+* License updated to [Unity Companion License (UCL)](https://unity3d.com/legal/licenses/unity_companion_license) for Unity-dependent projects. See LICENSE in package for details.
+
+## [0.1.1] - 2021-04-09
+
+v0.1.1 is a hotfix for an Early Access release for Boss Room: Small Scale Co-op Sample.
+
+### Updates
+
+* Added [Third Party Contributors](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/blob/master/third-party%20contributors.md) file listing external partner contributors.
+* Corrected information for `NetworkVariableBool`.
 
 ## [0.1.0] - 2021-04-07
 
-v0.1.0 is an Early Access release for Multiplayer Samples Co-op.
+v0.1.0 is an Early Access release for Boss Room: Small Scale Co-op Sample.
 
 It requires and supports Unity v2020.3 and later and Unity MLAPI v0.1.0. For additional information on MLAPI, see the changelog and release notes for the Unity MLAPI package.
 

--- a/Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md
+++ b/Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Boss Room: Small Scale Co-op Sample Changelog
 
-## [0.1.2] - 2021-04-22
+## [0.1.2] - 2021-04-23
 
 v0.1.2 is a hotfix for an Early Access release for Boss Room: Small Scale Co-op Sample.
 
@@ -15,7 +15,7 @@ v0.1.1 is a hotfix for an Early Access release for Boss Room: Small Scale Co-op 
 ### Updates
 
 * Added [Third Party Contributors](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/blob/master/third-party%20contributors.md) file listing external partner contributors.
-* Corrected information for `NetworkVariableBool`.
+* Refactored `IsStealthy` from `NetworkVariableByte` to `NetworkVariableBool` to indicate state.
 
 ## [0.1.0] - 2021-04-07
 

--- a/Packages/com.unity.multiplayer.samples.coop/LICENSE.md
+++ b/Packages/com.unity.multiplayer.samples.coop/LICENSE.md
@@ -1,5 +1,5 @@
 Boss Room: Small scale co-op sample © 2021 Unity Technologies
 
-Licensed under the Unity Companion License for Unity-dependent projects (see https://unity3d.com/legal/licenses/unity_companion_license); otherwise licensed under the Unity Package Distribution License (see https://unity3d.com/legal/licenses/Unity_Package_Distribution_License).
+Licensed under the Unity Companion License for Unity-dependent projects (see https://unity3d.com/legal/licenses/unity_companion_license).
 
 Unless expressly provided otherwise, the Software under this license is made available strictly on an “AS IS” BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. Please review the license for details on these and other terms and conditions.


### PR DESCRIPTION
Updates in this PR:
- Update LICENSE in repo and package to strictly UCL. Ticket GOMPS-494 , verified with Legal.
- Update changelog to include 0.1.1 hotfix.
- Added potential hotfix 0.1.2 entry for the UCL license. Can remove that entry if a hotfix is not cut.

Currently entering this PR against `master` branch. Can also provide a PR to `develop` if needed.