### PR TITLE
fix: host name not showing

### DIFF
--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/GameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/GameNetPortal.cs
@@ -242,8 +242,8 @@ namespace Unity.Multiplayer.Samples.BossRoom
 
         void StartHost()
         {
+            SessionManager<SessionPlayerData>.Instance.AddHostData(new SessionPlayerData(NetManager.ServerClientId, PlayerName, m_AvatarRegistry.GetRandomAvatar().Guid.ToNetworkGuid(), 0, true));
             NetManager.StartHost();
-            SessionManager<SessionPlayerData>.Instance.AddHostData(new SessionPlayerData(NetManager.LocalClientId, PlayerName, m_AvatarRegistry.GetRandomAvatar().Guid.ToNetworkGuid(), 0, true));
         }
 
         /// <summary>

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/GameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/GameNetPortal.cs
@@ -242,7 +242,6 @@ namespace Unity.Multiplayer.Samples.BossRoom
 
         void StartHost()
         {
-            // First initialize the host data so that objects that need it during their initial spawn can use it, using ServerClientId as the host's ClientId
             NetManager.StartHost();
         }
 

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/GameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/GameNetPortal.cs
@@ -243,7 +243,6 @@ namespace Unity.Multiplayer.Samples.BossRoom
         void StartHost()
         {
             // First initialize the host data so that objects that need it during their initial spawn can use it, using ServerClientId as the host's ClientId
-            SessionManager<SessionPlayerData>.Instance.AddHostData(new SessionPlayerData(NetManager.ServerClientId, PlayerName, m_AvatarRegistry.GetRandomAvatar().Guid.ToNetworkGuid(), 0, true));
             NetManager.StartHost();
         }
 

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/GameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/GameNetPortal.cs
@@ -242,6 +242,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
 
         void StartHost()
         {
+            // First initialize the host data so that objects that need it during their initial spawn can use it, using ServerClientId as the host's ClientId
             SessionManager<SessionPlayerData>.Instance.AddHostData(new SessionPlayerData(NetManager.ServerClientId, PlayerName, m_AvatarRegistry.GetRandomAvatar().Guid.ToNetworkGuid(), 0, true));
             NetManager.StartHost();
         }

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ServerGameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ServerGameNetPortal.cs
@@ -153,7 +153,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
                 return;
             }
 
-            ConnectStatus gameReturnStatus = ConnectStatus.Success;
+            ConnectStatus gameReturnStatus;
 
             // Test for over-capacity connection. This needs to be done asap, to make sure we refuse connections asap and don't spend useless time server side
             // on invalid users trying to connect

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ServerGameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ServerGameNetPortal.cs
@@ -146,6 +146,9 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
             // Approval check happens for Host too, but obviously we want it to be approved
             if (clientId == NetworkManager.Singleton.LocalClientId)
             {
+                SessionManager<SessionPlayerData>.Instance.AddHostData(
+                    new SessionPlayerData(clientId, m_Portal.PlayerName, m_Portal.AvatarRegistry.GetRandomAvatar().Guid.ToNetworkGuid(), 0, true));
+
                 connectionApprovedCallback(true, null, true, null, null);
                 return;
             }
@@ -176,7 +179,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
             Debug.Log("Host ApprovalCheck: connecting client GUID: " + connectionPayload.clientGUID);
 
             gameReturnStatus = SessionManager<SessionPlayerData>.Instance.OnClientApprovalCheck(clientId, connectionPayload.clientGUID,
-                new SessionPlayerData(clientId, connectionPayload.playerName, m_Portal.AvatarRegistry.GetRandomAvatar().Guid.ToNetworkGuid(), 0, true, false));
+                new SessionPlayerData(clientId, connectionPayload.playerName, m_Portal.AvatarRegistry.GetRandomAvatar().Guid.ToNetworkGuid(), 0, true));
 
             //Test for Duplicate Login.
             if (gameReturnStatus == ConnectStatus.LoggedInAgain)

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/SessionManager.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/SessionManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Unity.Multiplayer.Samples.BossRoom.Client;
 using Unity.Netcode;
 using UnityEngine;
 
