### PR TITLE
Fix boss-death helmet jiggle by deparenting helmet [GOMPS-463]

### DIFF
--- a/Assets/BossRoom/Models/CharacterSet.fbx.meta
+++ b/Assets/BossRoom/Models/CharacterSet.fbx.meta
@@ -1290,7 +1290,14 @@ ModelImporter:
       mirror: 0
       bodyMask: 01000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000
       curves: []
-      events: []
+      events:
+      - time: 0.3918564
+        functionName: OnAnimEvent
+        data: HelmetLanded
+        objectReferenceParameter: {instanceID: 0}
+        floatParameter: 0
+        intParameter: 0
+        messageOptions: 0
       transformMask: []
       maskType: 3
       maskSource: {instanceID: 0}

--- a/Assets/BossRoom/Prefabs/CharGFX/BossGraphics.prefab
+++ b/Assets/BossRoom/Prefabs/CharGFX/BossGraphics.prefab
@@ -1941,6 +1941,7 @@ GameObject:
   - component: {fileID: 5287069443216318009}
   - component: {fileID: 6713727153812284024}
   - component: {fileID: -2129752889114835779}
+  - component: {fileID: -1103479630647314628}
   m_Layer: 6
   m_Name: BossGraphics
   m_TagString: Untagged
@@ -2483,6 +2484,19 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!114 &-1103479630647314628
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6839301660383890230}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9861f5280458794a935935c2e0db02a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HelmetTransform: {fileID: 8350592313923235650}
 --- !u!1 &7108127146651356877
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/BossRoom/Scripts/Client/AnimationCallbacks/BossDeathHelmetHandler.cs
+++ b/Assets/BossRoom/Scripts/Client/AnimationCallbacks/BossDeathHelmetHandler.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+
+namespace BossRoom.Visual
+{
+    /// <summary>
+    /// De-parents the boss's helmet when he is defeated. This prevents the helmet from jittering during the
+    /// animation loop. The "boss defeat start" animation has an event that calls OnAnimEvent("HelmetLanded")
+    /// right as the helmet hits the ground. That's what we listen for here.
+    /// </summary>
+    /// <remarks>
+    /// Without this code, the boss's helmet appears to "jiggle" a bit while the boss throws his temper-tantrum.
+    /// The animation in the FBX keeps the helmet staying stationary, but it moves in-game due to animation
+    /// compression and floating-point round off. Since the helmet is parented deep in the transform hierarchy,
+    /// it's difficult to keep the helmet precisely still while all of its parent transforms are moving around wildly.
+    /// 
+    /// We could get rid of the majority of the jiggle by disabling animation-compression on the FBX, but that could
+    /// adversely impact performance. Since this is a special case, we deal with it via this special-case script.
+    /// </remarks>
+    public class BossDeathHelmetHandler : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("The transform of the boss's helmet, which will become de-parented when the boss is defeated")]
+        Transform m_HelmetTransform;
+
+        bool m_HasDeparentedHelmet;
+
+        public void OnAnimEvent(string id)
+        {
+            if (id == "HelmetLanded" && !m_HasDeparentedHelmet)
+            {
+                m_HasDeparentedHelmet = true;
+                m_HelmetTransform.parent = null;
+            }
+        }
+
+        public void OnDestroy()
+        {
+            if (m_HasDeparentedHelmet && m_HelmetTransform)
+            {
+                // the boss is going away, so the helmet should go too!
+                Destroy(m_HelmetTransform.gameObject);
+            }
+        }
+
+    }
+}

--- a/Assets/BossRoom/Scripts/Client/AnimationCallbacks/BossDeathHelmetHandler.cs.meta
+++ b/Assets/BossRoom/Scripts/Client/AnimationCallbacks/BossDeathHelmetHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f9861f5280458794a935935c2e0db02a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The boss's helmet appears to "jiggle" on the ground while the boss throws his temper-tantrum. This isn't a problem with the animation per se -- the helmet is stationary in the FBX file. Most of the jitter comes from animation compression, but even when turning that off, there is still a slight jiggle, which is just caused by 32-bit-float roundoff. The helmet is parented deep in the bone hierarchy, so when the boss is moving around, it's very difficult to keep the child transform perfectly still.

The best fix we could see is to de-parent the boss's helmet when it hits the ground. The death animation now generates an event at the proper moment, and a new component on the boss handles that event by disconnecting the helmet (and cleaning it up on destroy).