### PR TITLE
fix: client not correctly disconnected during character selection

### DIFF
--- a/Assets/BossRoom/Scripts/Client/Game/State/ClientCharSelectState.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/State/ClientCharSelectState.cs
@@ -395,6 +395,11 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
         {
             // Player is leaving the group
             // first disconnect then return to menu
+            if (IsServer)
+            {
+                NetworkObject networkObject = gameObject.GetComponent<NetworkObject>();
+                networkObject.Despawn();
+            }
             var gameNetPortal = GameObject.FindGameObjectWithTag("GameNetPortal").GetComponent<GameNetPortal>();
             gameNetPortal.RequestDisconnect();
             SceneManager.LoadScene("MainMenu");

--- a/Assets/BossRoom/Scripts/Client/Game/State/ClientCharSelectState.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/State/ClientCharSelectState.cs
@@ -395,11 +395,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
         {
             // Player is leaving the group
             // first disconnect then return to menu
-            if (IsServer)
-            {
-                NetworkObject networkObject = gameObject.GetComponent<NetworkObject>();
-                networkObject.Despawn();
-            }
             var gameNetPortal = GameObject.FindGameObjectWithTag("GameNetPortal").GetComponent<GameNetPortal>();
             gameNetPortal.RequestDisconnect();
             SceneManager.LoadScene("MainMenu");

--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
@@ -167,7 +167,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
             if (NetworkManager.Singleton)
             {
                 NetworkManager.Singleton.OnClientDisconnectCallback -= OnClientDisconnectCallback;
-                NetworkManager.Singleton.SceneManager.OnSceneEvent -= OnSceneEvent;
+                if (NetworkManager.Singleton.SceneManager != null)
+                    NetworkManager.Singleton.SceneManager.OnSceneEvent -= OnSceneEvent;
             }
             if (CharSelectData)
             {

--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
@@ -151,7 +151,18 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
             NetworkManager.SceneManager.LoadScene("BossRoom", LoadSceneMode.Single);
         }
 
+        public override void OnDestroy()
+        {
+            base.OnDestroy();
+            UnregisterCallbacks();
+        }
+
         public override void OnNetworkDespawn()
+        {
+            UnregisterCallbacks();
+        }
+
+        private void UnregisterCallbacks()
         {
             if (NetworkManager.Singleton)
             {
@@ -163,6 +174,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
                 CharSelectData.OnClientChangedSeat -= OnClientChangedSeat;
             }
         }
+
 
         public override void OnNetworkSpawn()
         {


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR resolves the issue causing clients to not be correctly disconnected when they exit a game during character selection, if the game was started by a host who previously started another game and exited during character selection.
### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): MTT-1507
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
