### PR TITLE
fix: spawners not working in case host exits

### DIFF
--- a/Assets/BossRoom/Scripts/Server/Game/Character/PlayerServerCharacter.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/PlayerServerCharacter.cs
@@ -27,12 +27,24 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
             if (!IsServer)
             {
                 enabled = false;
+                return;
             }
 
             s_ActivePlayers.Add(m_CachedServerCharacter);
         }
 
-        void OnDisable()
+        public override void OnNetworkDespawn()
+        {
+            RemovePlayerCharacter();
+        }
+
+        public override void OnDestroy()
+        {
+            base.OnDestroy();
+            RemovePlayerCharacter();
+        }
+
+        void RemovePlayerCharacter()
         {
             s_ActivePlayers.Remove(m_CachedServerCharacter);
         }

--- a/Assets/BossRoom/Scripts/Shared/Net/NetworkStats.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/NetworkStats.cs
@@ -150,7 +150,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
             LastRTT = rttSum / m_MaxWindowSize;
         }
 
-        public override void OnNetworkDespawn()
+        void RemoveText()
         {
             if (m_TextStat != null)
             {
@@ -160,6 +160,17 @@ namespace Unity.Multiplayer.Samples.BossRoom
             {
                 Destroy(m_TextHostType.gameObject);
             }
+        }
+
+        public override void OnNetworkDespawn()
+        {
+            RemoveText();
+        }
+
+        public override void OnDestroy()
+        {
+            base.OnDestroy();
+            RemoveText();
         }
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
Jira task [here](https://jira.unity3d.com/browse/MTT-1472).

If a host had exited the game abruptly while in-game, or had left while in the post-game screen, an exception was triggered on spawners which made them not spawn any imps on a subsequent playthrough.

This had to do with a static collection not being cleared on OnDisable(). This has been moved to both an OnNetworkDespawn() and OnDestroy(), as OnNetworkDespawn() is not guaranteed to be fired when the network is shutdown abruptly.

The same pattern was applied to a network text object that would not be cleared on a host exit event.

### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
Fixes issue(s): [MTT-1472](https://jira.unity3d.com/browse/MTT-1472).
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. This was tested with Photon relay, in the editor as well as on standalone builds.
2. ...
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
