### PR TITLE
Feature/another null-check to fix NRE in editor shutdown

### DIFF
--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerBossRoomState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerBossRoomState.cs
@@ -164,7 +164,7 @@ namespace BossRoom.Server
         private MLAPI.NetworkVariable.NetworkVariable<LifeState>.OnValueChangedDelegate GetLifeStateEvent(ulong id)
         {
             //this is all a little paranoid, because during shutdown it's not always obvious what state is still valid.
-            if (NetworkSpawnManager.SpawnedObjects.TryGetValue(id, out NetworkObject netObj))
+            if (NetworkSpawnManager.SpawnedObjects.TryGetValue(id, out NetworkObject netObj) && netObj != null)
             {
                 var netState = netObj.GetComponent<NetworkCharacterState>();
                 return netState != null ? netState.NetworkLifeState.OnValueChanged : null;


### PR DESCRIPTION
Fixes a null-reference error message that can happen when you stop Play mode in the editor. 

(I'm not sure if this one is tracked in jira. Judging by the code-comments, I think we already tried to fix it, but I got the error again, so the previous check didn't quite get the job done.)