### PR TITLE
[GOMPS-522] fixes character jitter in high packet loss scenarios

### DIFF
--- a/Assets/BossRoom/Scripts/Shared/Game/Entity/NetworkCharacterState.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/Entity/NetworkCharacterState.cs
@@ -45,7 +45,8 @@ namespace BossRoom
         /// <summary>
         /// The networked position of this Character. This reflects the authoritative position on the server.
         /// </summary>
-        public NetworkVariableVector3 NetworkPosition { get; } = new NetworkVariableVector3();
+        public NetworkVariableVector3 NetworkPosition { get; } = new NetworkVariableVector3(
+            new NetworkVariableSettings() { SendNetworkChannel = MLAPI.Transports.NetworkChannel.PositionUpdate });
 
         /// <summary>
         /// The networked rotation of this Character. This reflects the authoritative rotation on the server.

--- a/Assets/BossRoom/Scripts/Shared/Game/Entity/NetworkCharacterState.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/Entity/NetworkCharacterState.cs
@@ -51,7 +51,8 @@ namespace BossRoom
         /// <summary>
         /// The networked rotation of this Character. This reflects the authoritative rotation on the server.
         /// </summary>
-        public NetworkVariableFloat NetworkRotationY { get; } = new NetworkVariableFloat();
+        public NetworkVariableFloat NetworkRotationY { get; } = new NetworkVariableFloat(
+            new NetworkVariableSettings() { SendNetworkChannel = MLAPI.Transports.NetworkChannel.PositionUpdate });
 
         /// <summary>
         /// The speed that the character is currently allowed to move, according to the server.


### PR DESCRIPTION
I have moved position and rotation to the MLAPI PositionUpdate channel, which is {Unreliable,Sequenced}. This significantly improves the user experience in high packet loss scenarios. 

I tested with clumsy, 50ms of bi-directional latency (measuring 250ms RTT in game), and 10% packet loss. Without this change, movement and camera were both horribly janky. After the change, the experience was largely tolerable, with occasional subtle disruptions (not too bad, considering 10% packet loss is pretty rough!)