### PR TITLE
Remove project and org id's

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b1fd6ae81df2200156a455df1fee6c8f552234ae01c32da988a94b9469c72d4
-size 21167
+oid sha256:f443b4d690bfd5a1f49ff40e3009684e74e114012e4a3eef2b670efe0abbb117
+size 21103


### PR DESCRIPTION
This would remove the org and project id's and users would be able to set it up with their own