### PR TITLE
Feature/Shield-Charge attack has anticipation anim [GOMPS-472]

### DIFF
--- a/Assets/BossRoom/Scripts/Client/Game/Action/AoeActionInput.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/AoeActionInput.cs
@@ -59,7 +59,7 @@ namespace BossRoom.Visual
                         ShouldQueue = false,
                         TargetIds = null
                     };
-                    m_PlayerOwner.RecvDoActionServerRPC(data);
+                    m_SendInput(data);
                 }
                 Destroy(gameObject);
                 return;

--- a/Assets/BossRoom/Scripts/Client/Game/Action/ChargedActionInput.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/ChargedActionInput.cs
@@ -22,7 +22,7 @@ namespace BossRoom.Visual
                 ShouldQueue = false,
                 TargetIds = null
             };
-            m_PlayerOwner.RecvDoActionServerRPC(data);
+            m_SendInput(data);
         }
 
         public override void OnReleaseKey()

--- a/Assets/BossRoom/Scripts/Client/Game/Action/ChargedShieldActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/ChargedShieldActionFX.cs
@@ -30,13 +30,28 @@ namespace BossRoom.Visual
 
         public override bool Start()
         {
-            base.Start();
-
-            m_Parent.OurAnimator.SetTrigger(Description.Anim);
             Assert.IsTrue(Description.Spawns.Length == 2, $"Found {Description.Spawns.Length} spawns for action {Description.ActionTypeEnum}. Should be exactly 2: a charge-up particle and a fully-charged particle");
 
+            if (!Anticipated)
+            {
+                PlayAnim();
+            }
+
+            base.Start();
             m_ChargeGraphics = InstantiateSpecialFXGraphic(Description.Spawns[0], true);
             return true;
+        }
+
+        private void PlayAnim()
+        {
+            // because this action can be visually started and stopped as often and as quickly as the player wants, it's possible
+            // for several copies of this action to be playing at once. This can lead to situations where several
+            // dying versions of the action raise the end-trigger, but the animator only lowers it once, leaving the trigger
+            // in a raised state. So we'll make sure that our end-trigger isn't raised yet. (Generally a good idea anyway.)
+            m_Parent.OurAnimator.ResetTrigger(Description.Anim2);
+
+            // raise the start trigger to start the animation loop!
+            m_Parent.OurAnimator.SetTrigger(Description.Anim);
         }
 
         private bool IsChargingUp()
@@ -91,6 +106,12 @@ namespace BossRoom.Visual
                 // knows anything greater than zero means we shouldn't show hit-reacts.
                 m_Parent.OurAnimator.SetInteger(Description.OtherAnimatorVariable, m_Parent.OurAnimator.GetInteger(Description.OtherAnimatorVariable) + 1);
             }
+        }
+
+        public override void AnticipateAction()
+        {
+            base.AnticipateAction();
+            PlayAnim();
         }
 
     }

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
@@ -127,9 +127,15 @@ namespace BossRoom.Client
             m_MainCamera = Camera.main;
         }
 
-        public void FinishSkill()
+        void FinishSkill()
         {
             m_CurrentSkillInput = null;
+        }
+
+        void SendInput(ActionRequestData action)
+        {
+            ActionInputEvent?.Invoke(action);
+            m_NetworkCharacter.RecvDoActionServerRPC(action);
         }
 
         void FixedUpdate()
@@ -151,7 +157,7 @@ namespace BossRoom.Client
                     if (actionData.ActionInput != null)
                     {
                         var skillPlayer = Instantiate(actionData.ActionInput);
-                        skillPlayer.Initiate(m_NetworkCharacter, actionData.ActionTypeEnum, FinishSkill);
+                        skillPlayer.Initiate(m_NetworkCharacter, actionData.ActionTypeEnum, SendInput, FinishSkill);
                         m_CurrentSkillInput = skillPlayer;
                     }
                     else
@@ -228,8 +234,7 @@ namespace BossRoom.Client
                 //Don't trigger our move logic for a while. This protects us from moving just because we clicked on them to target them.
                 m_LastSentMove = Time.time + k_TargetMoveTimeout;
 
-                ActionInputEvent?.Invoke(playerAction);
-                m_NetworkCharacter.RecvDoActionServerRPC(playerAction);
+                SendInput(playerAction);
             }
             else if(actionType != ActionType.GeneralTarget )
             {
@@ -240,9 +245,7 @@ namespace BossRoom.Client
                 var data = new ActionRequestData();
                 PopulateSkillRequest(k_CachedHit[0].point, actionType, ref data);
 
-                ActionInputEvent?.Invoke(data);
-                m_NetworkCharacter.RecvDoActionServerRPC(data);
-
+                SendInput(data);
             }
         }
 

--- a/Assets/BossRoom/Scripts/Shared/Game/Action/BaseActionInput.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/Action/BaseActionInput.cs
@@ -7,12 +7,14 @@ namespace BossRoom
     {
         protected NetworkCharacterState m_PlayerOwner;
         protected ActionType m_ActionType;
+        protected Action<ActionRequestData> m_SendInput;
         Action m_OnFinished;
 
-        public void Initiate(NetworkCharacterState playerOwner, ActionType actionType, Action onFinished)
+        public void Initiate(NetworkCharacterState playerOwner, ActionType actionType, Action<ActionRequestData> onSendInput, Action onFinished)
         {
             m_PlayerOwner = playerOwner;
             m_ActionType = actionType;
+            m_SendInput = onSendInput;
             m_OnFinished = onFinished;
         }
 


### PR DESCRIPTION
The tank's "Charged Shield" action did not support Anticipation (i.e. playing a client-side action before the server tells us to, for more reactive gameplay). This is fixed by this PR.

Actions with special input-handlers didn't trigger the same client-side events that other actions did. To ensure that all actions sent to the server also send appropriate events to the client, I've routed a new callback into `BaseActionInput`, which derived versions can use to send input correctly. 

After this is done, the actual custom Anticipation logic for `ChargedShieldActionFX` is trivial, and just like other Actions.

Also fixed issue where you could sometimes get the animations out of sync if you spam-clicked the shield charge button. (By resetting the end-animation trigger before we begin.)