### PR TITLE
fix: imp spawn cap too high

### DIFF
--- a/Assets/BossRoom/Prefabs/Game/EnemySpawner.prefab
+++ b/Assets/BossRoom/Prefabs/Game/EnemySpawner.prefab
@@ -422,9 +422,9 @@ MonoBehaviour:
   m_RestartDelay: 10
   m_ProximityDistance: 30
   m_DetectStealthyPlayers: 1
-  m_MinSpawnCap: 2
-  m_MaxSpawnCap: 10
-  m_SpawnCapIncreasePerPlayer: 1
+  m_MinSpawnCap: 1
+  m_MaxSpawnCap: 5
+  m_SpawnCapIncreasePerPlayer: 0.5
 --- !u!114 &2847004539442057774
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/BossRoom/Prefabs/Game/StaticNetworkObjects/BossRoomStaticNetworkObjects.prefab
+++ b/Assets/BossRoom/Prefabs/Game/StaticNetworkObjects/BossRoomStaticNetworkObjects.prefab
@@ -570,15 +570,11 @@ PrefabInstance:
       objectReference: {fileID: 8192964625146938244}
     - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
       propertyPath: m_MinSpawnCap
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
       propertyPath: m_ProximityDistance
       value: 60
-      objectReference: {fileID: 0}
-    - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
-      propertyPath: m_SpawnCapIncreasePerPlayer
-      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
       propertyPath: m_SpawnedEntityDetectDistance
@@ -1621,15 +1617,11 @@ PrefabInstance:
       objectReference: {fileID: 8192964626818645629}
     - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
       propertyPath: m_MinSpawnCap
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
       propertyPath: m_ProximityDistance
       value: 60
-      objectReference: {fileID: 0}
-    - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
-      propertyPath: m_SpawnCapIncreasePerPlayer
-      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
       propertyPath: m_SpawnedEntityDetectDistance
@@ -1847,15 +1839,11 @@ PrefabInstance:
       objectReference: {fileID: 8192964625951251031}
     - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
       propertyPath: m_MinSpawnCap
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
       propertyPath: m_ProximityDistance
       value: 60
-      objectReference: {fileID: 0}
-    - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
-      propertyPath: m_SpawnCapIncreasePerPlayer
-      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
       propertyPath: m_SpawnedEntityDetectDistance
@@ -2689,15 +2677,11 @@ PrefabInstance:
       objectReference: {fileID: 4938561330712956744}
     - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
       propertyPath: m_MinSpawnCap
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
       propertyPath: m_ProximityDistance
       value: 60
-      objectReference: {fileID: 0}
-    - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
-      propertyPath: m_SpawnCapIncreasePerPlayer
-      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
       propertyPath: m_SpawnedEntityDetectDistance

--- a/Assets/BossRoom/Prefabs/Game/StaticNetworkObjects/EntranceStaticNetworkObjects.prefab
+++ b/Assets/BossRoom/Prefabs/Game/StaticNetworkObjects/EntranceStaticNetworkObjects.prefab
@@ -2641,16 +2641,8 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 8450919248631857223}
     - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
-      propertyPath: m_MinSpawnCap
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
       propertyPath: m_SpawnsPerWave
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4844841199312666291, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
-      propertyPath: m_SpawnCapIncreasePerPlayer
-      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6205854018081152875, guid: a6647793a8bc7c846abba94be1d257e5, type: 3}
       propertyPath: m_Name


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR reduces the spawn cap of imp spawners by half to prevent performance issues with lower-end devices. The scaling with the number of players was also diminished, going from 2 to 0.5, which means that for each two players connected, the base cap of spawners is increased by 1.
The maximum, with eight connected players was 10 per spawner, so 50 imps in total if both the entrance and final room additive scenes were loaded, plus the in-scene placed imps that were still alive. The maximum is now 5 per spawner with eight connected players, so 25 in total if both scenes are loaded. 

This was tested with a development build on a Motorola G Power (2021) using Android version 11, with 7 other players joining via development builds on Windows10. The game was hosted on the mobile device via Unity Relay. The graphics settings were on "Low" on the host.
Before this change, performance would drop drastically when the number of imps increased, which also greatly increased the RTT metric calculated by the game. With only a few imps spawned, the RTT oscillated around 150-200 ms. With all imps spawned, the RTT would jump to around 1000ms, with peaks at up to 2000 when the boss used its trample ability. The framerate was also very low and the game really hard to play, as it often did not even register inputs.
After the change, those performance issues diminished but were still somewhat noticeable. With all imps spawned, the RTT would go up to around 300 ms, with peaks nearing 500 ms during the Boss's trample action. The framerate also dropped but far less dramatically and the game was at least still playable.
### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-2325](https://jira.unity3d.com/browse/MTT-2325)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
