### PR TITLE
fix: cannot host a game after having previously played as a client

### DIFF
--- a/Assets/BossRoom/Scripts/Server/Game/Character/PlayerServerCharacter.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/PlayerServerCharacter.cs
@@ -24,12 +24,15 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
 
         public override void OnNetworkSpawn()
         {
-            if (!IsServer)
+            if (IsServer)
+            {
+                s_ActivePlayers.Add(m_CachedServerCharacter);
+            }
+            else
             {
                 enabled = false;
             }
 
-            s_ActivePlayers.Add(m_CachedServerCharacter);
         }
 
         void OnDisable()

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/GameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/GameNetPortal.cs
@@ -128,7 +128,10 @@ namespace Unity.Multiplayer.Samples.BossRoom
             if (clientId == NetManager.LocalClientId)
             {
                 OnNetworkReady();
-                NetManager.SceneManager.OnSceneEvent += OnSceneEvent;
+                if (NetManager.IsServer)
+                {
+                    NetManager.SceneManager.OnSceneEvent += OnSceneEvent;
+                }
             }
         }
 
@@ -256,6 +259,10 @@ namespace Unity.Multiplayer.Samples.BossRoom
         /// </summary>
         public void RequestDisconnect()
         {
+            if (NetManager.IsServer)
+            {
+                NetManager.SceneManager.OnSceneEvent -= OnSceneEvent;
+            }
             m_ClientPortal.OnUserDisconnectRequest();
             m_ServerPortal.OnUserDisconnectRequest();
             SessionManager<SessionPlayerData>.Instance.OnUserDisconnectRequest();

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ServerGameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ServerGameNetPortal.cs
@@ -93,7 +93,10 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
 
         public void OnClientSceneChanged(ulong clientId, int sceneIndex)
         {
-            m_ClientSceneMap[clientId] = sceneIndex;
+            if (m_Portal.NetManager.IsServer)
+            {
+                m_ClientSceneMap[clientId] = sceneIndex;
+            }
         }
 
         /// <summary>

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ServerGameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ServerGameNetPortal.cs
@@ -93,10 +93,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
 
         public void OnClientSceneChanged(ulong clientId, int sceneIndex)
         {
-            if (m_Portal.NetManager.IsServer)
-            {
-                m_ClientSceneMap[clientId] = sceneIndex;
-            }
+            m_ClientSceneMap[clientId] = sceneIndex;
         }
 
         /// <summary>


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR makes it so only the server adds entries to the m_ClientSceneMap by registering the callback handling this only on the server. This would previously cause issues since the OnClientSceneChanged is also called on clients. Adding entries on clients doesn't make sense, and causes issues when trying to host a new game afterwards. This new entry prevents spawning the characters in the BossRoom scene, which is triggered when all clients are in the scene, based on this map. So if this map has another entry, it will always be in the wrong scene and the spawn will never be triggered.
This PR also prevents clients from updating the static list of active PlayerServerCharacters, which used to result in a null reference exception when starting a new game in this scenario.
### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-2373](https://jira.unity3d.com/browse/MTT-2373)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Start two instances of the game
2. Host on instance 1 and join with instance 2
3. End the game (either by quitting as instance 1 or by going to the post-game scene and exiting to main menu)
4. Host a new game on instance 2
5. Join with instance 1
6. Proceed through character selection to the BossRoom scene
7. See the player characters properly spawning and the game starting normally

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
