### PR TITLE
networktransform handles players' movement syncing

### DIFF
--- a/Assets/BossRoom/Prefabs/Character/Character.prefab
+++ b/Assets/BossRoom/Prefabs/Character/Character.prefab
@@ -17,11 +17,11 @@ GameObject:
   - component: {fileID: -3542424572169399493}
   - component: {fileID: 6970334877957368017}
   - component: {fileID: 4602672899881656135}
-  - component: {fileID: 7690172137830037487}
   - component: {fileID: -909640835356089789}
   - component: {fileID: 514105321093282895}
   - component: {fileID: 4462343263575301329}
   - component: {fileID: -5107732197415868221}
+  - component: {fileID: 8540079631724274481}
   m_Layer: 3
   m_Name: Character
   m_TagString: Player
@@ -169,18 +169,6 @@ MonoBehaviour:
   m_BrainEnabled: 1
   m_KilledDestroyDelaySeconds: 3
   m_StartingAction: 0
---- !u!114 &7690172137830037487
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4600110157238723781}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 797d92969c575574d868e069887e8486, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &-909640835356089789
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -234,4 +222,27 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_LifeState:
+    m_InternalValue: 0
+--- !u!114 &8540079631724274481
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4600110157238723781}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e96cb6065543e43c4a752faaa1468eb1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TransformAuthority: 0
+  FixedSendsPerSecond: 50
+  InterpolatePosition: 1
+  SnapDistance: 10
+  InterpolateServer: 1
+  MinMeters: 0.15
+  MinDegrees: 1.5
+  MinSize: 0.15
+  Channel: 6
+  m_UseLocal:
     m_InternalValue: 0

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientCharacterVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientCharacterVisualization.cs
@@ -100,9 +100,7 @@ namespace BossRoom.Visual
             transform.SetParent(m_RuntimeObjectsParent.Value);
 
             // sync our visualization position & rotation to the most up to date version received from server
-            var parentMovement = Parent.GetComponent<INetMovement>();
-            transform.position = parentMovement.NetworkPosition.Value;
-            transform.rotation = Quaternion.Euler(0, parentMovement.NetworkRotationY.Value, 0);
+            transform.SetPositionAndRotation(Parent.position, Parent.rotation);
 
             // listen for char-select info to change (in practice, this info doesn't
             // change, but we may not have the values set yet) ...

--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacterMovement.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacterMovement.cs
@@ -54,8 +54,6 @@ namespace BossRoom.Server
                 return;
             }
 
-            m_NetworkCharacterState.InitNetworkPositionAndRotationY(transform.position, transform.rotation.eulerAngles.y);
-
             // On the server enable navMeshAgent and initialize
             m_NavMeshAgent.enabled = true;
             m_NavPath = new DynamicNavPath(m_NavMeshAgent, m_NavigationSystem);
@@ -151,10 +149,6 @@ namespace BossRoom.Server
         {
             PerformMovement();
 
-            // Send new position values to the client
-            m_NetworkCharacterState.NetworkPosition.Value = transform.position;
-            m_NetworkCharacterState.NetworkRotationY.Value = transform.rotation.eulerAngles.y;
-            m_NetworkCharacterState.NetworkMovementSpeed.Value = GetMaxMovementSpeed();
             m_NetworkCharacterState.MovementStatus.Value = GetMovementStatus();
         }
 

--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacterMovement.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacterMovement.cs
@@ -224,20 +224,6 @@ namespace BossRoom.Server
             m_Rigidbody.rotation = transform.rotation;
         }
 
-        private float GetMaxMovementSpeed()
-        {
-            switch (m_MovementState)
-            {
-                case MovementState.Charging:
-                case MovementState.Knockback:
-                    return m_ForcedSpeed;
-                case MovementState.Idle:
-                case MovementState.PathFollowing:
-                default:
-                    return GetBaseMovementSpeed();
-            }
-        }
-
         /// <summary>
         /// Retrieves the speed for this character's class.
         /// </summary>

--- a/Assets/BossRoom/Scripts/Shared/Game/Entity/NetworkCharacterState.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/Entity/NetworkCharacterState.cs
@@ -34,31 +34,8 @@ namespace BossRoom
     /// </summary>
     [RequireComponent(typeof(NetworkHealthState), typeof(NetworkCharacterTypeState),
         typeof(NetworkLifeState))]
-    public class NetworkCharacterState : NetworkBehaviour, INetMovement, ITargetable
+    public class NetworkCharacterState : NetworkBehaviour, ITargetable
     {
-        public void InitNetworkPositionAndRotationY(Vector3 initPosition, float initRotationY)
-        {
-            NetworkPosition.Value = initPosition;
-            NetworkRotationY.Value = initRotationY;
-        }
-
-        /// <summary>
-        /// The networked position of this Character. This reflects the authoritative position on the server.
-        /// </summary>
-        public NetworkVariableVector3 NetworkPosition { get; } = new NetworkVariableVector3(
-            new NetworkVariableSettings() { SendNetworkChannel = MLAPI.Transports.NetworkChannel.PositionUpdate });
-
-        /// <summary>
-        /// The networked rotation of this Character. This reflects the authoritative rotation on the server.
-        /// </summary>
-        public NetworkVariableFloat NetworkRotationY { get; } = new NetworkVariableFloat(
-            new NetworkVariableSettings() { SendNetworkChannel = MLAPI.Transports.NetworkChannel.PositionUpdate });
-
-        /// <summary>
-        /// The speed that the character is currently allowed to move, according to the server.
-        /// </summary>
-        public NetworkVariableFloat NetworkMovementSpeed { get; } = new NetworkVariableFloat();
-
         /// Indicates how the character's movement should be depicted.
         public NetworkVariable<MovementStatus> MovementStatus { get; } = new NetworkVariable<MovementStatus>();
 


### PR DESCRIPTION
Jira task [here](https://unity3d.atlassian.net/browse/GOMPS-567).

- Characters (`Player`, `Imp`, `Boss`) have now a `NetworkTransform` component, while `ClientGenericMovement` has been removed.
- NetworkVariables for position, rotation & speed have been removed from `NetworkCharacterState`.
- `NetworkTransform` component's `Fixed Sends Per Second` is set to 50 and `Channel` is set to `Position Update`.