### PR TITLE
fix: removing workaround for ngo issue 745

### DIFF
--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
@@ -28,10 +28,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
             int idx = FindLobbyPlayerIdx(clientId);
             if (idx == -1)
             {
-                //TODO-FIXME:Netcode See note about Netcode for GameObjects issue 745 in WaitToSeatNowPlayer.
-                //while this workaround is in place, we must simply ignore these update requests from the client.
-                //throw new System.Exception($"OnClientChangedSeat: client ID {clientId} is not a lobby player and cannot change seats!");
-                return;
+                throw new Exception($"OnClientChangedSeat: client ID {clientId} is not a lobby player and cannot change seats!");
             }
 
 

--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
@@ -28,7 +28,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
             int idx = FindLobbyPlayerIdx(clientId);
             if (idx == -1)
             {
-                throw new Exception($"OnClientChangedSeat: client ID {clientId} is not a lobby player and cannot change seats!");
+                throw new Exception($"OnClientChangedSeat: client ID {clientId} is not a lobby player and cannot change seats! Shouldn't be here!");
             }
 
 

--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
@@ -31,7 +31,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
                 throw new Exception($"OnClientChangedSeat: client ID {clientId} is not a lobby player and cannot change seats! Shouldn't be here!");
             }
 
-
             if (CharSelectData.IsLobbyClosed.Value)
             {
                 // The user tried to change their class after everything was locked in... too late! Discard this choice


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR removes the leftover code and comments from the obsolete workaround for netcode issue 745. The workaround which was to call a coroutine to wait before seating new players was already removed, so we do not need this other part of the workaround.
### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-1837](https://jira.unity3d.com/browse/MTT-1837)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
