### PR TITLE
feat: server-authoritative character NetworkAnimator

### DIFF
--- a/Assets/BossRoom/Prefabs/CharGFX/CharacterGraphics/CharacterSelect/PlayerGraphics_Archer_Boy_CharacterSelect.prefab
+++ b/Assets/BossRoom/Prefabs/CharGFX/CharacterGraphics/CharacterSelect/PlayerGraphics_Archer_Boy_CharacterSelect.prefab
@@ -11,6 +11,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: PlayerGraphics_Archer_Boy_CharacterSelect
       objectReference: {fileID: 0}
+    - target: {fileID: 2950036362190399201, guid: 29d0c8c1a1c40274d97718c37b8b1426, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3037349535683109858, guid: 29d0c8c1a1c40274d97718c37b8b1426, type: 3}
       propertyPath: m_RootOrder
       value: 0

--- a/Assets/BossRoom/Prefabs/CharGFX/CharacterGraphics/CharacterSelect/PlayerGraphics_Archer_Girl_CharacterSelect.prefab
+++ b/Assets/BossRoom/Prefabs/CharGFX/CharacterGraphics/CharacterSelect/PlayerGraphics_Archer_Girl_CharacterSelect.prefab
@@ -11,6 +11,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: PlayerGraphics_Archer_Girl_CharacterSelect
       objectReference: {fileID: 0}
+    - target: {fileID: 2950036362190399201, guid: c606ea8a9b63df640a18e10c81bbe28c, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3037349535683109858, guid: c606ea8a9b63df640a18e10c81bbe28c, type: 3}
       propertyPath: m_RootOrder
       value: 0

--- a/Assets/BossRoom/Prefabs/CharGFX/CharacterGraphics/CharacterSelect/PlayerGraphics_Mage_Boy_CharacterSelect.prefab
+++ b/Assets/BossRoom/Prefabs/CharGFX/CharacterGraphics/CharacterSelect/PlayerGraphics_Mage_Boy_CharacterSelect.prefab
@@ -55,6 +55,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3446292696262816305, guid: 5198848937b62074586fad6bc95e0f3d, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6437196459416029142, guid: 5198848937b62074586fad6bc95e0f3d, type: 3}
       propertyPath: m_AudioSources.Array.data[0]
       value: 

--- a/Assets/BossRoom/Prefabs/CharGFX/CharacterGraphics/CharacterSelect/PlayerGraphics_Mage_Girl_CharacterSelect.prefab
+++ b/Assets/BossRoom/Prefabs/CharGFX/CharacterGraphics/CharacterSelect/PlayerGraphics_Mage_Girl_CharacterSelect.prefab
@@ -55,6 +55,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3446292696262816305, guid: cd83969f4c2788748a18f10b2cab8f5f, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6437196459416029142, guid: cd83969f4c2788748a18f10b2cab8f5f, type: 3}
       propertyPath: m_AudioSources.Array.data[0]
       value: 

--- a/Assets/BossRoom/Prefabs/CharGFX/CharacterGraphics/CharacterSelect/PlayerGraphics_Rogue_Boy_CharacterSelect.prefab
+++ b/Assets/BossRoom/Prefabs/CharGFX/CharacterGraphics/CharacterSelect/PlayerGraphics_Rogue_Boy_CharacterSelect.prefab
@@ -67,6 +67,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6793030668134069502, guid: d462455aa2605fc41a44a4f249ec5b5d, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 7786333504589615745, guid: d462455aa2605fc41a44a4f249ec5b5d, type: 3}
     - {fileID: 1342614894023717942, guid: d462455aa2605fc41a44a4f249ec5b5d, type: 3}

--- a/Assets/BossRoom/Prefabs/CharGFX/CharacterGraphics/CharacterSelect/PlayerGraphics_Rogue_Girl_CharacterSelect.prefab
+++ b/Assets/BossRoom/Prefabs/CharGFX/CharacterGraphics/CharacterSelect/PlayerGraphics_Rogue_Girl_CharacterSelect.prefab
@@ -67,6 +67,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6793030668134069502, guid: 8034e8adbac536c4fb76fbe53f115741, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 7786333504589615745, guid: 8034e8adbac536c4fb76fbe53f115741, type: 3}
     - {fileID: 1342614894023717942, guid: 8034e8adbac536c4fb76fbe53f115741, type: 3}

--- a/Assets/BossRoom/Prefabs/CharGFX/CharacterGraphics/CharacterSelect/PlayerGraphics_Tank_Boy_CharacterSelect.prefab
+++ b/Assets/BossRoom/Prefabs/CharGFX/CharacterGraphics/CharacterSelect/PlayerGraphics_Tank_Boy_CharacterSelect.prefab
@@ -63,6 +63,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8511200453111303230, guid: ca36e58d8131c934c970b70f1f24fb68, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 9187479739242730375, guid: ca36e58d8131c934c970b70f1f24fb68, type: 3}
       propertyPath: m_Name
       value: PlayerGraphics_Tank_Boy_CharacterSelect

--- a/Assets/BossRoom/Prefabs/CharGFX/CharacterGraphics/CharacterSelect/PlayerGraphics_Tank_Girl_CharacterSelect.prefab
+++ b/Assets/BossRoom/Prefabs/CharGFX/CharacterGraphics/CharacterSelect/PlayerGraphics_Tank_Girl_CharacterSelect.prefab
@@ -63,6 +63,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8511200453111303230, guid: b87361d084178644cab2510090411db8, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 9187479739242730375, guid: b87361d084178644cab2510090411db8, type: 3}
       propertyPath: m_Name
       value: PlayerGraphics_Tank_Girl_CharacterSelect

