### PR TITLE
Fix/ready button text change

### DIFF
--- a/Assets/BossRoom/Scenes/CharSelect.unity
+++ b/Assets/BossRoom/Scenes/CharSelect.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c5fc95a38296b6566ed9b39db2a860de88420ad611718e66693e16c4d0f453ca
-size 48686
+oid sha256:c0173256cb71c85783047a83f5b3e5c35c1f81fd44b7844f8acfbcbf1ca7c16c
+size 49684

--- a/Assets/BossRoom/Scripts/Client/Game/State/ClientCharSelectState.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/State/ClientCharSelectState.cs
@@ -48,6 +48,10 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
         [Tooltip("Text element containing player count which updates as players connect")]
         private TextMeshProUGUI m_NumPlayersText;
 
+        [SerializeField]
+        [Tooltip("Text element for the Ready button")]
+        private TextMeshProUGUI m_ReadyButtonText;
+
         [Header("UI Elements for different lobby modes")]
         [SerializeField]
         [Tooltip("UI elements to turn on when the player hasn't chosen their seat yet. Turned off otherwise!")]
@@ -346,10 +350,12 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
                         }
                         m_ClassInfoBox.ConfigureForNoSelection();
                     }
+                    m_ReadyButtonText.text = "READY!";
                     break;
                 case LobbyMode.SeatChosen:
                     isSeatsDisabledInThisMode = true;
                     m_ClassInfoBox.SetLockedIn(true);
+                    m_ReadyButtonText.text = "UNREADY";
                     break;
                 case LobbyMode.FatalError:
                     isSeatsDisabledInThisMode = true;


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Changes ready button text to UNREADY when player is locked in
### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-1684](https://jira.unity3d.com/browse/MTT-1684)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
