### PR TITLE
feat: warning when using simulated latency

### DIFF
--- a/Assets/BossRoom/Scripts/Shared/Game/UI/Editor/NetworkLatencyWarning.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/UI/Editor/NetworkLatencyWarning.cs
@@ -27,21 +27,13 @@ namespace Unity.Multiplayer.Samples.BossRoom.Editor
 
                 switch (chosenTransport)
                 {
-                    // adding this preprocessor directive check since LiteNetLib only injects latency in #DEBUG
-                    // todo MTT-1426 do this for UTP
-                    // #if DEBUG
-                    // case LiteNetLibTransport liteNetLibTransport:
-                    //     m_ArtificialLatencyEnabled = liteNetLibTransport.SimulatePacketLossChance > 0 ||
-                    //         liteNetLibTransport.SimulateMinLatency > 0 ||
-                    //         liteNetLibTransport.SimulateMaxLatency > 0;
-                    //     break;
-                    // #endif
                     case UNetTransport unetTransport:
                         break;
                     case PhotonRealtimeTransport photonTransport:
                         break;
                     case UnityTransport unityTransport:
-#if UNITY_EDITOR || DEVELOPEMENT_BUILD
+// adding this preprocessor directive check since LiteNetLib only injects latency in #UNITY_EDITOR or in #DEVELOPMENT_BUILD
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
                         SimulatorUtility.Parameters simulatorParameters = unityTransport.ClientSimulatorParameters;
                         m_ArtificialLatencyEnabled = simulatorParameters.PacketDelayMs > 0 ||
                             simulatorParameters.PacketJitterMs > 0 ||

--- a/Assets/BossRoom/Scripts/Shared/Game/UI/Editor/NetworkLatencyWarning.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/UI/Editor/NetworkLatencyWarning.cs
@@ -32,7 +32,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Editor
                         m_ArtificialLatencyEnabled = false;
                         break;
                     case UnityTransport unityTransport:
-// adding this preprocessor directive check since LiteNetLib only injects latency in #UNITY_EDITOR or in #DEVELOPMENT_BUILD
+// adding this preprocessor directive check since UnityTransport's simulator tools only inject latency in #UNITY_EDITOR or in #DEVELOPMENT_BUILD
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
                         SimulatorUtility.Parameters simulatorParameters = unityTransport.ClientSimulatorParameters;
                         m_ArtificialLatencyEnabled = simulatorParameters.PacketDelayMs > 0 ||

--- a/Assets/BossRoom/Scripts/Shared/Game/UI/Editor/NetworkLatencyWarning.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/UI/Editor/NetworkLatencyWarning.cs
@@ -4,7 +4,9 @@ using UnityEngine;
 using UnityEngine.UI;
 using Unity.Netcode;
 using Unity.Netcode.Transports.UNET;
+using Unity.Networking.Transport.Utilities;
 using UnityEngine.Assertions;
+
 
 namespace Unity.Multiplayer.Samples.BossRoom.Editor
 {
@@ -35,9 +37,18 @@ namespace Unity.Multiplayer.Samples.BossRoom.Editor
                     //     break;
                     // #endif
                     case UNetTransport unetTransport:
+                        break;
                     case PhotonRealtimeTransport photonTransport:
-                    case UnityTransport UnityTransport:
+                        break;
+                    case UnityTransport unityTransport:
+#if UNITY_EDITOR || DEVELOPEMENT_BUILD
+                        SimulatorUtility.Parameters simulatorParameters = unityTransport.ClientSimulatorParameters;
+                        m_ArtificialLatencyEnabled = simulatorParameters.PacketDelayMs > 0 ||
+                            simulatorParameters.PacketJitterMs > 0 ||
+                            simulatorParameters.PacketDropPercentage > 0;
+#else
                         m_ArtificialLatencyEnabled = false;
+#endif
                         break;
                     default:
                         throw new Exception($"unhandled transport {chosenTransport.GetType()}");

--- a/Assets/BossRoom/Scripts/Shared/Game/UI/Editor/NetworkLatencyWarning.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/UI/Editor/NetworkLatencyWarning.cs
@@ -28,8 +28,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Editor
                 switch (chosenTransport)
                 {
                     case UNetTransport unetTransport:
-                        m_ArtificialLatencyEnabled = false;
-                        break;
                     case PhotonRealtimeTransport photonTransport:
                         m_ArtificialLatencyEnabled = false;
                         break;

--- a/Assets/BossRoom/Scripts/Shared/Game/UI/Editor/NetworkLatencyWarning.cs
+++ b/Assets/BossRoom/Scripts/Shared/Game/UI/Editor/NetworkLatencyWarning.cs
@@ -28,8 +28,10 @@ namespace Unity.Multiplayer.Samples.BossRoom.Editor
                 switch (chosenTransport)
                 {
                     case UNetTransport unetTransport:
+                        m_ArtificialLatencyEnabled = false;
                         break;
                     case PhotonRealtimeTransport photonTransport:
+                        m_ArtificialLatencyEnabled = false;
                         break;
                     case UnityTransport unityTransport:
 // adding this preprocessor directive check since LiteNetLib only injects latency in #UNITY_EDITOR or in #DEVELOPMENT_BUILD
@@ -56,6 +58,19 @@ namespace Unity.Multiplayer.Samples.BossRoom.Editor
 
                     m_TextColor.a = Mathf.PingPong(Time.time, 1f);
                     m_LatencyText.color = m_TextColor;
+                }
+            }
+            else
+            {
+                m_ArtificialLatencyEnabled = false;
+            }
+
+            if (!m_ArtificialLatencyEnabled)
+            {
+                if (m_LatencyTextCreated)
+                {
+                    m_LatencyTextCreated = false;
+                    Destroy(m_LatencyText);
                 }
             }
         }

--- a/Assets/BossRoom/Scripts/Shared/com.unity.multiplayer.samples.bossroom.shared.asmdef
+++ b/Assets/BossRoom/Scripts/Shared/com.unity.multiplayer.samples.bossroom.shared.asmdef
@@ -10,7 +10,8 @@
         "Unity.Netcode.Adapter.UTP",
         "Unity.Collections",
         "Photon Realtime Transport for Netcode for GameObjects",
-        "Unity.Multiplayer.Samples.Utilities"
+        "Unity.Multiplayer.Samples.Utilities",
+        "Unity.Networking.Transport"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR adds the simulated latency warning that we had with LiteNetLib, but for UTP's simulator tools.
### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-1426](https://jira.unity3d.com/browse/MTT-1426)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add simulated latency, jitter or packet loss via UTP's simulator tools
2. Start a game
3. See the warning popup in red on the bottom of the screen
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