--- a/Assets/BossRoom/Prefabs/CharGFX/PlayerGraphics.prefab
+++ b/Assets/BossRoom/Prefabs/CharGFX/PlayerGraphics.prefab
@@ -45,7 +45,7 @@ Animator:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3736552308919084700}
-  m_Enabled: 1
+  m_Enabled: 0
   m_Avatar: {fileID: 9000000, guid: 2115c4661f55eff45a5a0f91fc0a12f0, type: 3}
   m_Controller: {fileID: 9100000, guid: 81ba9d484ee6d174a8aeb3af411babc4, type: 2}
   m_CullingMode: 0
@@ -71,7 +71,6 @@ MonoBehaviour:
   m_ClientVisualsAnimator: {fileID: 4199396739699390757}
   m_CharacterSwapper: {fileID: 579958722332811098}
   m_VisualizationConfiguration: {fileID: 11400000, guid: 9504973cdecd65749889771972fa0117, type: 2}
-  m_RuntimeObjectsParent: {fileID: 11400000, guid: deda38c596e7fbd4386b9d8f9b7bb4b5, type: 2}
 --- !u!114 &579958722332811098
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -99,119 +98,6 @@ MonoBehaviour:
     shoulderLeft: {fileID: 0}
     specialFx: {fileID: 0}
     animatorOverrides: {fileID: 0}
-  m_CharacterModels:
-  - ears: {fileID: 0}
-    head: {fileID: 0}
-    mouth: {fileID: 0}
-    hair: {fileID: 0}
-    eyes: {fileID: 0}
-    torso: {fileID: 0}
-    gearRightHand: {fileID: 0}
-    gearLeftHand: {fileID: 0}
-    handRight: {fileID: 0}
-    handLeft: {fileID: 0}
-    shoulderRight: {fileID: 0}
-    shoulderLeft: {fileID: 0}
-    specialFx: {fileID: 0}
-    animatorOverrides: {fileID: 22100000, guid: c84cdd5b9f976074b8545c42342d2ce0, type: 2}
-  - ears: {fileID: 0}
-    head: {fileID: 0}
-    mouth: {fileID: 0}
-    hair: {fileID: 0}
-    eyes: {fileID: 0}
-    torso: {fileID: 0}
-    gearRightHand: {fileID: 0}
-    gearLeftHand: {fileID: 0}
-    handRight: {fileID: 0}
-    handLeft: {fileID: 0}
-    shoulderRight: {fileID: 0}
-    shoulderLeft: {fileID: 0}
-    specialFx: {fileID: 0}
-    animatorOverrides: {fileID: 22100000, guid: c84cdd5b9f976074b8545c42342d2ce0, type: 2}
-  - ears: {fileID: 0}
-    head: {fileID: 0}
-    mouth: {fileID: 0}
-    hair: {fileID: 0}
-    eyes: {fileID: 0}
-    torso: {fileID: 0}
-    gearRightHand: {fileID: 0}
-    gearLeftHand: {fileID: 0}
-    handRight: {fileID: 0}
-    handLeft: {fileID: 0}
-    shoulderRight: {fileID: 0}
-    shoulderLeft: {fileID: 0}
-    specialFx: {fileID: 0}
-    animatorOverrides: {fileID: 22100000, guid: a264cfb5b89b3054d83727922fcf312c, type: 2}
-  - ears: {fileID: 0}
-    head: {fileID: 0}
-    mouth: {fileID: 0}
-    hair: {fileID: 0}
-    eyes: {fileID: 0}
-    torso: {fileID: 0}
-    gearRightHand: {fileID: 0}
-    gearLeftHand: {fileID: 0}
-    handRight: {fileID: 0}
-    handLeft: {fileID: 0}
-    shoulderRight: {fileID: 0}
-    shoulderLeft: {fileID: 0}
-    specialFx: {fileID: 0}
-    animatorOverrides: {fileID: 22100000, guid: a264cfb5b89b3054d83727922fcf312c, type: 2}
-  - ears: {fileID: 0}
-    head: {fileID: 0}
-    mouth: {fileID: 0}
-    hair: {fileID: 0}
-    eyes: {fileID: 0}
-    torso: {fileID: 0}
-    gearRightHand: {fileID: 0}
-    gearLeftHand: {fileID: 0}
-    handRight: {fileID: 0}
-    handLeft: {fileID: 0}
-    shoulderRight: {fileID: 0}
-    shoulderLeft: {fileID: 0}
-    specialFx: {fileID: 0}
-    animatorOverrides: {fileID: 22100000, guid: 2c3286578a51645449e8926f958438a7, type: 2}
-  - ears: {fileID: 0}
-    head: {fileID: 0}
-    mouth: {fileID: 0}
-    hair: {fileID: 0}
-    eyes: {fileID: 0}
-    torso: {fileID: 0}
-    gearRightHand: {fileID: 0}
-    gearLeftHand: {fileID: 0}
-    handRight: {fileID: 0}
-    handLeft: {fileID: 0}
-    shoulderRight: {fileID: 0}
-    shoulderLeft: {fileID: 0}
-    specialFx: {fileID: 0}
-    animatorOverrides: {fileID: 22100000, guid: 2c3286578a51645449e8926f958438a7, type: 2}
-  - ears: {fileID: 0}
-    head: {fileID: 0}
-    mouth: {fileID: 0}
-    hair: {fileID: 0}
-    eyes: {fileID: 0}
-    torso: {fileID: 0}
-    gearRightHand: {fileID: 0}
-    gearLeftHand: {fileID: 0}
-    handRight: {fileID: 0}
-    handLeft: {fileID: 0}
-    shoulderRight: {fileID: 0}
-    shoulderLeft: {fileID: 0}
-    specialFx: {fileID: 0}
-    animatorOverrides: {fileID: 22100000, guid: 59250e4e9e5786b408633dbbdb2cecff, type: 2}
-  - ears: {fileID: 0}
-    head: {fileID: 0}
-    mouth: {fileID: 0}
-    hair: {fileID: 0}
-    eyes: {fileID: 0}
-    torso: {fileID: 0}
-    gearRightHand: {fileID: 0}
-    gearLeftHand: {fileID: 0}
-    handRight: {fileID: 0}
-    handLeft: {fileID: 0}
-    shoulderRight: {fileID: 0}
-    shoulderLeft: {fileID: 0}
-    specialFx: {fileID: 0}
-    animatorOverrides: {fileID: 22100000, guid: 59250e4e9e5786b408633dbbdb2cecff, type: 2}
   m_Animator: {fileID: 4199396739699390757}
   m_StealthySelfMaterial: {fileID: 2100000, guid: 3a999e4944c72a84c830c337bdb6348b, type: 2}
   m_StealthyOtherMaterial: {fileID: 2100000, guid: f3b8028a3fb2d3a42b5a0c73fc01b6f0, type: 2}

