### PR TITLE
Update to MLAPI: onnetworkspawn refactoring, player prefab removed from networkmanager prefab list

### DIFF
--- a/Assets/BossRoom/Prefabs/NetworkingManager.prefab
+++ b/Assets/BossRoom/Prefabs/NetworkingManager.prefab
@@ -203,11 +203,6 @@ MonoBehaviour:
       SourceHashToOverride: 0
       OverridingTargetPrefab: {fileID: 0}
     - Override: 0
-      Prefab: {fileID: 6009713983291384756, guid: 8237adf32a9b6de4892e6febe6b4bdef, type: 3}
-      SourcePrefabToOverride: {fileID: 0}
-      SourceHashToOverride: 0
-      OverridingTargetPrefab: {fileID: 0}
-    - Override: 0
       Prefab: {fileID: 3713729372785093424, guid: 6cdd52f1fa2ed34469a487ae6477eded, type: 3}
       SourcePrefabToOverride: {fileID: 0}
       SourceHashToOverride: 0

--- a/Assets/BossRoom/Scripts/Client/ClientDoorVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/ClientDoorVisualization.cs
@@ -42,7 +42,7 @@ public class ClientDoorVisualization : NetworkBehaviour
         }
     }
 
-    private void OnDestroy()
+    public override void OnNetworkDespawn()
     {
         if (m_DoorState)
         {

--- a/Assets/BossRoom/Scripts/Client/ClientDoorVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/ClientDoorVisualization.cs
@@ -27,7 +27,7 @@ public class ClientDoorVisualization : NetworkBehaviour
         m_DoorState = GetComponent<NetworkDoorState>();
     }
 
-    public override void NetworkStart()
+    public override void OnNetworkSpawn()
     {
         if (!IsClient)
         {

--- a/Assets/BossRoom/Scripts/Client/ClientFloorSwitchVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/ClientFloorSwitchVisualization.cs
@@ -20,7 +20,7 @@ public class ClientFloorSwitchVisualization : NetworkBehaviour
         m_FloorSwitchState = GetComponent<NetworkFloorSwitchState>();
     }
 
-    public override void NetworkStart()
+    public override void OnNetworkSpawn()
     {
         m_FloorSwitchState.IsSwitchedOn.OnValueChanged += OnFloorSwitchStateChanged;
     }

--- a/Assets/BossRoom/Scripts/Client/ClientFloorSwitchVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/ClientFloorSwitchVisualization.cs
@@ -25,7 +25,7 @@ public class ClientFloorSwitchVisualization : NetworkBehaviour
         m_FloorSwitchState.IsSwitchedOn.OnValueChanged += OnFloorSwitchStateChanged;
     }
 
-    private void OnDestroy()
+    public override void OnNetworkDespawn()
     {
         if (m_FloorSwitchState)
         {

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientCharacter.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientCharacter.cs
@@ -11,7 +11,7 @@ namespace BossRoom.Client
         /// </summary>
         public BossRoom.Visual.ClientCharacterVisualization ChildVizObject { get; set; }
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
             if (!IsClient) { this.enabled = false; }
         }

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientCharacterVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientCharacterVisualization.cs
@@ -69,7 +69,7 @@ namespace BossRoom.Visual
         event Action Destroyed;
 
         /// <inheritdoc />
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
             if (!IsClient || transform.parent == null)
             {

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientCharacterVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientCharacterVisualization.cs
@@ -189,7 +189,7 @@ namespace BossRoom.Visual
                     break;
             }
         }
-        private void OnDestroy()
+        public override void OnNetworkDespawn()
         {
             if (m_NetState)
             {

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientGenericMovement.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientGenericMovement.cs
@@ -21,7 +21,7 @@ namespace BossRoom.Client
             m_Rigidbody = GetComponent<Rigidbody>(); //this may be null.
         }
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
             if (IsServer)
             {

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
@@ -97,6 +97,12 @@ namespace BossRoom.Client
         /// </summary>
         CharacterClass CharacterData => GameDataSource.Instance.CharacterDataByType[m_NetworkCharacter.CharacterType];
 
+        bool m_IsLocalClient;
+
+        public static event Action<ClientInputSender> LocalClientReadied;
+
+        public static event Action LocalClientRemoved;
+
         public override void OnNetworkSpawn()
         {
             if (!IsClient || !IsOwner)
@@ -109,15 +115,17 @@ namespace BossRoom.Client
             k_GroundLayerMask = LayerMask.GetMask(new[] { "Ground" });
             k_ActionLayerMask = LayerMask.GetMask(new[] { "PCs", "NPCs", "Ground" });
 
-            // find the hero action UI bar
-            GameObject actionUIobj = GameObject.FindGameObjectWithTag("HeroActionBar");
-            actionUIobj.GetComponent<Visual.HeroActionBar>().RegisterInputSender(this);
+            m_IsLocalClient = true;
+            LocalClientReadied?.Invoke(this);
+        }
 
-            // find the emote bar to track its buttons
-            GameObject emoteUIobj = GameObject.FindGameObjectWithTag("HeroEmoteBar");
-            emoteUIobj.GetComponent<Visual.HeroEmoteBar>().RegisterInputSender(this);
-            // once connected to the emote bar, hide it
-            emoteUIobj.SetActive(false);
+        public override void OnNetworkDespawn()
+        {
+            if (m_IsLocalClient)
+            {
+                m_IsLocalClient = false;
+                LocalClientRemoved?.Invoke();
+            }
         }
 
         void Awake()
@@ -393,19 +401,19 @@ namespace BossRoom.Client
                 RequestAction(CharacterData.Skill3, SkillTriggerStyle.KeyboardRelease);
             }
 
-            if (Input.GetKeyDown(KeyCode.Alpha4))
+            if (Input.GetKeyDown(KeyCode.Alpha5))
             {
                 RequestAction(ActionType.Emote1, SkillTriggerStyle.Keyboard);
             }
-            if (Input.GetKeyDown(KeyCode.Alpha5))
+            if (Input.GetKeyDown(KeyCode.Alpha6))
             {
                 RequestAction(ActionType.Emote2, SkillTriggerStyle.Keyboard);
             }
-            if (Input.GetKeyDown(KeyCode.Alpha6))
+            if (Input.GetKeyDown(KeyCode.Alpha7))
             {
                 RequestAction(ActionType.Emote3, SkillTriggerStyle.Keyboard);
             }
-            if (Input.GetKeyDown(KeyCode.Alpha7))
+            if (Input.GetKeyDown(KeyCode.Alpha8))
             {
                 RequestAction(ActionType.Emote4, SkillTriggerStyle.Keyboard);
             }

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
@@ -97,7 +97,7 @@ namespace BossRoom.Client
         /// </summary>
         CharacterClass CharacterData => GameDataSource.Instance.CharacterDataByType[m_NetworkCharacter.CharacterType];
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
             if (!IsClient || !IsOwner)
             {

--- a/Assets/BossRoom/Scripts/Client/Game/Entity/ClientBreakableVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Entity/ClientBreakableVisualization.cs
@@ -27,7 +27,7 @@ namespace BossRoom.Visual
 
         private GameObject m_CurrentBrokenVisualization;
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
             if (!IsClient)
             {

--- a/Assets/BossRoom/Scripts/Client/Game/Entity/ClientBreakableVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Entity/ClientBreakableVisualization.cs
@@ -57,7 +57,7 @@ namespace BossRoom.Visual
             }
         }
 
-        private void OnDestroy()
+        public override void OnNetworkDespawn()
         {
             if (m_NetState)
             {

--- a/Assets/BossRoom/Scripts/Client/Game/Entity/ClientProjectileVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Entity/ClientProjectileVisualization.cs
@@ -17,7 +17,7 @@ namespace BossRoom.Visual
 
         private float m_SmoothedSpeed;
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
             if (!IsClient || transform.parent == null)
             {

--- a/Assets/BossRoom/Scripts/Client/Game/Entity/ClientProjectileVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Entity/ClientProjectileVisualization.cs
@@ -31,7 +31,7 @@ namespace BossRoom.Visual
             m_NetState.HitEnemyEvent += OnEnemyHit;
         }
 
-        void OnDestroy()
+        public override void OnNetworkDespawn()
         {
             if( m_NetState != null )
             {

--- a/Assets/BossRoom/Scripts/Client/Game/State/ClientBossRoomState.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/State/ClientBossRoomState.cs
@@ -7,16 +7,16 @@ namespace BossRoom.Client
 {
 
     /// <summary>
-    /// Client specialization of core BossRoom game logic. 
+    /// Client specialization of core BossRoom game logic.
     /// </summary>
     public class ClientBossRoomState : GameStateBehaviour
     {
         public override GameState ActiveState {  get { return GameState.BossRoom; } }
 
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
-            base.NetworkStart();
+            base.OnNetworkSpawn();
             if( !IsClient ) { this.enabled = false; }
         }
 

--- a/Assets/BossRoom/Scripts/Client/Game/State/ClientBossRoomState.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/State/ClientBossRoomState.cs
@@ -16,7 +16,6 @@ namespace BossRoom.Client
 
         public override void OnNetworkSpawn()
         {
-            base.OnNetworkSpawn();
             if( !IsClient ) { this.enabled = false; }
         }
 

--- a/Assets/BossRoom/Scripts/Client/Game/State/ClientCharSelectState.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/State/ClientCharSelectState.cs
@@ -144,9 +144,9 @@ namespace BossRoom.Client
                 Instance = null;
         }
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
-            base.NetworkStart();
+            base.OnNetworkSpawn();
             if (!IsClient)
             {
                 enabled = false;

--- a/Assets/BossRoom/Scripts/Client/Game/State/ClientCharSelectState.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/State/ClientCharSelectState.cs
@@ -145,7 +145,6 @@ namespace BossRoom.Client
 
         public override void OnNetworkSpawn()
         {
-            base.OnNetworkSpawn();
             if (!IsClient)
             {
                 enabled = false;

--- a/Assets/BossRoom/Scripts/Client/Game/State/ClientCharSelectState.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/State/ClientCharSelectState.cs
@@ -130,9 +130,8 @@ namespace BossRoom.Client
             UpdateCharacterSelection(CharSelectData.SeatState.Inactive);
         }
 
-        protected override void OnDestroy()
+        public override void OnNetworkDespawn()
         {
-            base.OnDestroy();
             if (CharSelectData)
             {
                 CharSelectData.IsLobbyClosed.OnValueChanged -= OnLobbyClosedChanged;

--- a/Assets/BossRoom/Scripts/Client/Game/State/ClientMainMenuState.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/State/ClientMainMenuState.cs
@@ -9,14 +9,11 @@ namespace BossRoom.Client
     /// Game Logic that runs when sitting at the MainMenu. This is likely to be "nothing", as no game has been started. But it is
     /// nonetheless important to have a game state, as the GameStateBehaviour system requires that all scenes have states.
     /// </summary>
+    /// <remarks> OnNetworkSpawn() won't ever run, because there is no network connection at the main menu screen.
+    /// Fortunately we know you are a client, because all players are clients when sitting at the main menu screen.
+    /// </remarks>
     public class ClientMainMenuState : GameStateBehaviour
     {
         public override GameState ActiveState { get { return GameState.MainMenu;  } }
-
-        public override void OnNetworkSpawn()
-        {
-            //note: this code won't ever run, because there is no network connection at the main menu screen.
-            //fortunately we know you are a client, because all players are clients when sitting at the main menu screen.
-        }
     }
 }

--- a/Assets/BossRoom/Scripts/Client/Game/State/ClientMainMenuState.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/State/ClientMainMenuState.cs
@@ -7,16 +7,16 @@ namespace BossRoom.Client
 {
     /// <summary>
     /// Game Logic that runs when sitting at the MainMenu. This is likely to be "nothing", as no game has been started. But it is
-    /// nonetheless important to have a game state, as the GameStateBehaviour system requires that all scenes have states. 
+    /// nonetheless important to have a game state, as the GameStateBehaviour system requires that all scenes have states.
     /// </summary>
     public class ClientMainMenuState : GameStateBehaviour
     {
         public override GameState ActiveState { get { return GameState.MainMenu;  } }
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
             //note: this code won't ever run, because there is no network connection at the main menu screen.
-            //fortunately we know you are a client, because all players are clients when sitting at the main menu screen. 
+            //fortunately we know you are a client, because all players are clients when sitting at the main menu screen.
         }
     }
 }

--- a/Assets/BossRoom/Scripts/Client/Game/State/ClientPostGameState.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/State/ClientPostGameState.cs
@@ -23,9 +23,9 @@ namespace BossRoom.Client
             portalGO.GetComponent<ClientGameNetPortal>().DisconnectReason.SetDisconnectReason(ConnectStatus.UserRequestedDisconnect);
         }
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
-            base.NetworkStart();
+            base.OnNetworkSpawn();
             if (!IsClient)
             {
                 enabled = false;

--- a/Assets/BossRoom/Scripts/Client/Game/State/ClientPostGameState.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/State/ClientPostGameState.cs
@@ -25,7 +25,6 @@ namespace BossRoom.Client
 
         public override void OnNetworkSpawn()
         {
-            base.OnNetworkSpawn();
             if (!IsClient)
             {
                 enabled = false;

--- a/Assets/BossRoom/Scripts/Client/Net/ClientGameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Client/Net/ClientGameNetPortal.cs
@@ -152,7 +152,7 @@ namespace BossRoom.Client
         /// </summary>
         /// <remarks>
         /// This method must be static because, when it is invoked, the client still doesn't know it's a client yet, and in particular, GameNetPortal hasn't
-        /// yet initialized its client and server GNP-Logic objects yet (which it does in NetworkStart, based on the role that the current player is performing).
+        /// yet initialized its client and server GNP-Logic objects yet (which it does in OnNetworkSpawn, based on the role that the current player is performing).
         /// </remarks>
         /// <param name="portal"> </param>
         /// <param name="ipaddress">the IP address of the host to connect to. (currently IPV4 only)</param>
@@ -236,7 +236,7 @@ namespace BossRoom.Client
             portal.NetManager.NetworkConfig.ClientConnectionBufferTimeout = k_TimeoutDuration;
 
             //and...we're off! MLAPI will establish a socket connection to the host.
-            //  If the socket connection fails, we'll hear back by getting an OnClientDisconnect callback for ourselves (TODO-FIXME:MLAPI GOMPS-79, provide feedback for different transport failures). 
+            //  If the socket connection fails, we'll hear back by getting an OnClientDisconnect callback for ourselves (TODO-FIXME:MLAPI GOMPS-79, provide feedback for different transport failures).
             //  If the socket connection succeeds, we'll get our RecvConnectFinished invoked. This is where game-layer failures will be reported.
             portal.NetManager.StartClient();
         }

--- a/Assets/BossRoom/Scripts/Server/Game/Character/PlayerServerCharacter.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/PlayerServerCharacter.cs
@@ -23,7 +23,7 @@ namespace BossRoom.Server
         [SerializeField]
         ServerCharacter m_CachedServerCharacter;
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
             if( !IsServer )
             {

--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
@@ -75,7 +75,7 @@ namespace BossRoom.Server
             }
         }
 
-        public void OnDestroy()
+        public override void OnNetworkDespawn()
         {
             if (NetState)
             {

--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
@@ -54,7 +54,7 @@ namespace BossRoom.Server
             }
         }
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
             if (!IsServer) { enabled = false; }
             else

--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacterMovement.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacterMovement.cs
@@ -169,7 +169,7 @@ namespace BossRoom.Server
             }
         }
 
-        private void OnDestroy()
+        public override void OnNetworkDespawn()
         {
             if (m_NavPath != null)
             {

--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacterMovement.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacterMovement.cs
@@ -45,7 +45,7 @@ namespace BossRoom.Server
             m_NavigationSystem = GameObject.FindGameObjectWithTag(NavigationSystem.NavigationSystemTag).GetComponent<NavigationSystem>();
         }
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
             if (!IsServer)
             {

--- a/Assets/BossRoom/Scripts/Server/Game/Entity/RaiseEventOnLifeChange.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Entity/RaiseEventOnLifeChange.cs
@@ -19,7 +19,7 @@ namespace BossRoom.Server
         [SerializeField]
         LifeState m_RaiseCondition;
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
             if (!IsServer)
             {

--- a/Assets/BossRoom/Scripts/Server/Game/Entity/RaiseEventOnLifeChange.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Entity/RaiseEventOnLifeChange.cs
@@ -32,7 +32,7 @@ namespace BossRoom.Server
             m_NetworkLifeState.LifeState.OnValueChanged += LifeStateChanged;
         }
 
-        void OnDestroy()
+        public override void OnNetworkDespawn()
         {
             m_NetworkLifeState.LifeState.OnValueChanged -= LifeStateChanged;
         }

--- a/Assets/BossRoom/Scripts/Server/Game/Entity/ServerBreakableLogic.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Entity/ServerBreakableLogic.cs
@@ -32,7 +32,7 @@ namespace BossRoom.Server
             m_State = GetComponent<NetworkBreakableState>();
         }
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
             if (!IsServer)
             {

--- a/Assets/BossRoom/Scripts/Server/Game/Entity/ServerEnemyPortal.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Entity/ServerEnemyPortal.cs
@@ -59,7 +59,7 @@ namespace BossRoom.Server
             MaintainState();
         }
 
-        private void OnDestroy()
+        public override void OnNetworkDespawn()
         {
             if (m_CoroDormant != null)
                 StopCoroutine(m_CoroDormant);

--- a/Assets/BossRoom/Scripts/Server/Game/Entity/ServerEnemyPortal.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Entity/ServerEnemyPortal.cs
@@ -11,7 +11,7 @@ namespace BossRoom.Server
     /// nearby. It has one or more "breakable bits". When all the breakable elements are broken,
     /// the portal becomes dormant for a fixed amount of time, before repairing its breakables
     /// and starting up again.
-    /// 
+    ///
     /// The actual monster-spawning logic is managed by a ServerWaveSpawner component.
     /// </summary>
     /// <remarks>
@@ -43,7 +43,7 @@ namespace BossRoom.Server
             m_State = GetComponent<NetworkBreakableState>();
         }
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
             if (!IsServer)
             {

--- a/Assets/BossRoom/Scripts/Server/Game/Entity/ServerProjectileLogic.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Entity/ServerProjectileLogic.cs
@@ -58,7 +58,7 @@ namespace BossRoom.Server
 
         /// <summary>
         /// Set everything up based on provided projectile information.
-        /// (Note that this is called before NetworkStart(), so don't try to do any network stuff here.)
+        /// (Note that this is called before OnNetworkSpawn(), so don't try to do any network stuff here.)
         /// </summary>
         public void Initialize(ulong creatorsNetworkObjectId, in ActionDescription.ProjectileInfo projectileInfo)
         {
@@ -66,7 +66,7 @@ namespace BossRoom.Server
             m_ProjectileInfo = projectileInfo;
         }
 
-        public override void NetworkStart(Stream stream)
+        public override void OnNetworkSpawn(Stream stream)
         {
             if (!IsServer)
             {
@@ -87,7 +87,7 @@ namespace BossRoom.Server
 
         private void FixedUpdate()
         {
-            if (!m_Started) { return; } //don't do anything before NetworkStart has run.
+            if (!m_Started) { return; } //don't do anything before OnNetworkSpawn has run.
 
             Vector3 displacement = transform.forward * (m_ProjectileInfo.Speed_m_s * Time.fixedDeltaTime);
             transform.position += displacement;

--- a/Assets/BossRoom/Scripts/Server/Game/Entity/ServerWaveSpawner.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Entity/ServerWaveSpawner.cs
@@ -100,8 +100,6 @@ namespace BossRoom.Server
 
         public override void OnNetworkSpawn()
         {
-            base.OnNetworkSpawn();
-
             if (!IsServer)
             {
                 enabled = false;
@@ -151,7 +149,7 @@ namespace BossRoom.Server
             m_WatchForPlayers = null;
         }
 
-        void OnDestroy()
+        public override void OnNetworkDespawn()
         {
             StopWaveSpawning();
         }

--- a/Assets/BossRoom/Scripts/Server/Game/Entity/ServerWaveSpawner.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Entity/ServerWaveSpawner.cs
@@ -81,7 +81,7 @@ namespace BossRoom.Server
         // cache array of RaycastHit as it will be reused for player visibility
         RaycastHit[] m_Hit;
 
-        // indicates whether NetworkStart() has been called on us yet
+        // indicates whether OnNetworkSpawn() has been called on us yet
         bool m_IsStarted;
 
         // are we currently spawning stuff?
@@ -98,9 +98,9 @@ namespace BossRoom.Server
             m_Transform = transform;
         }
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
-            base.NetworkStart();
+            base.OnNetworkSpawn();
 
             if (!IsServer)
             {

--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerBossRoomState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerBossRoomState.cs
@@ -59,9 +59,9 @@ namespace BossRoom.Server
             return returnValue;
         }
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
-            base.NetworkStart();
+            base.OnNetworkSpawn();
 
             if (!IsServer)
             {

--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerBossRoomState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerBossRoomState.cs
@@ -120,10 +120,8 @@ namespace BossRoom.Server
             }
         }
 
-        protected override void OnDestroy()
+        public override void OnNetworkDespawn()
         {
-            base.OnDestroy();
-
             foreach (ulong id in m_HeroIds)
             {
                 var heroLife = GetLifeStateEvent(id);

--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
@@ -146,9 +146,8 @@ namespace BossRoom.Server
             NetworkManager.SceneManager.SwitchScene("BossRoom");
         }
 
-        protected override void OnDestroy()
+        public override void OnNetworkDespawn()
         {
-            base.OnDestroy();
             if (NetworkManager.Singleton)
             {
                 NetworkManager.Singleton.OnClientConnectedCallback -= OnClientConnected;
@@ -163,7 +162,6 @@ namespace BossRoom.Server
 
         public override void OnNetworkSpawn()
         {
-            base.OnNetworkSpawn();
             if (!IsServer)
             {
                 enabled = false;

--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
@@ -161,9 +161,9 @@ namespace BossRoom.Server
             }
         }
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
-            base.NetworkStart();
+            base.OnNetworkSpawn();
             if (!IsServer)
             {
                 enabled = false;

--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerPostGameState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerPostGameState.cs
@@ -6,7 +6,7 @@ namespace BossRoom.Server
 {
 
     /// <summary>
-    /// The ServerPostGameState contains logic for 
+    /// The ServerPostGameState contains logic for
     /// </summary>
     [RequireComponent(typeof(PostGameData))]
     public class ServerPostGameState : GameStateBehaviour
@@ -16,9 +16,9 @@ namespace BossRoom.Server
 
         public override GameState ActiveState { get { return GameState.PostGame; } }
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
-            base.NetworkStart();
+            base.OnNetworkSpawn();
             if (!IsServer)
             {
                 enabled = false;

--- a/Assets/BossRoom/Scripts/Server/Net/ServerGameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Server/Net/ServerGameNetPortal.cs
@@ -56,7 +56,7 @@ namespace BossRoom.Server
             m_Portal = GetComponent<GameNetPortal>();
             m_Portal.NetworkReadied += OnNetworkReady;
 
-            // we add ApprovalCheck callback BEFORE NetworkStart to avoid spurious MLAPI warning:
+            // we add ApprovalCheck callback BEFORE OnNetworkSpawn to avoid spurious MLAPI warning:
             // "No ConnectionApproval callback defined. Connection approval will timeout"
             m_Portal.NetManager.ConnectionApprovalCallback += ApprovalCheck;
             m_Portal.NetManager.OnServerStarted += ServerStartedHandler;
@@ -125,7 +125,7 @@ namespace BossRoom.Server
 
             if( clientId == m_Portal.NetManager.LocalClientId )
             {
-                //the ServerGameNetPortal may be initialized again, which will cause its NetworkStart to be called again.
+                //the ServerGameNetPortal may be initialized again, which will cause its OnNetworkSpawn to be called again.
                 //Consequently we need to unregister anything we registered, when the NetworkManager is shutting down.
                 m_Portal.UserDisconnectRequested -= OnUserDisconnectRequest;
                 m_Portal.NetManager.OnClientDisconnectCallback -= OnClientDisconnect;

--- a/Assets/BossRoom/Scripts/Server/ServerFloorSwitch.cs
+++ b/Assets/BossRoom/Scripts/Server/ServerFloorSwitch.cs
@@ -32,7 +32,7 @@ namespace BossRoom.Server
             }
         }
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
             if (!IsServer)
             {

--- a/Assets/BossRoom/Scripts/Server/ServerSwitchedDoor.cs
+++ b/Assets/BossRoom/Scripts/Server/ServerSwitchedDoor.cs
@@ -19,14 +19,14 @@ public class ServerSwitchedDoor : NetworkBehaviour
     {
         m_NetworkDoorState = GetComponent<NetworkDoorState>();
 
-        // don't let Update() run until after NetworkStart()
+        // don't let Update() run until after OnNetworkSpawn()
         enabled = false;
 
         if (m_SwitchesThatOpenThisDoor.Count == 0)
             Debug.LogError("Door has no switches and can never be opened!", gameObject);
     }
 
-    public override void NetworkStart()
+    public override void OnNetworkSpawn()
     {
         enabled = IsServer;
     }

--- a/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs
+++ b/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs
@@ -30,9 +30,9 @@ namespace BossRoom.Server
         [Tooltip("Key that the Host can press to quit the game")]
         KeyCode m_InstantQuitKeyCode = KeyCode.Q;
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
-            base.NetworkStart();
+            base.OnNetworkSpawn();
 
             if (!IsServer)
             {

--- a/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs
+++ b/Assets/BossRoom/Scripts/Server/ServerTestingHotkeys.cs
@@ -32,8 +32,6 @@ namespace BossRoom.Server
 
         public override void OnNetworkSpawn()
         {
-            base.OnNetworkSpawn();
-
             if (!IsServer)
             {
                 // these commands don't work on the client

--- a/Assets/BossRoom/Scripts/Shared/Game/Entity/PersistentPlayer.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/Entity/PersistentPlayer.cs
@@ -20,11 +20,11 @@ namespace BossRoom
             DontDestroyOnLoad(this);
         }
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
             gameObject.name = "PersistentPlayer" + OwnerClientId;
 
-            // Note that this is done here on NetworkStart in case this NetworkBehaviour's properties are accessed
+            // Note that this is done here on OnNetworkSpawn in case this NetworkBehaviour's properties are accessed
             // when this element is added to the runtime collection. If this was done in OnEnable() there is a chance
             // that OwnerClientID could be its default value (0).
             m_PersistentPlayerRuntimeCollection.Add(this);

--- a/Assets/BossRoom/Scripts/Shared/Game/Entity/PersistentPlayer.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/Entity/PersistentPlayer.cs
@@ -30,7 +30,7 @@ namespace BossRoom
             m_PersistentPlayerRuntimeCollection.Add(this);
         }
 
-        void OnDestroy()
+        public override void OnNetworkDespawn()
         {
             m_PersistentPlayerRuntimeCollection.Remove(this);
         }

--- a/Assets/BossRoom/Scripts/Shared/Net/GameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/GameNetPortal.cs
@@ -100,7 +100,7 @@ namespace BossRoom
 
             NetManager = NetworkManagerGO.GetComponent<NetworkManager>();
 
-            //we synthesize a "NetworkStart" event for the NetworkManager out of existing events. At some point
+            //we synthesize a "OnNetworkSpawn" event for the NetworkManager out of existing events. At some point
             //we expect NetworkManager will expose an event like this itself.
             NetManager.OnServerStarted += OnNetworkReady;
             NetManager.OnClientConnectedCallback += ClientNetworkReadyWrapper;
@@ -203,7 +203,7 @@ namespace BossRoom
 
         /// <summary>
         /// This method runs when NetworkManager has started up (following a succesful connect on the client, or directly after StartHost is invoked
-        /// on the host). It is named to match NetworkBehaviour.NetworkStart, and serves the same role, even though GameNetPortal itself isn't a NetworkBehaviour.
+        /// on the host). It is named to match NetworkBehaviour.OnNetworkSpawn, and serves the same role, even though GameNetPortal itself isn't a NetworkBehaviour.
         /// </summary>
         private void OnNetworkReady()
         {

--- a/Assets/BossRoom/Scripts/Shared/Net/NetworkStats.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/NetworkStats.cs
@@ -151,7 +151,7 @@ namespace BossRoom
             LastRTT = rttSum / m_MaxWindowSize;
         }
 
-        void OnDestroy()
+        public override void OnNetworkDespawn()
         {
             if (m_TextStat != null)
             {

--- a/Assets/BossRoom/Scripts/Shared/Net/NetworkStats.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/NetworkStats.cs
@@ -46,7 +46,7 @@ namespace BossRoom
         ClientRpcParams m_PongClientParams;
 
 
-        public override void NetworkStart()
+        public override void OnNetworkSpawn()
         {
             bool isClientOnly = IsClient && !IsServer;
             if (!IsOwner && isClientOnly) // we don't want to track player ghost stats, only our own

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -101,7 +101,7 @@
         "com.unity.modules.animation": "1.0.0",
         "com.unity.nuget.mono-cecil": "1.10.1-preview.1"
       },
-      "hash": "fa2109e7e54cb15c96661a03506d6bbb7bcda517"
+      "hash": "7e19026a74f6573cc4aa22d746275332e702d2c5"
     },
     "com.unity.multiplayer.samples.coop": {
       "version": "file:com.unity.multiplayer.samples.coop",


### PR DESCRIPTION
BossRoom now tracks MLAPI develop hash `7e19026a74f6573cc4aa22d746275332e702d2c5`.

This fixes quite a bit of editor QoL issues. Namely:

- Inspecting `NetworkVariable<T>` in editor fix: https://github.com/Unity-Technologies/com.unity.multiplayer.mlapi/pull/898.
- List of `NetworkPrefabs` inside NetworkManager being invalidated: https://github.com/Unity-Technologies/com.unity.multiplayer.mlapi/pull/905.

Notable API change: `NetworkStart()` refactored to `OnNetworkSpawn()`. Same functionality.

`Player` prefab has also been removed from `NetworkPrefabs` list since there is now a dedicated field for `Player Prefab`.