### PR TITLE
fix: mage bolts not damaging spawners

### DIFF
--- a/Assets/BossRoom/Prefabs/Dungeon/Dungeon Pieces/env_door_crystral_base.prefab
+++ b/Assets/BossRoom/Prefabs/Dungeon/Dungeon Pieces/env_door_crystral_base.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 8801324764397981686}
   - component: {fileID: 8184890942973508939}
   - component: {fileID: 4897062626467851486}
-  m_Layer: 8
+  m_Layer: 6
   m_Name: env_door_crystral_base
   m_TagString: Untagged
   m_Icon: {fileID: 0}


### PR DESCRIPTION
This PR fixes the issue by changing the collision layer of spawner's base to prevent the mage's raycast to the crystal from failing.