### PR TITLE
fix: removing room name textbox for ip based connections

### DIFF
--- a/Assets/BossRoom/Scripts/Client/UI/RoomNameBox.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/RoomNameBox.cs
@@ -16,19 +16,31 @@ public class RoomNameBox : MonoBehaviour
         Assert.IsNotNull(m_RoomNameText, $"{nameof(m_RoomNameText)} not assigned!");
 
         var transport = NetworkManager.Singleton.NetworkConfig.NetworkTransport;
-
+        bool isUsingRelay = true;
         switch (transport)
         {
             case PhotonRealtimeTransport realtimeTransport:
                 m_RoomNameText.text = $"Loading room key...";
                 break;
             case UnityTransport utp:
-                m_RoomNameText.text = $"Loading join code...";
+                if (utp.Protocol == UnityTransport.ProtocolType.RelayUnityTransport)
+                {
+                    m_RoomNameText.text = $"Loading join code...";
+                }
+                else
+                {
+                    isUsingRelay = false;
+                }
                 break;
             default:
-                // RoomName should only be displayed when using relay.
-                Destroy(gameObject);
+                isUsingRelay = false;
                 break;
+        }
+
+        if (!isUsingRelay)
+        {
+            // RoomName should only be displayed when using relay.
+            Destroy(gameObject);
         }
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR removes the room name textbox in the character selection scene when the game uses ip-based connections.
### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-1506](https://jira.unity3d.com/browse/MTT-1506)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
