### PR TITLE
Feature/remove cooldown time variable

### DIFF
--- a/Assets/BossRoom/GameData/Action/Boss/BossImpTrampleAttack.asset
+++ b/Assets/BossRoom/GameData/Action/Boss/BossImpTrampleAttack.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:818857ebae4fad947db07995cf25acf9838d60e6c8c60ec16c9238c1b16546b3
-size 955
+oid sha256:db2842d2b13725ad76131a5033581688d829341806fa39a4acc6695f54edc30e
+size 995

--- a/Assets/BossRoom/Models/Animation Controllers/CharacterSetController.controller
+++ b/Assets/BossRoom/Models/Animation Controllers/CharacterSetController.controller
@@ -945,8 +945,8 @@ AnimatorStateTransition:
   m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
-  - m_ConditionMode: 4
-    m_ConditionEvent: Speed
+  - m_ConditionMode: 1
+    m_ConditionEvent: TrampleStop
     m_EventTreshold: 0.001
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1411007122952585507}
@@ -1746,6 +1746,12 @@ AnimatorController:
     m_Controller: {fileID: 0}
   - m_Name: Invincible
     m_Type: 3
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
+  - m_Name: TrampleStop
+    m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0

--- a/Assets/BossRoom/Scripts/Client/Game/Action/TrampleActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/TrampleActionFX.cs
@@ -38,7 +38,16 @@ namespace BossRoom.Visual
         public override bool Start()
         {
             base.Start();
-            m_Parent.OurAnimator.SetTrigger(Description.Anim);
+            // reset our "stop" trigger (in case the previous run of the trample action was aborted due to e.g. being stunned)
+            if (!string.IsNullOrEmpty(Description.Anim2))
+            {
+                m_Parent.OurAnimator.ResetTrigger(Description.Anim2);
+            }
+            // start the animation sequence!
+            if (!string.IsNullOrEmpty(Description.Anim))
+            {
+                m_Parent.OurAnimator.SetTrigger(Description.Anim);
+            }
             return true;
         }
 
@@ -66,6 +75,11 @@ namespace BossRoom.Visual
                 }
             }
             m_SpawnedGraphics = null;
+
+            if (!string.IsNullOrEmpty(Description.Anim2))
+            {
+                m_Parent.OurAnimator.SetTrigger(Description.Anim2);
+            }
         }
     }
 }

--- a/Assets/BossRoom/Scripts/Server/Game/AIState/AttackAIState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/AIState/AttackAIState.cs
@@ -94,8 +94,8 @@ namespace BossRoom.Server
             }
 
             // choose the attack to use
-            var attackInfo = GetCurrentAttackInfo();
-            if (attackInfo == null)
+            m_CurAttackAction = ChooseAttack();
+            if (m_CurAttackAction == ActionType.None)
             {
                 // no actions are usable right now
                 return;
@@ -104,7 +104,7 @@ namespace BossRoom.Server
             // attack!
             var attackData = new ActionRequestData
             {
-                ActionTypeEnum = attackInfo.ActionTypeEnum,
+                ActionTypeEnum = m_CurAttackAction,
                 TargetIds = new ulong[] { m_Foe.NetworkObjectId },
                 ShouldClose = true
             };
@@ -135,10 +135,10 @@ namespace BossRoom.Server
         }
 
         /// <summary>
-        /// Chooses a usable attack and returns an ActionDescription representing it. If no actions are usable, returns null.
+        /// Randomly picks a usable attack. If no actions are usable right now, returns ActionType.None.
         /// </summary>
-        /// <returns>Action to use, or null</returns>
-        private ActionDescription GetCurrentAttackInfo()
+        /// <returns>Action to attack with, or ActionType.None</returns>
+        private ActionType ChooseAttack()
         {
             m_TempListOfAttackActions.Clear();
             foreach (var actionType in m_AttackActions)
@@ -151,19 +151,10 @@ namespace BossRoom.Server
 
             if (m_TempListOfAttackActions.Count == 0)
             {
-                return null;
+                return ActionType.None;
             }
 
-            m_CurAttackAction = m_TempListOfAttackActions[Random.Range(0, m_TempListOfAttackActions.Count)];
-
-            ActionDescription result;
-            bool found = GameDataSource.Instance.ActionDataByType.TryGetValue(m_CurAttackAction, out result);
-            if (!found)
-            {
-                throw new System.Exception($"GameObject {m_Brain.GetMyServerCharacter().gameObject.name} tried to play Action {m_CurAttackAction} but this action does not exist");
-            }
-
-            return result;
+            return m_TempListOfAttackActions[Random.Range(0, m_TempListOfAttackActions.Count)];
         }
     }
 }

