### PR TITLE
fixing null refs on boss charge action

### DIFF
--- a/Assets/BossRoom/Prefabs/Character/Imp.prefab
+++ b/Assets/BossRoom/Prefabs/Character/Imp.prefab
@@ -194,6 +194,18 @@ PrefabInstance:
       propertyPath: m_ClientCharacterVisualization
       value: 
       objectReference: {fileID: 3121817358174221070}
+    - target: {fileID: 7629562350973231512, guid: 64cfd098f62285f42918875fef849e88, type: 3}
+      propertyPath: m_Height
+      value: 1.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7629562350973231512, guid: 64cfd098f62285f42918875fef849e88, type: 3}
+      propertyPath: m_Radius
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 7629562350973231512, guid: 64cfd098f62285f42918875fef849e88, type: 3}
+      propertyPath: m_Center.y
+      value: 0.8
+      objectReference: {fileID: 0}
     - target: {fileID: 8273023854864590149, guid: 64cfd098f62285f42918875fef849e88, type: 3}
       propertyPath: m_Height
       value: 1.6

--- a/Assets/BossRoom/Prefabs/Character/ImpBoss.prefab
+++ b/Assets/BossRoom/Prefabs/Character/ImpBoss.prefab
@@ -138,10 +138,26 @@ PrefabInstance:
       propertyPath: m_CharacterClass
       value: 
       objectReference: {fileID: 11400000, guid: 1fdbcd02edb11484a91de118f5ef44b3, type: 2}
+    - target: {fileID: 5448876330215689433, guid: 64cfd098f62285f42918875fef849e88, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6995351927119310807, guid: 64cfd098f62285f42918875fef849e88, type: 3}
       propertyPath: m_ClientCharacterVisualization
       value: 
       objectReference: {fileID: 5970403413429264330}
+    - target: {fileID: 7629562350973231512, guid: 64cfd098f62285f42918875fef849e88, type: 3}
+      propertyPath: m_Height
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7629562350973231512, guid: 64cfd098f62285f42918875fef849e88, type: 3}
+      propertyPath: m_Radius
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7629562350973231512, guid: 64cfd098f62285f42918875fef849e88, type: 3}
+      propertyPath: m_Center.y
+      value: 4
+      objectReference: {fileID: 0}
     - target: {fileID: 8273023854864590149, guid: 64cfd098f62285f42918875fef849e88, type: 3}
       propertyPath: m_Height
       value: 8

--- a/Assets/BossRoom/Scripts/Server/Game/Action/TrampleAction.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Action/TrampleAction.cs
@@ -54,15 +54,25 @@ namespace BossRoom.Server
         public override bool Start()
         {
             m_PreviousStage = ActionStage.Windup;
-            m_Movement = m_Parent.GetComponent<ServerCharacterMovement>();
+            m_Movement = m_Parent.Movement;
 
             if (m_Data.TargetIds != null && m_Data.TargetIds.Length > 0)
             {
                 NetworkObject initialTarget = NetworkManager.Singleton.SpawnManager.SpawnedObjects[m_Data.TargetIds[0]];
                 if (initialTarget)
                 {
+                    Vector3 lookAtPosition;
+                    if (PhysicsWrapper.TryGetPhysicsWrapper(initialTarget.NetworkObjectId, out var physicsWrapper))
+                    {
+                        lookAtPosition = physicsWrapper.Transform.position;
+                    }
+                    else
+                    {
+                        lookAtPosition = initialTarget.transform.position;
+                    }
+
                     // snap to face our target! This is the direction we'll attack in
-                    m_Parent.physicsWrapper.Transform.LookAt(initialTarget.transform.position);
+                    m_Parent.physicsWrapper.Transform.LookAt(lookAtPosition);
                 }
             }
 
@@ -145,7 +155,7 @@ namespace BossRoom.Server
                 victim.ReceiveHP(this.m_Parent, -damage);
             }
 
-            var victimMovement = victim.GetComponent<ServerCharacterMovement>();
+            var victimMovement = victim.Movement;
             victimMovement.StartKnockback(m_Parent.physicsWrapper.Transform.position, Description.KnockbackSpeed, Description.KnockbackDuration);
         }
 
@@ -167,7 +177,7 @@ namespace BossRoom.Server
 
             m_CollidedAlready.Add(collider);
 
-            var victim = collider.gameObject.GetComponent<ServerCharacter>();
+            var victim = collider.gameObject.GetComponentInParent<ServerCharacter>();
             if (victim)
             {
                 CollideWithVictim(victim);
@@ -195,7 +205,7 @@ namespace BossRoom.Server
             // So when we start charging across the screen, we check to see what's already touching us
             // (or close enough) and treat that like a collision.
             RaycastHit[] results;
-            int numResults = ActionUtils.DetectNearbyEntities(true, true, m_Parent.GetComponent<Collider>(), k_PhysicalTouchDistance, out results);
+            int numResults = ActionUtils.DetectNearbyEntities(true, true, m_Parent.physicsWrapper.DamageCollider, k_PhysicalTouchDistance, out results);
             for (int i = 0; i < numResults; i++)
             {
                 Collide(results[i].collider);

--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacter.cs
@@ -68,6 +68,7 @@ namespace BossRoom.Server
                 NetState.OnStopChargingUpServer += OnStoppedChargingUp;
                 NetState.NetworkLifeState.LifeState.OnValueChanged += OnLifeStateChanged;
                 m_DamageReceiver.damageReceived += ReceiveHP;
+                m_DamageReceiver.collisionEntered += CollisionEntered;
 
                 if (NetState.IsNpc)
                 {
@@ -97,6 +98,7 @@ namespace BossRoom.Server
             if (m_DamageReceiver)
             {
                 m_DamageReceiver.damageReceived -= ReceiveHP;
+                m_DamageReceiver.collisionEntered -= CollisionEntered;
             }
         }
 
@@ -253,7 +255,7 @@ namespace BossRoom.Server
             }
         }
 
-        private void OnCollisionEnter(Collision collision)
+        private void CollisionEntered(Collision collision)
         {
             if (m_ActionPlayer != null)
             {

--- a/Assets/BossRoom/Scripts/Server/Game/Entity/DamageReceiver.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Entity/DamageReceiver.cs
@@ -8,6 +8,8 @@ namespace BossRoom.Server
     {
         public event Action<ServerCharacter, int> damageReceived;
 
+        public event Action<Collision> collisionEntered;
+
         [SerializeField]
         NetworkLifeState m_NetworkLifeState;
 
@@ -24,6 +26,11 @@ namespace BossRoom.Server
         public bool IsDamageable()
         {
             return m_NetworkLifeState.LifeState.Value == LifeState.Alive;
+        }
+
+        void OnCollisionEnter(Collision other)
+        {
+            collisionEntered?.Invoke(other);
         }
     }
 }


### PR DESCRIPTION
Fix for [issue](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/issues/364) with the Boss' charge.

- `OnCollisionEnter` wasn't fired on `ServerCharacter` component due to a hierarchy change. Collider component was moved to a child GameObject. `DamageReceiver` instead checks for collisions.
- Null references have been addressed (mostly referencing to `PhysicsWrapper` component).