--- a/Assets/BossRoom/Prefabs/Character/Character.prefab
+++ b/Assets/BossRoom/Prefabs/Character/Character.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: -5107732197415868221}
   - component: {fileID: -6618539813679097072}
   - component: {fileID: 7420593339233078707}
+  - component: {fileID: 4058497248645145345}
   m_Layer: 3
   m_Name: Character
   m_TagString: Player
@@ -141,7 +142,21 @@ MonoBehaviour:
   m_StartingAction: 0
   m_DamageReceiver: {fileID: 1855969081593386876}
   m_Movement: {fileID: 324656297602094545}
-  m_PhysicsWrapper: {fileID: 2925909444737100379}
+  m_PhysicsWrapper: {fileID: 4058497248645145345}
+--- !u!114 &4058497248645145345
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4600110157238723781}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bc85fa0320dca1545a3e037ee46391cf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Transform: {fileID: 6479125009090019661}
+  m_DamageCollider: {fileID: 8905185955776261132}
 --- !u!1 &8690326290994660422
 GameObject:
   m_ObjectHideFlags: 0
@@ -155,7 +170,6 @@ GameObject:
   - component: {fileID: 2714035606948642704}
   - component: {fileID: 8905185955776261132}
   - component: {fileID: 324656297602094545}
-  - component: {fileID: 2925909444737100379}
   - component: {fileID: 1855969081593386876}
   - component: {fileID: 1048126315205703499}
   m_Layer: 3
@@ -247,20 +261,6 @@ MonoBehaviour:
   m_Rigidbody: {fileID: 538169960015632806}
   m_NetworkCharacterState: {fileID: 4600110157238723777}
   m_CharLogic: {fileID: 7420593339233078707}
---- !u!114 &2925909444737100379
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8690326290994660422}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bc85fa0320dca1545a3e037ee46391cf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Transform: {fileID: 6479125009090019661}
-  m_DamageCollider: {fileID: 8905185955776261132}
 --- !u!114 &1855969081593386876
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -286,14 +286,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96cb6065543e43c4a752faaa1468eb1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TransformAuthority: 0
+  SyncPositionX: 1
+  SyncPositionY: 1
+  SyncPositionZ: 1
+  SyncRotAngleX: 1
+  SyncRotAngleY: 1
+  SyncRotAngleZ: 1
+  SyncScaleX: 1
+  SyncScaleY: 1
+  SyncScaleZ: 1
+  PositionThreshold: 0
+  RotAngleThreshold: 0
+  ScaleThreshold: 0
+  InLocalSpace: 0
+  Interpolate: 1
   FixedSendsPerSecond: 50
-  InterpolatePosition: 1
-  SnapDistance: 10
-  InterpolateServer: 1
-  MinMeters: 0.15
-  MinDegrees: 1.5
-  MinSize: 0.15
-  Channel: 6
-  m_UseLocal:
-    m_InternalValue: 0

--- a/Assets/BossRoom/Prefabs/Character/Imp.prefab
+++ b/Assets/BossRoom/Prefabs/Character/Imp.prefab
@@ -1,5 +1,20 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &6027014890250673899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5858966600248860054}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e8d0727d5ae3244e3b569694d3912374, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  AnimatorAuthority: 0
+  m_SendRate: 0.1
+  m_Animator: {fileID: 929086692793228630}
 --- !u!114 &-4570750241117365215
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -83,9 +98,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1ffde884792e9a44a9fbe049ebb79c9f, type: 3}
+--- !u!1 &5858966600248860054 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6839301660383890230, guid: 1ffde884792e9a44a9fbe049ebb79c9f, type: 3}
+  m_PrefabInstance: {fileID: 1127359556114831008}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &6486568539699693356 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6170428688339538316, guid: 1ffde884792e9a44a9fbe049ebb79c9f, type: 3}
+  m_PrefabInstance: {fileID: 1127359556114831008}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &929086692793228630 stripped
+Animator:
+  m_CorrespondingSourceObject: {fileID: 234724737205816310, guid: 1ffde884792e9a44a9fbe049ebb79c9f, type: 3}
   m_PrefabInstance: {fileID: 1127359556114831008}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &3121817358174221070 stripped
@@ -93,7 +118,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2663813019036984750, guid: 1ffde884792e9a44a9fbe049ebb79c9f, type: 3}
   m_PrefabInstance: {fileID: 1127359556114831008}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 5858966600248860054}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9520a47fc61d5ab4ca99cdac2d574909, type: 3}

--- a/Assets/BossRoom/Prefabs/Character/ImpBoss.prefab
+++ b/Assets/BossRoom/Prefabs/Character/ImpBoss.prefab
@@ -51,6 +51,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_NetworkLifeState: {fileID: 3889605435075370027}
   m_NetworkHealthState: {fileID: 848206395698055335}