--- a/Assets/BossRoom/Scripts/Server/Game/AIState/AttackAIState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/AIState/AttackAIState.cs
@@ -12,11 +12,6 @@ namespace BossRoom.Server
 
         List<ActionType> m_AttackActions;
 
-        /// <summary>
-        /// a temporary list used by GetCurrentAttackInfo() so that it doesn't have to allocate a list every call
-        /// </summary>
-        List<ActionType> m_TempListOfAttackActions = new List<ActionType>();
-
         public AttackAIState(AIBrain brain, ActionPlayer actionPlayer)
         {
             m_Brain = brain;
@@ -140,21 +135,30 @@ namespace BossRoom.Server
         /// <returns>Action to attack with, or ActionType.None</returns>
         private ActionType ChooseAttack()
         {
-            m_TempListOfAttackActions.Clear();
-            foreach (var actionType in m_AttackActions)
+            // make a random choice
+            int idx = Random.Range(0, m_AttackActions.Count);
+
+            // now iterate through our options to find one that's currently usable
+            bool anyUsable;
+            do
             {
-                if (m_ActionPlayer.IsReuseTimeElapsed(actionType))
+                anyUsable = false;
+                for (int i = 0; i < m_AttackActions.Count; ++i)
                 {
-                    m_TempListOfAttackActions.Add(actionType);
+                    if (m_ActionPlayer.IsReuseTimeElapsed(m_AttackActions[i]))
+                    {
+                        anyUsable = true;
+                        if (idx == 0)
+                        {
+                            return m_AttackActions[i];
+                        }
+                        --idx;
+                    }
                 }
-            }
+            } while (anyUsable);
 
-            if (m_TempListOfAttackActions.Count == 0)
-            {
-                return ActionType.None;
-            }
-
-            return m_TempListOfAttackActions[Random.Range(0, m_TempListOfAttackActions.Count)];
+            // none of our actions are available now
+            return ActionType.None;
         }
     }
 }

