### PR TITLE
fix: dead imps spawning on late join

### DIFF
--- a/Assets/BossRoom/Scripts/Shared/Game/Entity/NetworkCharacterState.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/Entity/NetworkCharacterState.cs
@@ -110,6 +110,16 @@ namespace Unity.Multiplayer.Samples.BossRoom
         /// </summary>
         public event Action<Vector3> ReceivedClientInput;
 
+        void Start()
+        {
+            // This removes characters who are in the scene but have not been spawned, i.e. imps that have despawned
+            // before this client connected to the server
+            if (IsClient && !IsSpawned)
+            {
+                Destroy(gameObject);
+            }
+        }
+
         public override void OnNetworkSpawn()
         {
             if (!IsServer) return;


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixes the issue where clients connecting to an ongoing game would see imps that have already been killed and despawned by destroying the associating gameobjects on start if they are not spawned.
### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): MTT-1558
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
