### PR TITLE
Bugfix: boss's "charging" particles not canceled when stunned

### DIFF
--- a/Assets/BossRoom/Prefabs/CharGFX/BossGraphics.prefab
+++ b/Assets/BossRoom/Prefabs/CharGFX/BossGraphics.prefab
@@ -2002,9 +2002,6 @@ MonoBehaviour:
   m_CharacterSwapper: {fileID: 0}
   m_VisualizationConfiguration: {fileID: 11400000, guid: 9504973cdecd65749889771972fa0117, type: 2}
   m_RuntimeObjectsParent: {fileID: 11400000, guid: deda38c596e7fbd4386b9d8f9b7bb4b5, type: 2}
-  TargetReticule: {fileID: 0}
-  ReticuleFriendlyMat: {fileID: 0}
-  ReticuleHostileMat: {fileID: 0}
 --- !u!114 &4538447335436592133
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2023,7 +2020,7 @@ MonoBehaviour:
     m_AnimatorNodeNameHash: -1491039896
     m_Prefab: {fileID: -1433333703484781611, guid: 1333b84cd80da3e4a820009415068d44, type: 3}
     m_PrefabSpawnDelaySeconds: 0
-    m_PrefabCanBeAbortedUntilSecs: 0
+    m_PrefabCanBeAbortedUntilSecs: 999999
     m_PrefabParent: {fileID: 1363468141647399746}
     m_PrefabParentOffset: {x: 18, y: 76, z: 42.6}
     m_DeParentPrefab: 0
@@ -2035,7 +2032,7 @@ MonoBehaviour:
     m_AnimatorNodeNameHash: -1491039896
     m_Prefab: {fileID: -1433333703484781611, guid: 1333b84cd80da3e4a820009415068d44, type: 3}
     m_PrefabSpawnDelaySeconds: 0
-    m_PrefabCanBeAbortedUntilSecs: 0
+    m_PrefabCanBeAbortedUntilSecs: 999999
     m_PrefabParent: {fileID: 1363468141647399746}
     m_PrefabParentOffset: {x: -18, y: 76, z: 42.6}
     m_DeParentPrefab: 0
@@ -2047,7 +2044,7 @@ MonoBehaviour:
     m_AnimatorNodeNameHash: -2018876257
     m_Prefab: {fileID: -1144995844113132186, guid: bad05de9531f2604fb84de8c856043b9, type: 3}
     m_PrefabSpawnDelaySeconds: 0
-    m_PrefabCanBeAbortedUntilSecs: 0
+    m_PrefabCanBeAbortedUntilSecs: 999999
     m_PrefabParent: {fileID: 0}
     m_PrefabParentOffset: {x: 0, y: 0, z: 0}
     m_DeParentPrefab: 0
@@ -2059,7 +2056,7 @@ MonoBehaviour:
     m_AnimatorNodeNameHash: -186961091
     m_Prefab: {fileID: 6043546068530540440, guid: d6bbda1efd94fe64caedc72c5eb9e8e6, type: 3}
     m_PrefabSpawnDelaySeconds: 0
-    m_PrefabCanBeAbortedUntilSecs: 0
+    m_PrefabCanBeAbortedUntilSecs: 999999
     m_PrefabParent: {fileID: 0}
     m_PrefabParentOffset: {x: 0, y: 0, z: 0}
     m_DeParentPrefab: 0


### PR DESCRIPTION
If the boss is stunned while performing their trample attack, the trample particles were not aborted. This is fixed with a data change, by setting the "how long can we abort this graphic" setting to a very high number. (We use 999,999 seconds as a way to denote "forever".)