--- a/Assets/BossRoom/Scripts/Server/Game/AIState/AttackAIState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/AIState/AttackAIState.cs
@@ -143,14 +143,14 @@ namespace BossRoom.Server
             do
             {
                 anyUsable = false;
-                for (int i = 0; i < m_AttackActions.Count; ++i)
+                foreach (var actionType in m_AttackActions)
                 {
-                    if (m_ActionPlayer.IsReuseTimeElapsed(m_AttackActions[i]))
+                    if (m_ActionPlayer.IsReuseTimeElapsed(actionType))
                     {
                         anyUsable = true;
                         if (idx == 0)
                         {
-                            return m_AttackActions[i];
+                            return actionType;
                         }
                         --idx;
                     }

--- a/Assets/BossRoom/Scripts/Server/Game/Action/Action.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Action/Action.cs
@@ -55,9 +55,7 @@ namespace BossRoom.Server
         /// <returns>true to become a non-blocking Action, false to remain a blocking Action</returns>
         public virtual bool ShouldBecomeNonBlocking()
         {
-            return Description.BlockingMode == BlockingMode.OnlyDuringExecTime ?  TimeRunning >= Description.ExecTimeSeconds :
-                   Description.BlockingMode == BlockingMode.ExecTimeWithCooldown ? TimeRunning >= (Description.ExecTimeSeconds + Description.CooldownSeconds) :
-                   false;
+            return Description.BlockingMode == BlockingMode.OnlyDuringExecTime ?  TimeRunning >= Description.ExecTimeSeconds : false;
         }
 
         /// <summary>

--- a/Assets/BossRoom/Scripts/Server/Game/Action/ActionPlayer.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Action/ActionPlayer.cs
@@ -97,6 +97,29 @@ namespace BossRoom.Server
         }
 
         /// <summary>
+        /// Figures out if an action can be played now, or if it would automatically fail because it was
+        /// used too recently. (Meaning that its ReuseTimeSeconds hasn't elapsed since the last use.)
+        /// </summary>
+        /// <param name="actionType">the action we want to run</param>
+        /// <returns>true if the action can be run now, false if more time must elapse before this action can be run</returns>
+        public bool IsReuseTimeElapsed(ActionType actionType)
+        {
+            if (m_LastUsedTimestamps.TryGetValue(actionType, out float lastTimeUsed))
+            {
+                if (GameDataSource.Instance.ActionDataByType.TryGetValue(actionType, out ActionDescription description))
+                {
+                    float reuseTime = description.ReuseTimeSeconds;
+                    if (reuseTime > 0 && Time.time - lastTimeUsed < reuseTime)
+                    {
+                        // still needs more time!
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
         /// Returns how many actions are actively running. This includes all non-blocking actions,
         /// and the one blocking action at the head of the queue (if present).
         /// </summary>
@@ -288,8 +311,7 @@ namespace BossRoom.Server
             bool keepGoing = action.Update();
             bool expirable = action.Description.DurationSeconds > 0f; //non-positive value is a sentinel indicating the duration is indefinite.
             var timeElapsed = Time.time - action.TimeStarted;
-            bool timeExpired = expirable &&
-                timeElapsed >= (action.Description.DurationSeconds + action.Description.CooldownSeconds);
+            bool timeExpired = expirable && timeElapsed >= action.Description.DurationSeconds;
             return keepGoing && !timeExpired;
         }
 
@@ -307,8 +329,7 @@ namespace BossRoom.Server
             {
                 var info = action.Description;
                 float actionTime =  info.BlockingMode == BlockingMode.OnlyDuringExecTime   ? info.ExecTimeSeconds :
-                                    info.BlockingMode == BlockingMode.ExecTimeWithCooldown ? (info.ExecTimeSeconds+info.CooldownSeconds) :
-                                    info.BlockingMode == BlockingMode.EntireDuration       ? (info.DurationSeconds + info.CooldownSeconds) :
+                                    info.BlockingMode == BlockingMode.EntireDuration       ? info.DurationSeconds :
                                     throw new System.Exception($"Unrecognized blocking mode: {info.BlockingMode}");
                 totalTime += actionTime;
             }

--- a/Assets/BossRoom/Scripts/Server/Game/Action/TrampleAction.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Action/TrampleAction.cs
@@ -22,7 +22,6 @@ namespace BossRoom.Server
             Windup,     // performing animations prior to actually moving
             Charging,   // running across the screen and hitting characters
             Complete,   // ending action
-            Cooldown,   // time spent after completion
         }
 
         /// <summary>
@@ -78,13 +77,9 @@ namespace BossRoom.Server
             {
                 return ActionStage.Windup;
             }
-            if (timeSoFar < Description.ExecTimeSeconds + Description.DurationSeconds)
+            if (timeSoFar < Description.DurationSeconds)
             {
                 return ActionStage.Charging;
-            }
-            if (timeSoFar < Description.ExecTimeSeconds + Description.DurationSeconds + Description.CooldownSeconds)
-            {
-                return ActionStage.Cooldown;
             }
             return ActionStage.Complete;
         }

--- a/Assets/BossRoom/Scripts/Shared/Data/ActionDescription.cs
+++ b/Assets/BossRoom/Scripts/Shared/Data/ActionDescription.cs
@@ -29,9 +29,6 @@ namespace BossRoom
         [Tooltip("Duration in seconds that this Action takes to play")]
         public float DurationSeconds;
 
-        [Tooltip("Duration in seconds that this Action takes to cooldown, after DurationSeconds has elapsed.")]
-        public float CooldownSeconds;
-
         [Tooltip("Time when the Action should do its \"main thing\" (e.g. when a melee attack should apply damage")]
         public float ExecTimeSeconds;
 
@@ -79,7 +76,6 @@ namespace BossRoom
         {
             EntireDuration,
             OnlyDuringExecTime,
-            ExecTimeWithCooldown,
         }
         [Tooltip("Indicates how long this action blocks other actions from happening: during the execution stage, or for as long as it runs?")]
         public BlockingModeType BlockingMode;


### PR DESCRIPTION
The `CooldownTimeSeconds` variable of `ActionDescription` was obsoleted by `ReuseTimeSeconds`, and this PR removes the old variable.

Only one action was still using the `CooldownTimeSeconds` feature: the boss's trample attack. To fix this, the AI is changed to instead pick actions whose `ReuseTimeSeconds` are up.

There was a subtle side-effect to the boss's use of cooldown time: the boss would stand still for a few seconds after the trample ended (waiting for the cooldown to run out). This made the boss more vulnerable than was probably intended -- he should only stand still while stunned! But it turns out our animator controller relied on this behavior: the animation loop only stopped when the boss's movement became zero. Since the boss doesn't *necessarily* stop moving anymore, we now just use a trigger to end the animation sequence. (Which in retrospect is probably how it should have been done in the first place.)

*Notes*
- to let the boss use his trample as often as before, I've given `BossImpTrampleAttack` a `ReuseTimeSeconds` of 7.5. (The `DurationSeconds` is 3.5, and the `CooldownTimeSeconds` was previously 4, so a reuse time of 3.5+4=7.5.) 
- there was some weird timing calculation going on in the old TrampleAction.cs which doesn't look like it was accurate -- but it happened to work. It's all removed now though, so problem solved
- Merging note: added one trigger, and changed one transition to use the trigger
- Testing note: remember that you can spawn a boss imp at the dungeon entrance by pressing "B"