### PR TITLE
Bugfix/gomps 527 pots not breaking on client

### DIFF
--- a/Assets/BossRoom/Prefabs/NetworkingManager.prefab
+++ b/Assets/BossRoom/Prefabs/NetworkingManager.prefab
@@ -212,11 +212,11 @@ MonoBehaviour:
     EnableSceneManagement: 1
     ForceSamePrefabs: 0
     UsePrefabSync: 0
-    RecycleNetworkIds: 1
+    RecycleNetworkIds: 0
     NetworkIdRecycleDelay: 120
     RpcHashSize: 0
     LoadSceneTimeOut: 120
-    EnableMessageBuffering: 0
+    EnableMessageBuffering: 1
     MessageBufferTimeout: 20
     EnableNetworkLogs: 1
   references:


### PR DESCRIPTION
This is a speculative fix for GOMPS-527. We don't have a good repro for this problem, so the hope is to remove a few potential causes, and see if it reoccurs. The changes are:

1. Enables Message Buffering in NetworkManager config, with the default 20s timeout. This is because the pots-breaking issue was accompanied by a lot of discarded packets for objects that didn't exist. If this was some kind of creation race, then the message buffering should help, although the user in question experienced pots not breaking as a _persistent_ issue, so it's not a sure thing that this well help. 

2. Disables NetworkID recycling. For our match-based game, I don't think this provides much value. And, although I don't have any evidence implicating it, it's just one more confounding factor I'd like to eliminate (if the host reused a networkId but that Id was still somehow extant on the client, then it could explain some of the weirdness the user saw). 
