### PR TITLE
Updated Bossroom banner image

### DIFF
--- a/Documentation/Images/Banner.png
+++ b/Documentation/Images/Banner.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0e58e92a43b1b0819eaf63e9dac5917abcef878a06789d2b2aa50bc3c7393aa
-size 256831
+oid sha256:b5e052b7f44b18bfb67f8d3a43767678361521ca01a136377ac5e8a04fc86e9b
+size 488679


### PR DESCRIPTION
Updated Bossroom banner image to one with the new Unity logo!


Before:
![image](https://user-images.githubusercontent.com/89089503/138338422-aefc9f37-d86e-4c08-885b-0b8ad0fede62.png)

After:
![image](https://user-images.githubusercontent.com/89089503/138338488-8582330c-09f9-4e39-baea-56c487793c9d.png)


