### PR TITLE
photon version upgrade

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.mlapi.contrib.transport.litenetlib": "https://github.com/Unity-Technologies/mlapi-community-contributions.git?path=/Transports/com.mlapi.contrib.transport.litenetlib#3f0350ae57befd5ea7deabb1db310eb77704f58e",
-    "com.mlapi.contrib.transport.photon-realtime": "https://github.com/Unity-Technologies/mlapi-community-contributions.git?path=/Transports/com.mlapi.contrib.transport.photon-realtime#3f0350ae57befd5ea7deabb1db310eb77704f58e",
+    "com.mlapi.contrib.transport.photon-realtime": "https://github.com/Unity-Technologies/mlapi-community-contributions.git?path=/Transports/com.mlapi.contrib.transport.photon-realtime#e47ee18972b110a689c23d6ffc0e5994d18e9eb2",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.ai.navigation.components": "https://github.com/Unity-Technologies/NavMeshComponents.git#package",
     "com.unity.cinemachine": "2.6.3",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -8,11 +8,11 @@
       "hash": "3f0350ae57befd5ea7deabb1db310eb77704f58e"
     },
     "com.mlapi.contrib.transport.photon-realtime": {
-      "version": "https://github.com/Unity-Technologies/mlapi-community-contributions.git?path=/Transports/com.mlapi.contrib.transport.photon-realtime#3f0350ae57befd5ea7deabb1db310eb77704f58e",
+      "version": "https://github.com/Unity-Technologies/mlapi-community-contributions.git?path=/Transports/com.mlapi.contrib.transport.photon-realtime#e47ee18972b110a689c23d6ffc0e5994d18e9eb2",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "3f0350ae57befd5ea7deabb1db310eb77704f58e"
+      "hash": "e47ee18972b110a689c23d6ffc0e5994d18e9eb2"
     },
     "com.unity.2d.sprite": {
       "version": "1.0.0",


### PR DESCRIPTION
Jira task [here](https://unity3d.atlassian.net/browse/GOMPS-525). Photon has been upgraded to version `e47ee18972b110a689c23d6ffc0e5994d18e9eb2`. Photon-related errors are not logged when pulling network cable.

However, there are still game-side errors that are logged on the host when pulling the network cable. That's tracked [here](https://unity3d.atlassian.net/browse/GOMPS-564) for a follow-up PR.