### PR TITLE
[GOMPS-532] removing incorrect use of null propagation on Unity object

### DIFF
--- a/Assets/BossRoom/Scripts/Client/Game/Action/FXProjectileTargetedActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/FXProjectileTargetedActionFX.cs
@@ -137,7 +137,7 @@ namespace BossRoom.Visual
             }
 
             // now that we have our projectile, initialize it so it'll fly at the target appropriately
-            projectile.Initialize(m_Parent.transform.position, m_Target?.transform, m_Data.Position, m_ProjectileDuration);
+            projectile.Initialize(m_Parent.transform.position, m_Target != null ? m_Target.transform : null, m_Data.Position, m_ProjectileDuration);
             return projectile;
         }
 


### PR DESCRIPTION
This fixes an exception that showed up during extreme network scenario testing. We were incorrectly using null propagation on a Unity object, and then trying to get a transform off a deleted object, which didn't work so well. 