+--- !u!114 &8719619227092032086
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2938305229903524178}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e8d0727d5ae3244e3b569694d3912374, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  AnimatorAuthority: 0
+  m_SendRate: 0.1
+  m_Animator: {fileID: 8461429659892969874}
 --- !u!1001 &2203142923062114684
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -276,12 +291,22 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1e8ae28d24c5683478548d7e96e5ba55, type: 3}
+--- !u!1 &2938305229903524178 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6839301660383890230, guid: 1e8ae28d24c5683478548d7e96e5ba55, type: 3}
+  m_PrefabInstance: {fileID: 8515429031237761636}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &8461429659892969874 stripped
+Animator:
+  m_CorrespondingSourceObject: {fileID: 234724737205816310, guid: 1e8ae28d24c5683478548d7e96e5ba55, type: 3}
+  m_PrefabInstance: {fileID: 8515429031237761636}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &5970403413429264330 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2663813019036984750, guid: 1e8ae28d24c5683478548d7e96e5ba55, type: 3}
   m_PrefabInstance: {fileID: 8515429031237761636}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 2938305229903524178}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9520a47fc61d5ab4ca99cdac2d574909, type: 3}

--- a/Assets/BossRoom/Prefabs/Character/PlayerAvatar.prefab
+++ b/Assets/BossRoom/Prefabs/Character/PlayerAvatar.prefab
@@ -87,7 +87,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_CharacterClassContainer: {fileID: 5230418375993597025}
-  m_PhysicsWrapper: {fileID: 4912019773021580586}
+  m_PhysicsWrapper: {fileID: 6116655102486013040}
 --- !u!114 &5043718152237111612
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -114,6 +114,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ClientCharacter: {fileID: 2292431908892550450}
+  m_GraphicsAnimator: {fileID: 1829276847453002016}
   m_CharacterClassContainer: {fileID: 5230418375993597025}
   m_NetworkAvatarGuidState: {fileID: 2466014342928185240}
   m_AvatarRegistry: {fileID: 11400000, guid: 48d17d764bff6c643a3dc035fb71c979, type: 2}
@@ -130,6 +131,72 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_FeedbackPrefab: {fileID: 9137928905311479176, guid: 5d22c1d86e0e5604cbe14004bf924827, type: 3}
+--- !u!1 &9073758047842524076
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7902288483105483375}
+  - component: {fileID: 1829276847453002016}
+  - component: {fileID: 3352015142852197742}
+  m_Layer: 3
+  m_Name: PlayerGraphics
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7902288483105483375
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073758047842524076}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6009713983291384766}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!95 &1829276847453002016
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073758047842524076}
+  m_Enabled: 1
+  m_Avatar: {fileID: 9000000, guid: 2115c4661f55eff45a5a0f91fc0a12f0, type: 3}
+  m_Controller: {fileID: 9100000, guid: 81ba9d484ee6d174a8aeb3af411babc4, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!114 &3352015142852197742
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9073758047842524076}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e8d0727d5ae3244e3b569694d3912374, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  AnimatorAuthority: 0
+  m_SendRate: 0.1
+  m_Animator: {fileID: 1829276847453002016}
 --- !u!1001 &7831782662127126385
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -225,6 +292,11 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 4600110157238723781, guid: 0d2d836e2e83b754fa1a1c4022d6d65d, type: 3}
   m_PrefabInstance: {fileID: 7831782662127126385}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &6009713983291384766 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4600110157238723791, guid: 0d2d836e2e83b754fa1a1c4022d6d65d, type: 3}
+  m_PrefabInstance: {fileID: 7831782662127126385}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2292431908892550450 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: -909640835356089789, guid: 0d2d836e2e83b754fa1a1c4022d6d65d, type: 3}
@@ -269,12 +341,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 920a440eb254ba348915767fd046027a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &4912019773021580586 stripped
+--- !u!114 &6116655102486013040 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2925909444737100379, guid: 0d2d836e2e83b754fa1a1c4022d6d65d, type: 3}
+  m_CorrespondingSourceObject: {fileID: 4058497248645145345, guid: 0d2d836e2e83b754fa1a1c4022d6d65d, type: 3}
   m_PrefabInstance: {fileID: 7831782662127126385}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 6009713983291384756}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: bc85fa0320dca1545a3e037ee46391cf, type: 3}

--- a/Assets/BossRoom/Scripts/Client/AnimationCallbacks/AnimatorFootstepSounds.cs
+++ b/Assets/BossRoom/Scripts/Client/AnimationCallbacks/AnimatorFootstepSounds.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace BossRoom.Visual
@@ -6,7 +7,7 @@ namespace BossRoom.Visual
     /// Plays one of a few sound effects, on a loop, based on a variable in an Animator.
     /// We use this to play footstep sounds.
     /// </summary>
-    /// 
+    ///
     /// <remarks>
     /// For this project we're using a few looped footstep sounds, choosing between them
     /// based on the animated speed. This method has good performance versus a more complicated
@@ -61,6 +62,11 @@ namespace BossRoom.Visual
         [SerializeField]
         [Tooltip("If the speed variable is between WalkSpeedThreshold and this, we're running. (Higher than this means no sound)")]
         private float m_RunSpeedThreshold = 1.2f;
