### PR TITLE
[GOMPS-228][GOMPS-513] fixing handful of remaining bugs

### DIFF
--- a/Assets/BossRoom/Scripts/Client/Game/Action/ChargedLaunchProjectileActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/ChargedLaunchProjectileActionFX.cs
@@ -21,7 +21,7 @@ namespace BossRoom.Visual
         /// (like mobile devices), it can lead to major performance problems. On mobile platforms, visual graphics should
         /// use object-pooling (i.e. reusing the same GameObjects repeatedly). But that's outside the scope of this demo.
         /// </remarks>
-        private List<SpecialFXGraphic> m_Graphics;
+        private List<SpecialFXGraphic> m_Graphics = new List<SpecialFXGraphic>();
 
         private bool m_ChargeEnded;
 

--- a/Assets/BossRoom/Scripts/Client/Game/Action/FXProjectileTargetedActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/FXProjectileTargetedActionFX.cs
@@ -51,8 +51,8 @@ namespace BossRoom.Visual
             if (TimeRunning >= Description.ExecTimeSeconds && m_Projectile == null)
             {
                 // figure out how long the pretend-projectile will be flying to the target
-                Vector3 targetPos = m_Target ? m_Target.transform.position : m_Data.Position;
-                float initialDistance = Vector3.Distance(targetPos, m_Parent.transform.position);
+                var targetPos = m_Target ? m_Target.transform.position : m_Data.Position;
+                var initialDistance = Vector3.Distance(targetPos, m_Parent.transform.position);
                 m_ProjectileDuration = initialDistance / Description.Projectiles[0].Speed_m_s;
 
                 // create the projectile. It will control itself from here on out
@@ -61,11 +61,6 @@ namespace BossRoom.Visual
 
             // we keep going until the projectile's duration ends
             return TimeRunning <= m_ProjectileDuration + Description.ExecTimeSeconds;
-        }
-
-        public override void OnAnimEvent(string id)
-        {
-            //Debug.Log($"Anim event: {id}");
         }
 
         public override void Cancel()
@@ -133,9 +128,9 @@ namespace BossRoom.Visual
 
         private FXProjectile SpawnAndInitializeProjectile()
         {
-            GameObject projectileGO = Object.Instantiate(Description.Projectiles[0].ProjectilePrefab, m_Parent.transform.position, m_Parent.transform.rotation, null);
+            var projectileGO = Object.Instantiate(Description.Projectiles[0].ProjectilePrefab, m_Parent.transform.position, m_Parent.transform.rotation, null);
 
-            FXProjectile projectile = projectileGO.GetComponent<FXProjectile>();
+            var projectile = projectileGO.GetComponent<FXProjectile>();
             if (!projectile)
             {
                 throw new System.Exception($"FXProjectileTargetedAction tried to spawn projectile {projectileGO.name}, as dictated for action type {Data.ActionTypeEnum}, but the object doesn't have a FXProjectile component!");

--- a/Assets/BossRoom/Scripts/Server/Game/Entity/ServerWaveSpawner.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Entity/ServerWaveSpawner.cs
@@ -227,7 +227,7 @@ namespace BossRoom.Server
             var clone = Instantiate(m_NetworkedPrefab, m_SpawnPositions[posIdx].position, m_SpawnPositions[posIdx].rotation);
             if (!clone.IsSpawned)
             {
-                clone.Spawn();
+                clone.Spawn(null, true);
             }
 
             if (m_SpawnedEntityDetectDistance > -1)

--- a/Assets/BossRoom/Scripts/Shared/Game/Action/ActionRequestData.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/Action/ActionRequestData.cs
@@ -60,21 +60,6 @@ namespace BossRoom
         //O__O adding a new ActionLogic branch? Update Action.MakeAction!
     }
 
-    /// <summary>
-    /// Retrieves static information about ActionLogics
-    /// </summary>
-    public static class ActionLogicUtils
-    {
-        /// <summary>
-        /// When requesting an action with this type of ActionLogic, do we need to store the Position where player clicked?
-        /// (We separate this out so that we don't need to send the extra Vector3 across the network if unneeded.)
-        /// </summary>
-        public static bool IsPositionUsed(ActionLogic logic)
-        {
-            return logic == ActionLogic.RangedFXTargeted;
-        }
-
-    }
 
     /// <summary>
     /// Comprehensive class that contains information needed to play back any action on the server. This is what gets sent client->server when
@@ -179,4 +164,3 @@ namespace BossRoom
         }
     }
 }
-


### PR DESCRIPTION
* Fixes a case where some imps were leaking out of the BossRoom scene and contaminating the postgame scene. This was invisible unless somebody tried to join post-game, and then those imps would get instantiated on the joining client and throw exceptions (the issue was that Imp Spawners weren't setting imps to `deleteWithScene=true`)
* [GOMPS-513] Fixes an NRE with ChargedShot. I did this by making a throw-away alloc, but at the rate that these objects get instantiated (one every couple seconds, probably), I didn't think it was a big deal. 
* [GOMPS-228] Some open PR style feedback. 