@@ -17,8 +18,6 @@ namespace Unity.Multiplayer.Samples.BossRoom
     // If the player disconnects and reconnects to the same host, the session is preserved.
     public class SessionManager<T> where T : struct, ISessionPlayerData
     {
-        const string k_HostGUID = "host_guid";
-
         NetworkManager m_NetworkManager;
 
         protected SessionManager()
@@ -59,8 +58,9 @@ namespace Unity.Multiplayer.Samples.BossRoom
         {
             if (sessionPlayerData.ClientID == m_NetworkManager.ServerClientId)
             {
-                m_ClientData.Add(k_HostGUID, sessionPlayerData);
-                m_ClientIDToGuid.Add(sessionPlayerData.ClientID, k_HostGUID);
+                string hostGUID = ClientPrefs.GetGuid();
+                m_ClientData.Add(hostGUID, sessionPlayerData);
+                m_ClientIDToGuid.Add(sessionPlayerData.ClientID, hostGUID);
             }
             else
             {

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/SessionManager.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/SessionManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Unity.Multiplayer.Samples.BossRoom.Client;
 using Unity.Netcode;
 using UnityEngine;
 
@@ -18,6 +17,8 @@ namespace Unity.Multiplayer.Samples.BossRoom
     // If the player disconnects and reconnects to the same host, the session is preserved.
     public class SessionManager<T> where T : struct, ISessionPlayerData
     {
+        const string k_HostGUID = "host_guid";
+
         NetworkManager m_NetworkManager;
 
         protected SessionManager()
@@ -58,9 +59,8 @@ namespace Unity.Multiplayer.Samples.BossRoom
         {
             if (sessionPlayerData.ClientID == m_NetworkManager.ServerClientId)
             {
-                string hostGUID = ClientPrefs.GetGuid();
-                m_ClientData.Add(hostGUID, sessionPlayerData);
-                m_ClientIDToGuid.Add(sessionPlayerData.ClientID, hostGUID);
+                m_ClientData.Add(k_HostGUID, sessionPlayerData);
+                m_ClientIDToGuid.Add(sessionPlayerData.ClientID, k_HostGUID);
             }
             else
             {

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/SessionManager.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/SessionManager.cs
@@ -186,7 +186,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
                 return GetPlayerData(clientGUID);
             }
 
-            Debug.LogError("No client guid found mapped to the given client ID");
+            Debug.LogError($"No client guid found mapped to the given client ID: {clientId}");
             return null;
         }
 
@@ -202,7 +202,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
                 return data;
             }
 
-            Debug.LogError("No PlayerData of matching guid found");
+            Debug.LogError($"No PlayerData of matching guid found: {clientGUID}");
             return null;
         }
 
@@ -219,7 +219,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
             }
             else
             {
-                Debug.LogError("No client guid found mapped to the given client ID");
+                Debug.LogError($"No client guid found mapped to the given client ID: {clientId}");
             }
         }
 

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/SessionManager.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/SessionManager.cs
@@ -58,7 +58,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
         public void AddHostData(T sessionPlayerData)
         {
             m_ClientData.Add(k_HostGUID, sessionPlayerData);
-            m_ClientIDToGuid.Add(m_NetworkManager.LocalClientId, k_HostGUID);
+            m_ClientIDToGuid.Add(sessionPlayerData.ClientID, k_HostGUID);
         }
 
         /// <summary>

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/SessionManager.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/SessionManager.cs
@@ -186,7 +186,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
                 return GetPlayerData(clientGUID);
             }
 
-            Debug.Log("No client guid found mapped to the given client ID");
+            Debug.LogError("No client guid found mapped to the given client ID");
             return null;
         }
 
@@ -202,7 +202,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
                 return data;
             }
 
-            Debug.Log("No PlayerData of matching guid found");
+            Debug.LogError("No PlayerData of matching guid found");
             return null;
         }
 
@@ -216,6 +216,10 @@ namespace Unity.Multiplayer.Samples.BossRoom
             if (m_ClientIDToGuid.TryGetValue(clientId, out string clientGUID))
             {
                 m_ClientData[clientGUID] = sessionPlayerData;
+            }
+            else
+            {
+                Debug.LogError("No client guid found mapped to the given client ID");
             }
         }
 

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/SessionManager.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/SessionManager.cs
@@ -57,8 +57,15 @@ namespace Unity.Multiplayer.Samples.BossRoom
 
         public void AddHostData(T sessionPlayerData)
         {
-            m_ClientData.Add(k_HostGUID, sessionPlayerData);
-            m_ClientIDToGuid.Add(sessionPlayerData.ClientID, k_HostGUID);
+            if (sessionPlayerData.ClientID == m_NetworkManager.ServerClientId)
+            {
+                m_ClientData.Add(k_HostGUID, sessionPlayerData);
+                m_ClientIDToGuid.Add(sessionPlayerData.ClientID, k_HostGUID);
+            }
+            else
+            {
+                Debug.LogError($"Invalid ClientId for host. Got {sessionPlayerData.ClientID}, but should have gotten {m_NetworkManager.ServerClientId}.");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixes an issue that caused the host's player name to not be shown on the UI. The name is set in PersistentPlayer's OnNetworkSpawn(), using data from the SessionManager. However, this data was initialized after the call to StartHost(), and the PersistentPlayer was spawned during that call. This was introduced by PR #434 which aimed to solve a different issue, because the host data initialization used data from NetworkManager that was not properly initialized.

Here, the initialization of the host session data has been moved to the connection approval callback, so that it happens before the spawning of NetworkBehaviours, but after the server has been properly initialized.

### Related Pull Requests
<!-- related pull request placeholder -->
#434
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-2157](https://jira.unity3d.com/browse/MTT-2157) & [MTT-2010](https://jira.unity3d.com/browse/MTT-2010)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
For MTT-2157:
1. Start a game as a host
2. Select a character, then load the BossRoom scene
3. See that the host's name is now visible on the UI

For MTT-2010:
1. Start a game as a host
2. Join the game as a client
3. As the client, disconnect while still in the character selection scene
4. As the former client, try to host a new game
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