+
+        public void SetAnimator(Animator animator)
+        {
+            m_Animator = animator;
+        }
 
         private void Update()
         {

--- a/Assets/BossRoom/Scripts/Client/Game/Action/AnimationOnlyActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/AnimationOnlyActionFX.cs
@@ -10,7 +10,7 @@ namespace BossRoom.Visual
 
         public override bool Start()
         {
-            if( !Anticipated )
+            if (!Anticipated)
             {
                 PlayStartAnim();
             }
@@ -19,15 +19,15 @@ namespace BossRoom.Visual
             return true;
         }
 
-        private void PlayStartAnim()
+        private void PlayStartAnim(bool anticipated = false)
         {
-            m_Parent.OurAnimator.SetTrigger(Description.Anim);
+            m_Parent.TrySetTrigger(Description.Anim, anticipated);
         }
 
         public override void AnticipateAction()
         {
             base.AnticipateAction();
-            PlayStartAnim();
+            PlayStartAnim(true);
         }
 
         public override bool Update()
@@ -39,7 +39,7 @@ namespace BossRoom.Visual
         {
             if (!string.IsNullOrEmpty(Description.Anim2))
             {
-                m_Parent.OurAnimator.SetTrigger(Description.Anim2);
+                m_Parent.TrySetTrigger(Description.Anim2);
             }
         }
 

--- a/Assets/BossRoom/Scripts/Client/Game/Action/AoeActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/AoeActionFX.cs
@@ -12,7 +12,7 @@ namespace BossRoom.Visual
         public override bool Start()
         {
             base.Start();
-            m_Parent.OurAnimator.SetTrigger(Description.Anim);
+            m_Parent.TrySetTrigger(Description.Anim);
             GameObject.Instantiate(Description.Spawns[0], m_Data.Position, Quaternion.identity);
             return ActionConclusion.Stop;
         }

--- a/Assets/BossRoom/Scripts/Client/Game/Action/ChargedLaunchProjectileActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/ChargedLaunchProjectileActionFX.cs
@@ -26,7 +26,7 @@ namespace BossRoom.Visual
         public override bool Start()
         {
             base.Start();
-            m_Parent.OurAnimator.SetTrigger(Description.Anim);
+            m_Parent.TrySetTrigger(Description.Anim);
 
             m_Graphics = InstantiateSpecialFXGraphics(m_Parent.transform, true);
             return true;
@@ -41,7 +41,7 @@ namespace BossRoom.Visual
         {
             if (!string.IsNullOrEmpty(Description.Anim2))
             {
-                m_Parent.OurAnimator.SetTrigger(Description.Anim2);
+                m_Parent.TrySetTrigger(Description.Anim2);
             }
 
             if (!m_ChargeEnded)

--- a/Assets/BossRoom/Scripts/Client/Game/Action/ChargedShieldActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/ChargedShieldActionFX.cs
@@ -42,16 +42,16 @@ namespace BossRoom.Visual
             return true;
         }
 
-        private void PlayAnim()
+        private void PlayAnim(bool anticipated = false)
         {
             // because this action can be visually started and stopped as often and as quickly as the player wants, it's possible
             // for several copies of this action to be playing at once. This can lead to situations where several
             // dying versions of the action raise the end-trigger, but the animator only lowers it once, leaving the trigger
             // in a raised state. So we'll make sure that our end-trigger isn't raised yet. (Generally a good idea anyway.)
-            m_Parent.OurAnimator.ResetTrigger(Description.Anim2);
+            m_Parent.TryResetTrigger(Description.Anim2, anticipated);
 
             // raise the start trigger to start the animation loop!
-            m_Parent.OurAnimator.SetTrigger(Description.Anim);
+            m_Parent.TrySetTrigger(Description.Anim, anticipated);
         }
 
         private bool IsChargingUp()
@@ -73,13 +73,13 @@ namespace BossRoom.Visual
                 {
                     m_ChargeGraphics.Shutdown();
                 }
-                m_Parent.OurAnimator.SetTrigger(Description.Anim2);
+                m_Parent.TrySetTrigger(Description.Anim2);
             }
 
             if (m_ShieldGraphics)
             {
                 m_ShieldGraphics.Shutdown();
-                m_Parent.OurAnimator.SetInteger(Description.OtherAnimatorVariable, m_Parent.OurAnimator.GetInteger(Description.OtherAnimatorVariable) - 1);
+                m_Parent.TrySetInteger(Description.OtherAnimatorVariable, m_Parent.OurAnimator.GetInteger(Description.OtherAnimatorVariable) - 1);
             }
         }
 
@@ -88,7 +88,7 @@ namespace BossRoom.Visual
             if (!IsChargingUp()) { return; }
 
             m_StoppedChargingUpTime = Time.time;
-            m_Parent.OurAnimator.SetTrigger(Description.Anim2);
+            m_Parent.TrySetTrigger(Description.Anim2);
             if (m_ChargeGraphics)
             {
                 m_ChargeGraphics.Shutdown();
@@ -104,14 +104,14 @@ namespace BossRoom.Visual
                 // can restart their shield before the first one has ended, thereby getting two stacks of invincibility.
                 // So each active copy of the charge-up increments the invincibility counter, and the animator controller
                 // knows anything greater than zero means we shouldn't show hit-reacts.
-                m_Parent.OurAnimator.SetInteger(Description.OtherAnimatorVariable, m_Parent.OurAnimator.GetInteger(Description.OtherAnimatorVariable) + 1);
+                m_Parent.TrySetInteger(Description.OtherAnimatorVariable, m_Parent.OurAnimator.GetInteger(Description.OtherAnimatorVariable) + 1);
             }
         }
 
         public override void AnticipateAction()
         {
             base.AnticipateAction();
-            PlayAnim();
+            PlayAnim(true);
         }
 
     }

--- a/Assets/BossRoom/Scripts/Client/Game/Action/DashAttackActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/DashAttackActionFX.cs
@@ -4,7 +4,7 @@ namespace BossRoom.Visual
 {
     /// <summary>
     /// Visualization of a DashAttackAction. See DashAttackAction.cs for more info.
-    /// 
+    ///
     /// From the server's point of view, the dash attack is just a delayed teleport, followed by a melee attack.
     /// But on the client, we visualize this as the character dashing across the screen. The dashing begins after
     /// ExecTimeSeconds have elapsed.
@@ -38,15 +38,15 @@ namespace BossRoom.Visual
             return true;
         }
 
