### PR TITLE
photon transport send queue batch size incremented to 8192

### DIFF
--- a/Assets/BossRoom/Prefabs/NetworkingManager.prefab
+++ b/Assets/BossRoom/Prefabs/NetworkingManager.prefab
@@ -49,7 +49,7 @@ MonoBehaviour:
   m_ChannelIdCodesStartRange: 130
   m_AttachSupportLogger: 0
   m_BatchMode: 1
-  m_SendQueueBatchSize: 4096
+  m_SendQueueBatchSize: 8192
   m_BatchedTransportEventCode: 129
   m_KickEventCode: 130
 --- !u!1 &3591499506183471245


### PR DESCRIPTION
Simple increment to photon realtime transport's `Send Queue Batch Size` field. This resolves a breaking issue on Photon that prevented players from entering BossRoom scene successfully.

![image](https://user-images.githubusercontent.com/75813458/121583436-3c91db00-c9fe-11eb-863d-ec3f6f1e6996.PNG)
