### PR TITLE
fixing issue where host disconnects on player leaving.

### DIFF
--- a/Assets/BossRoom/Scripts/Client/Net/ClientGameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Client/Net/ClientGameNetPortal.cs
@@ -96,7 +96,7 @@ namespace BossRoom.Client
         {
             // we could also check whether the disconnect was us or the host, but the "interesting" question is whether
             //following the disconnect, we're no longer a Connected Client, so we just explicitly check that scenario.
-            if ( !MLAPI.NetworkManager.Singleton.IsConnectedClient )
+            if ( !MLAPI.NetworkManager.Singleton.IsConnectedClient && !MLAPI.NetworkManager.Singleton.IsHost )
             {
                 SceneManager.sceneLoaded -= OnSceneLoaded;
                 m_Portal.UserDisconnectRequested -= OnUserDisconnectRequest;


### PR DESCRIPTION
In MLAPI, on the Host, `IsClient` returns true. But `IsConnectedClient` returns false. Doesn't seem right. At any rate, I've fixed it. Now it has the correct behavior on both hosts and clients. 

This was causing an issue where whenever any player left, the Host was booted to Main Menu. 