-        private void PlayStartAnim()
+        private void PlayStartAnim(bool anticipated = false)
         {
-            m_Parent.OurAnimator.SetTrigger(Description.Anim);
+            m_Parent.TrySetTrigger(Description.Anim, anticipated);
         }
 
         public override void AnticipateAction()
         {
             base.AnticipateAction();
-            PlayStartAnim();
+            PlayStartAnim(true);
         }
 
         public override bool Update()
@@ -78,7 +78,7 @@ namespace BossRoom.Visual
             // Anim2 contains the name of the end-loop-sequence trigger
             if (!string.IsNullOrEmpty(Description.Anim2))
             {
-                m_Parent.OurAnimator.SetTrigger(Description.Anim2);
+                m_Parent.TrySetTrigger(Description.Anim2);
             }
         }
 
@@ -87,7 +87,7 @@ namespace BossRoom.Visual
             // OtherAnimatorVariable contains the name of the cancelation trigger
             if (!string.IsNullOrEmpty(Description.OtherAnimatorVariable))
             {
-                m_Parent.OurAnimator.SetTrigger(Description.OtherAnimatorVariable);
+                m_Parent.TrySetTrigger(Description.OtherAnimatorVariable);
             }
         }
 

--- a/Assets/BossRoom/Scripts/Client/Game/Action/FXProjectileTargetedActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/FXProjectileTargetedActionFX.cs
@@ -47,9 +47,9 @@ namespace BossRoom.Visual
             return true;
         }
 
-        private void PlayFireAnim()
+        private void PlayFireAnim(bool anticipated = false)
         {
-            m_Parent.OurAnimator.SetTrigger(Description.Anim);
+            m_Parent.TrySetTrigger(Description.Anim, anticipated);
         }
 
         public override bool Update()
@@ -92,7 +92,7 @@ namespace BossRoom.Visual
             if (m_Target && m_Target.TryGetComponent(out Client.ClientCharacter clientCharacter) && clientCharacter.ChildVizObject != null )
             {
                 var hitReact = !string.IsNullOrEmpty(Description.ReactAnim) ? Description.ReactAnim : k_DefaultHitReact;
-                clientCharacter.ChildVizObject.OurAnimator.SetTrigger(hitReact);
+                clientCharacter.ChildVizObject.TrySetTrigger(hitReact);
             }
         }
 
@@ -150,7 +150,7 @@ namespace BossRoom.Visual
         public override void AnticipateAction()
         {
             base.AnticipateAction();
-            PlayFireAnim();
+            PlayFireAnim(true);
 
             // see if this is going to be a "miss" because the player tried to click through a wall. If so,
             // we change our data in the same way that the server will (changing our target point to the spot on the wall)

--- a/Assets/BossRoom/Scripts/Client/Game/Action/MeleeActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/MeleeActionFX.cs
@@ -57,7 +57,7 @@ namespace BossRoom.Visual
                 if ((m_Parent.transform.position - targetPosition).sqrMagnitude < (padRange * padRange))
                 {
                     // target is in range! Play the graphics
-                    m_SpawnedGraphics = InstantiateSpecialFXGraphics(targetNetworkObj.transform, true);
+                    m_SpawnedGraphics = InstantiateSpecialFXGraphics(physicsWrapper ? physicsWrapper.Transform : targetNetworkObj.transform, true);
                 }
             }
             return true;
@@ -99,9 +99,9 @@ namespace BossRoom.Visual
             }
         }
 
-        private void PlayAnim()
+        private void PlayAnim(bool anticipated = false)
         {
-            m_Parent.OurAnimator.SetTrigger(Description.Anim);
+            m_Parent.TrySetTrigger(Description.Anim, anticipated);
         }
 
         private void PlayHitReact()
@@ -136,7 +136,7 @@ namespace BossRoom.Visual
                         var clientChar = targetNetworkObj.GetComponent<Client.ClientCharacter>();
                         if (clientChar && clientChar.ChildVizObject && clientChar.ChildVizObject.OurAnimator)
                         {
-                            clientChar.ChildVizObject.OurAnimator.SetTrigger(hitAnim);
+                            clientChar.ChildVizObject.TrySetTrigger(hitAnim);
                         }
                     }
                 }
@@ -152,7 +152,7 @@ namespace BossRoom.Visual
 
             //note: because the hit-react is driven from the animation, this means we can anticipatively trigger a hit-react too. That
             //will make combat feel responsive, but of course the actual damage won't be applied until the server tells us about it.
-            PlayAnim();
+            PlayAnim(true);
         }
     }
 }

--- a/Assets/BossRoom/Scripts/Client/Game/Action/StealthModeActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/StealthModeActionFX.cs
@@ -6,7 +6,7 @@ namespace BossRoom.Visual
     /// Graphics for the rogue's StealthModeAction. Note that this is only part of the visual-effects for this action!
     /// The ClientCharacterVisualization is also involved: it hides the actual character model from other players.
     /// That means our job here is just to:
-    /// 
+    ///
     /// - play animations
     /// - show a particle effect, but only for the player that owns this character! (Because the other players can't see
     ///   the character, and showing a particle effect where they're standing would be a dead giveaway.)
@@ -27,7 +27,7 @@ namespace BossRoom.Visual
         public override bool Start()
         {
             base.Start();
-            m_Parent.OurAnimator.SetTrigger(Description.Anim);
+            m_Parent.TrySetTrigger(Description.Anim);
             return true;
         }
 
@@ -57,7 +57,7 @@ namespace BossRoom.Visual
 
             if (!string.IsNullOrEmpty(Description.Anim2))
             {
-                m_Parent.OurAnimator.SetTrigger(Description.Anim2);
+                m_Parent.TrySetTrigger(Description.Anim2);
             }
         }
     }

--- a/Assets/BossRoom/Scripts/Client/Game/Action/TrampleActionFX.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Action/TrampleActionFX.cs
@@ -6,11 +6,11 @@ namespace BossRoom.Visual
 
     /// <summary>
     /// The visual part of a TrampleAction. See TrampleAction.cs for more about this action type.
