### PR TITLE
Fix: arrows despawning error while switching scenes

### DIFF
--- a/Assets/BossRoom/Scripts/Server/Game/Action/LaunchProjectileAction.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Action/LaunchProjectileAction.cs
@@ -72,7 +72,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
 
                 no.GetComponent<ServerProjectileLogic>().Initialize(m_Parent.NetworkObjectId, projectileInfo);
 
-                no.Spawn();
+                no.Spawn(true);
             }
         }
 

--- a/Assets/BossRoom/Scripts/Shared/Net/NetworkObjectPool.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/NetworkObjectPool.cs
@@ -24,7 +24,7 @@ namespace BossRoom.Scripts.Shared.Net.NetworkObjectPool
 
         HashSet<GameObject> prefabs = new HashSet<GameObject>();
 
-        Dictionary<GameObject, List<NetworkObject>> pooledObjects = new Dictionary<GameObject, List<NetworkObject>>();
+        Dictionary<GameObject, Queue<NetworkObject>> pooledObjects = new Dictionary<GameObject, Queue<NetworkObject>>();
 
         private bool m_HasInitialized = false;
 
@@ -87,10 +87,11 @@ namespace BossRoom.Scripts.Shared.Net.NetworkObjectPool
         /// <summary>
         /// Return an object to the pool (reset objects before returning).
         /// </summary>
-        public void ReturnNetworkObject(NetworkObject networkObject)
+        public void ReturnNetworkObject(NetworkObject networkObject, GameObject prefab)
         {
             var go = networkObject.gameObject;
             go.SetActive(false);
+            pooledObjects[prefab].Enqueue(networkObject);
         }
 
         /// <summary>
@@ -115,14 +116,12 @@ namespace BossRoom.Scripts.Shared.Net.NetworkObjectPool
         {
             prefabs.Add(prefab);
 
-            var prefabList = new List<NetworkObject>();
-            pooledObjects[prefab] = prefabList;
+            var prefabQueue = new Queue<NetworkObject>();
+            pooledObjects[prefab] = prefabQueue;
             for (int i = 0; i < prewarmCount; i++)
             {
                 var go = CreateInstance(prefab);
-                var no = go.GetComponent<NetworkObject>();
-                ReturnNetworkObject(no);
-                prefabList.Add(no);
+                ReturnNetworkObject(go.GetComponent<NetworkObject>(), prefab);
             }
 
             // Register Netcode Spawn handlers
@@ -135,23 +134,6 @@ namespace BossRoom.Scripts.Shared.Net.NetworkObjectPool
             return Instantiate(prefab);
         }
 
-        private NetworkObject GetNextSpawnObject(GameObject prefab)
-        {
-            var list = pooledObjects[prefab];
-
-            foreach (var no in list)
-            {
-                if (!no.gameObject.activeInHierarchy)
-                {
-                    return no;
-                }
-            }
-            //We are out of objects, expand our pool by 1 more NetworkObject
-            NetworkObject networkObject = CreateInstance(prefab).GetComponent<NetworkObject>();
-            list.Add(networkObject);
-            return networkObject;
-        }
-
         /// <summary>
         /// This matches the signature of <see cref="NetworkSpawnManager.SpawnHandlerDelegate"/>
         /// </summary>
@@ -161,7 +143,17 @@ namespace BossRoom.Scripts.Shared.Net.NetworkObjectPool
         /// <returns></returns>
         private NetworkObject GetNetworkObjectInternal(GameObject prefab, Vector3 position, Quaternion rotation)
         {
-            NetworkObject networkObject = GetNextSpawnObject(prefab);
+            var queue = pooledObjects[prefab];
+
+            NetworkObject networkObject;
+            if (queue.Count > 0)
+            {
+                networkObject = queue.Dequeue();
+            }
+            else
+            {
+                networkObject = CreateInstance(prefab).GetComponent<NetworkObject>();
+            }
 
             // Here we must reverse the logic in ReturnNetworkObject.
             var go = networkObject.gameObject;
@@ -195,10 +187,6 @@ namespace BossRoom.Scripts.Shared.Net.NetworkObjectPool
             {
                 // Unregister Netcode Spawn handlers
                 NetworkManager.Singleton.PrefabHandler.RemoveHandler(prefab);
-                foreach (var no in pooledObjects[prefab])
-                {
-                    Destroy(no);
-                }
             }
             pooledObjects.Clear();
         }
@@ -230,7 +218,7 @@ namespace BossRoom.Scripts.Shared.Net.NetworkObjectPool
 
         void INetworkPrefabInstanceHandler.Destroy(NetworkObject networkObject)
         {
-            m_Pool.ReturnNetworkObject(networkObject);
+            m_Pool.ReturnNetworkObject(networkObject, m_Prefab);
         }
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Arrows spawned now correctly despawn when switching scenes.
### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-1557](https://jira.unity3d.com/browse/MTT-1557)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Start game with an archer
2. Shoot an arrow
3. Go to PostGame scene by pressing 'q', or by dying or killing the boss
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
