### PR TITLE
Fix occasional NREs during object destruction [GOMPS-502][GOMPS-503]

### DIFF
--- a/Assets/BossRoom/Scripts/Shared/Game/UI/UIStateDisplayHandler.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/UI/UIStateDisplayHandler.cs
@@ -209,7 +209,7 @@ namespace BossRoom
 
         void LateUpdate()
         {
-            if (m_UIStateActive)
+            if (m_UIStateActive && m_TransformToTrack)
             {
                 // set world position with world offset added
                 m_WorldPos.Set(m_TransformToTrack.position.x,


### PR DESCRIPTION
Because order of object `Destroy()`ing isn't guaranteed, sometimes a character's visualization object is destroyed before the health-bar UI elements that are tracking it. Added a null check. 

I've seen this error myself occasionally, but could not reproduce it on demand. I suspect this is a stop-play-in-editor situation, because in a standalone, I think both the child and parent objects should be destroyed before the next `LateUpdate()` is called. In any case I'm fairly confident this will address the problem.