-    /// 
+    ///
     /// TrampleActionFX can include a visual "cue" object which is placed at the attacker's feet.
     /// If used, the object should have a SpecialFXGraphic component on it, which is used to cleanly
     /// shut down the graphics.
-    /// 
+    ///
     /// Note: unlike most ActionFX, this is NOT responsible for triggering hit-react animations on
     /// the trampled victims. The TrampleAction triggers these directly when it determines a collision.
     /// </summary>
@@ -40,12 +40,12 @@ namespace BossRoom.Visual
             // reset our "stop" trigger (in case the previous run of the trample action was aborted due to e.g. being stunned)
             if (!string.IsNullOrEmpty(Description.Anim2))
             {
-                m_Parent.OurAnimator.ResetTrigger(Description.Anim2);
+                m_Parent.TryResetTrigger(Description.Anim2);
             }
             // start the animation sequence!
             if (!string.IsNullOrEmpty(Description.Anim))
             {
-                m_Parent.OurAnimator.SetTrigger(Description.Anim);
+                m_Parent.TrySetTrigger(Description.Anim);
             }
             return true;
         }
@@ -77,7 +77,7 @@ namespace BossRoom.Visual
 
             if (!string.IsNullOrEmpty(Description.Anim2))
             {
-                m_Parent.OurAnimator.SetTrigger(Description.Anim2);
+                m_Parent.TrySetTrigger(Description.Anim2);
             }
         }
     }

--- a/Assets/BossRoom/Scripts/Client/Game/Character/CharacterSwap.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/CharacterSwap.cs
@@ -110,8 +110,10 @@ namespace BossRoom.Client
         /// </summary>
         private Dictionary<Renderer, Material> m_OriginalMaterials = new Dictionary<Renderer, Material>();
 
