### PR TITLE
fetching MLAPI experimental package through registry

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -10,7 +10,7 @@
     "com.unity.ide.visualstudio": "2.0.7",
     "com.unity.ide.vscode": "1.2.3",
     "com.unity.learn.iet-framework": "1.2.1",
-    "com.unity.multiplayer.mlapi": "https://github.com/Unity-Technologies/com.unity.multiplayer.mlapi.git?path=/com.unity.multiplayer.mlapi#release/0.1.0",
+    "com.unity.multiplayer.mlapi": "0.1.0",
     "com.unity.postprocessing": "2.3.0",
     "com.unity.test-framework": "1.1.24",
     "com.unity.textmeshpro": "3.0.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -93,15 +93,13 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.multiplayer.mlapi": {
-      "version": "https://github.com/Unity-Technologies/com.unity.multiplayer.mlapi.git?path=/com.unity.multiplayer.mlapi#release/0.1.0",
+      "version": "0.1.0",
       "depth": 0,
-      "source": "git",
+      "source": "registry",
       "dependencies": {
-        "com.unity.modules.ai": "1.0.0",
-        "com.unity.modules.animation": "1.0.0",
         "com.unity.nuget.mono-cecil": "1.10.1-preview.1"
       },
-      "hash": "3e3aef6aa02c2a25359898319e5bd49d3518b57b"
+      "url": "https://packages.unity.com"
     },
     "com.unity.multiplayer.samples.coop": {
       "version": "file:com.unity.multiplayer.samples.coop",


### PR DESCRIPTION
MLAPI v0.1-experimental is fetched through internal Unity Package Manager registry, namely `com.unity.multiplayer.mlapi`.