### PR TITLE
Bug Fix: Boss Room title missing

### DIFF
--- a/Assets/BossRoom/Scenes/MainMenu.unity
+++ b/Assets/BossRoom/Scenes/MainMenu.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e26d1efc86555cf976ec8dc69fb97bc2b12c864a2cf1d422ba2facd2aed4a456
-size 52554
+oid sha256:894ac2d8ffb2e0f6994fa4e7d40c08dde73be1df67e24c98134fcd31a31c7974
+size 52651


### PR DESCRIPTION
### Description (*)
Fixed the Boss Room title not showing up on Mac builds again ([same fix as before](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/pull/387), but redone for the URP version of the main menu scene)
### Related Pull Requests
https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/pull/387