-        private void Awake()
+        public void Initialize(Animator animator)
         {
+            m_Animator = animator;
+
             if (m_Animator)
             {
                 m_OriginalController = m_Animator.runtimeAnimatorController;

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientCharacterVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientCharacterVisualization.cs
@@ -64,6 +64,8 @@ namespace BossRoom.Visual
 
         public ulong NetworkObjectId => m_NetState.NetworkObjectId;
 
+        static bool IsServer => NetworkManager.Singleton.LocalClientId == NetworkManager.Singleton.ServerClientId;
+
         public void Start()
         {
             if (!NetworkManager.Singleton.IsClient || transform.parent == null)
@@ -76,11 +78,23 @@ namespace BossRoom.Visual
 
             m_ActionViz = new ActionVisualization(this);
 
-            Parent = transform.parent;
+            m_NetState = GetComponentInParent<NetworkCharacterState>();
 
-            m_NetState = Parent.gameObject.GetComponent<NetworkCharacterState>();
+            Parent = m_NetState.transform;
 
-            PhysicsWrapper.TryGetPhysicsWrapper(m_NetState.NetworkObjectId, out m_PhysicsWrapper);
+            if (Parent.TryGetComponent(out ClientAvatarGuidHandler clientAvatarGuidHandler))
+            {
+                m_ClientVisualsAnimator = clientAvatarGuidHandler.graphicsAnimator;
+
+                m_CharacterSwapper.Initialize(m_ClientVisualsAnimator);
+
+                if (TryGetComponent(out AnimatorFootstepSounds animatorFootstepSounds))
+                {
+                    animatorFootstepSounds.SetAnimator(m_ClientVisualsAnimator);
+                }
+            }
+
+            m_PhysicsWrapper = m_NetState.GetComponent<PhysicsWrapper>();
 
             m_NetState.DoActionEventClient += PerformActionFX;
             m_NetState.CancelAllActionsEventClient += CancelAllActionFXs;
@@ -95,9 +109,6 @@ namespace BossRoom.Visual
 
             // ...and visualize the current char-select value that we know about
             SetAppearanceSwap();
-
-            // sync our animator to the most up to date version received from server
-            SyncEntryAnimation(m_NetState.LifeState);
 
             if (!m_NetState.IsNpc)
             {
@@ -127,27 +138,10 @@ namespace BossRoom.Visual
         {
             if (!IsAnimating())
             {
-                OurAnimator.SetTrigger(m_VisualizationConfiguration.AnticipateMoveTriggerID);
+                TrySetTrigger(m_VisualizationConfiguration.AnticipateMoveTriggerID);
             }
         }
 
-        /// <summary>
-        /// The switch to certain LifeStates fires an animation on an NPC/PC. This bypasses that initial animation
-        /// and sends an NPC/PC to their eventual looping animation. This is necessary for mid-game player connections.
-        /// </summary>
-        /// <param name="lifeState"> The last LifeState received by server. </param>
-        void SyncEntryAnimation(LifeState lifeState)
-        {
-            switch (lifeState)
-            {
-                case LifeState.Dead: // ie. NPCs already dead
-                    m_ClientVisualsAnimator.SetTrigger(m_VisualizationConfiguration.EntryDeathTriggerID);
-                    break;
-                case LifeState.Fainted: // ie. PCs already fainted
-                    m_ClientVisualsAnimator.SetTrigger(m_VisualizationConfiguration.EntryFaintedTriggerID);
-                    break;
-            }
-        }
         private void OnDestroy()
         {
             if (m_NetState)
@@ -170,7 +164,7 @@ namespace BossRoom.Visual
 
         private void OnPerformHitReaction()
         {
-            m_ClientVisualsAnimator.SetTrigger(m_HitStateTriggerID);
+            TrySetTrigger(m_HitStateTriggerID);
         }
 
         private void PerformActionFX(ActionRequestData data)
@@ -198,13 +192,13 @@ namespace BossRoom.Visual
             switch (newValue)
             {
                 case LifeState.Alive:
-                    m_ClientVisualsAnimator.SetTrigger(m_VisualizationConfiguration.AliveStateTriggerID);
+                    TrySetTrigger(m_VisualizationConfiguration.AliveStateTriggerID);
                     break;
                 case LifeState.Fainted:
-                    m_ClientVisualsAnimator.SetTrigger(m_VisualizationConfiguration.FaintedStateTriggerID);
+                    TrySetTrigger(m_VisualizationConfiguration.FaintedStateTriggerID);
                     break;
                 case LifeState.Dead:
-                    m_ClientVisualsAnimator.SetTrigger(m_VisualizationConfiguration.DeadStateTriggerID);
+                    TrySetTrigger(m_VisualizationConfiguration.DeadStateTriggerID);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(newValue), newValue, null);
@@ -282,7 +276,7 @@ namespace BossRoom.Visual
             if (m_ClientVisualsAnimator)
             {
                 // set Animator variables here
-                m_ClientVisualsAnimator.SetFloat(m_VisualizationConfiguration.SpeedVariableID, GetVisualMovementSpeed());
+                TrySetFloat(m_VisualizationConfiguration.SpeedVariableID, GetVisualMovementSpeed());
             }
 
             m_ActionViz.Update();
@@ -313,5 +307,44 @@ namespace BossRoom.Visual
             return false;
         }
 
+        public void TrySetTrigger(string anim, bool anticipated = false)
+        {
+            if (IsServer || anticipated)
+            {
+                OurAnimator.SetTrigger(anim);
+            }
+        }
+
+        void TrySetTrigger(int id, bool anticipated = false)
+        {
+            if (IsServer || anticipated)
+            {
+                OurAnimator.SetTrigger(id);
+            }
+        }
+
+        public void TryResetTrigger(string anim, bool anticipated = false)
+        {
+            if (IsServer || anticipated)
+            {
+                OurAnimator.ResetTrigger(anim);
+            }
+        }
+
+        public void TrySetInteger(string anim, int value)
+        {
+            if (IsServer)
+            {
+                OurAnimator.SetInteger(anim, value);
+            }
+        }
+
+        void TrySetFloat(int id, float value)
+        {
+            if (IsServer)
+            {
+                OurAnimator.SetFloat(id, value);
+            }
+        }
     }
 }

--- a/Assets/BossRoom/Scripts/Client/Game/Entity/ClientAvatarGuidHandler.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Entity/ClientAvatarGuidHandler.cs
@@ -15,6 +15,9 @@ namespace BossRoom.Client
         ClientCharacter m_ClientCharacter;
 
         [SerializeField]
+        Animator m_GraphicsAnimator;
+
+        [SerializeField]
         CharacterClassContainer m_CharacterClassContainer;
 
         [SerializeField]
@@ -24,6 +27,8 @@ namespace BossRoom.Client
         AvatarRegistry m_AvatarRegistry;
 
         Avatar m_Avatar;
+
+        public Animator graphicsAnimator => m_GraphicsAnimator;
 
         public Avatar RegisteredAvatar => m_Avatar;
 
@@ -37,7 +42,7 @@ namespace BossRoom.Client
         void RegisterAvatar(Guid guid)
         {
             // based on the Guid received, Avatar is fetched from AvatarRegistry
-            if (!m_AvatarRegistry.TryGetAvatar(guid, out Avatar avatar))
+            if (!m_AvatarRegistry.TryGetAvatar(guid, out var avatar))
             {
                 Debug.LogError("Avatar not found!");
                 return;
@@ -55,9 +60,12 @@ namespace BossRoom.Client
             m_CharacterClassContainer.SetCharacterClass(avatar.CharacterClass);
 
             // spawn avatar graphics GameObject
-            var graphicsGameObject = Instantiate(avatar.Graphics, transform);
+            var graphicsGameObject = Instantiate(avatar.Graphics, m_GraphicsAnimator.transform);
 
             m_ClientCharacter.SetCharacterVisualization(graphicsGameObject.GetComponent<ClientCharacterVisualization>());
+
+            m_GraphicsAnimator.Rebind();
+            m_GraphicsAnimator.Update(0f);
 
             AvatarGraphicsSpawned?.Invoke(graphicsGameObject);
         }

--- a/Assets/BossRoom/Scripts/Client/Game/Entity/ClientProjectileVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Entity/ClientProjectileVisualization.cs
@@ -66,7 +66,7 @@ namespace BossRoom.Visual
                 var clientChar = targetNetObject.GetComponent<Client.ClientCharacter>();
                 if(clientChar)
                 {
-                    clientChar.ChildVizObject.OurAnimator.SetTrigger(ActionFX.k_DefaultHitReact);
+                    clientChar.ChildVizObject.TrySetTrigger(ActionFX.k_DefaultHitReact);
                 }
             }
         }

--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerBossRoomState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerBossRoomState.cs
@@ -159,8 +159,7 @@ namespace BossRoom.Server
 
             if (spawnPoint != null)
             {
-                // workaround; position of child transform not currently synced on spawn message
-                StartCoroutine(WaitToReposition(physicsTransform, spawnPoint.position, spawnPoint.rotation));
+                physicsTransform.SetPositionAndRotation(spawnPoint.position, spawnPoint.rotation);
             }
 
             var persistentPlayerExists = playerNetworkObject.TryGetComponent(out PersistentPlayer persistentPlayer);


### PR DESCRIPTION
Jira task [here](https://jira.unity3d.com/browse/MTT-993).

Here, server-authoritative `NetworkTransform` is added to the Characters (players, imps, imp boss). With this change the player hierarchy looks like so:

PlayerAvatar (`NetworkObject`)
- PhysicsObject (`NetworkTransform`)
- PlayerGraphics (`Animator` & `NetworkAnimator`)

Animations are still played on client FX scripts, but only on the host player. This change then gets replicated to other clients through `NetworkTransform`.
Anticipated actions can still played locally through an override.