### PR TITLE
Feature/Anticipation logic tweaks [GOMPS-505]

### DIFF
--- a/Assets/BossRoom/Scripts/Client/Game/Action/ActionVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/ActionVisualization.cs
@@ -30,7 +30,7 @@ namespace BossRoom.Visual
             for (int i = m_PlayingActions.Count - 1; i >= 0; --i)
             {
                 var action = m_PlayingActions[i];
-                bool keepGoing = action.Update();
+                bool keepGoing = action.Anticipated || action.Update(); // only call Update() on actions that are past anticipation
                 bool expirable = action.Description.DurationSeconds > 0f; //non-positive value is a sentinel indicating the duration is indefinite.
                 bool timeExpired = expirable && action.TimeRunning >= action.Description.DurationSeconds;
                 bool timedOut = action.Anticipated && action.TimeRunning >= k_AnticipationTimeoutSeconds;
@@ -118,6 +118,10 @@ namespace BossRoom.Visual
             if (actionFX.Start())
             {
                 m_PlayingActions.Add(actionFX);
+            }
+            else if (anticipatedActionIndex >= 0)
+            {
+                m_PlayingActions.RemoveAt(anticipatedActionIndex);
             }
         }
 


### PR DESCRIPTION
- if an anticipated action's `Start()` returns false, we should remove the action
- do not call `Update()` on an anticipated action (until it stops being anticipated)

This addresses [GOMPS-505]: Archer's Volley generates "This should not execute" exceptions