### PR TITLE
DIScope - an implementation of dependency injection container pattern

### DIFF
--- a/Assets/BossRoom/Scripts/Shared/Infrastructure.meta
+++ b/Assets/BossRoom/Scripts/Shared/Infrastructure.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6d8ea77207ee409481b14eaae926a86c
+timeCreated: 1641600958

--- a/Assets/BossRoom/Scripts/Shared/Infrastructure/DIScope.cs
+++ b/Assets/BossRoom/Scripts/Shared/Infrastructure/DIScope.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace BossRoom.Scripts.Shared.Infrastructure
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor)]
+    public sealed class Inject : Attribute
+    {
+    }
+
+    public class NoInstanceToInjectException : Exception
+    {
+        public NoInstanceToInjectException(string message) : base(message)
+        {
+        }
+    }
+
+    public class ScopeNotFinalizedException : Exception
+    {
+        public ScopeNotFinalizedException(string message) : base(message)
+        {
+        }
+    }
+
+    public interface IInstanceResolver
+    {
+        T Resolve<T>()
+            where T : class;
+
+        void InjectIn(object obj);
+        void InjectIn(GameObject obj);
+    }
+
+    public sealed class DIScope : IInstanceResolver, IDisposable
+    {
+        private static DIScope m_rootScope;
+
+        private readonly DisposableGroup m_DisposableGroup = new DisposableGroup();
+        private readonly Dictionary<Type, LazyBindDescriptor> m_LazyBindDescriptors = new Dictionary<Type, LazyBindDescriptor>();
+
+        private readonly DIScope m_Parent;
+        private readonly Dictionary<Type, object> m_TypesToInstances = new Dictionary<Type, object>();
+        private bool m_Disposed;
+
+        private bool m_ScopeConstructionComplete;
+
+        public DIScope(DIScope parent = null)
+        {
+            m_Parent = parent;
+            BindInstanceAsSingle<IInstanceResolver, DIScope>(this);
+        }
+
+        public static DIScope RootScope
+        {
+            get
+            {
+                if (m_rootScope == null) m_rootScope = new DIScope();
+
+                return m_rootScope;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!m_Disposed)
+            {
+                m_TypesToInstances.Clear();
+                m_DisposableGroup.Dispose();
+                m_Disposed = true;
+            }
+        }
+
+        public T Resolve<T>()
+            where T : class
+        {
+            if (!m_ScopeConstructionComplete)
+                throw new ScopeNotFinalizedException(
+                    $"Trying to Resolve type {typeof(T)}, but the DISCope is not yet finalized! You should call FinalizeScopeConstruction before any of the Resolve calls.");
+            //if we have this type as lazy-bound instance - we are going to instantiate it now
+            if (m_LazyBindDescriptors.TryGetValue(typeof(T), out var lazyBindDescriptor))
+            {
+                var instance = (T) InstantiateLazyBoundObject(lazyBindDescriptor);
+                m_LazyBindDescriptors.Remove(typeof(T));
+                return instance;
+            }
+
+            if (!m_TypesToInstances.TryGetValue(typeof(T), out var value))
+            {
+                if (m_Parent != null) return m_Parent.Resolve<T>();
+
+                throw new NoInstanceToInjectException($"Injection of type {typeof(T)} failed.");
+            }
+
+            return (T) value;
+        }
+
+        public void InjectIn(object obj)
+        {
+            if (CachedReflectionUtility.TryGetInjectableMethod(obj.GetType(), out var injectionMethod))
+            {
+                var parameters = CachedReflectionUtility.GetMethodParameters(injectionMethod);
+
+                var paramColleciton = new object[parameters.Length];
+
+                for (var i = 0; i < parameters.Length; i++)
+                {
+                    var parameter = parameters[i];
+
+                    var genericResolveMethod = CachedReflectionUtility.GetTypedResolveMethod(parameter.ParameterType);
+                    var resolved = genericResolveMethod.Invoke(this, null);
+                    paramColleciton[i] = resolved;
+                }
+
+                injectionMethod.Invoke(obj, paramColleciton);
+            }
+        }
+
+        public void InjectIn(GameObject go)
+        {
+            var components = go.GetComponentsInChildren<Component>();
+
+            foreach (var component in components) InjectIn(component);
+        }
+
+        ~DIScope()
+        {
+            Dispose();
+        }
+
+        public void BindInstanceAsSingle<T>(T instance) where T : class
+        {
+            BindInstanceToType(instance, typeof(T));
+        }
+
+        public void BindInstanceAsSingle<TInterface, TImplementation>(TImplementation instance)
+            where TImplementation : class, TInterface
+            where TInterface : class
+        {
+            BindInstanceAsSingle<TInterface>(instance);
+            BindInstanceAsSingle(instance);
+        }
+
+        private void BindInstanceToType(object instance, Type type)
+        {
+            m_TypesToInstances[type] = instance;
+        }
+
+        public void BindAsSingle<TImplementation, TInterface>()
+            where TImplementation : class, TInterface
+            where TInterface : class
+        {
+            LazyBind(typeof(TImplementation), typeof(TInterface));
+        }
+
+        public void BindAsSingle<TImplementation, TInterface, TInterface2>()
+            where TImplementation : class, TInterface, TInterface2
+            where TInterface : class
+            where TInterface2 : class
+        {
+            LazyBind(typeof(TImplementation), typeof(TInterface), typeof(TInterface2));
+        }
+
+        public void BindAsSingle<T>()
+            where T : class
+        {
+            LazyBind(typeof(T));
+        }
+
+        private void LazyBind(Type type, params Type[] typeAliases)
+        {
+            var descriptor = new LazyBindDescriptor(type, typeAliases);
+
+            foreach (var typeAlias in typeAliases) m_LazyBindDescriptors[typeAlias] = descriptor;
+
+            m_LazyBindDescriptors[type] = descriptor;
+        }
+
+        private object InstantiateLazyBoundObject(LazyBindDescriptor descriptor)
+        {
+            object instance;
+            if (CachedReflectionUtility.TryGetInjectableConstructor(descriptor.Type, out var constructor))
+            {
+                var parameters = GetResolvedInjectionMethodParameters(constructor);
+                instance = constructor.Invoke(parameters);
+            }
+            else
+            {
+                instance = Activator.CreateInstance(descriptor.Type);
+                InjectIn(instance);
+            }
+
+            AddToDisposableGroupIfDisposable(instance);
+
+            BindInstanceToType(instance, descriptor.Type);
+
+            if (descriptor.InterfaceTypes != null)
+                foreach (var interfaceType in descriptor.InterfaceTypes)
+                    BindInstanceToType(instance, interfaceType);
+
+            return instance;
+        }
+
+        private void AddToDisposableGroupIfDisposable(object instance)
+        {
+            if (instance is IDisposable disposable) m_DisposableGroup.Add(disposable);
+        }
+
+        /// <summary>
+        ///     This method forces the finalization of construction of DI Scope. It would inject all the instances passed to it directly.
+        ///     Objects that were bound by just type will be instantiated on their first use.
+        /// </summary>
+        public void FinalizeScopeConstruction()
+        {
+            if (m_ScopeConstructionComplete) return;
+
+            m_ScopeConstructionComplete = true;
+
+            var uniqueObjects = new HashSet<object>(m_TypesToInstances.Values);
+
+            foreach (var objectToInject in uniqueObjects)
+            {
+                InjectIn(objectToInject);
+            }
+        }
+
+        private object[] GetResolvedInjectionMethodParameters(MethodBase injectionMethod)
+        {
+            var parameters = CachedReflectionUtility.GetMethodParameters(injectionMethod);
+
+            var paramColleciton = new object[parameters.Length];
+
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                var parameter = parameters[i];
+
+                var genericResolveMethod = CachedReflectionUtility.GetTypedResolveMethod(parameter.ParameterType);
+                var resolved = genericResolveMethod.Invoke(this, null);
+                paramColleciton[i] = resolved;
+            }
+
+            return paramColleciton;
+        }
+
+        private static class CachedReflectionUtility
+        {
+            private static readonly Dictionary<Type, MethodBase> k_CachedInjectableMethods = new Dictionary<Type, MethodBase>();
+            private static readonly Dictionary<Type, ConstructorInfo> k_CachedInjectableConstructors = new Dictionary<Type, ConstructorInfo>();
+            private static readonly Dictionary<MethodBase, ParameterInfo[]> k_CachedMethodParameters = new Dictionary<MethodBase, ParameterInfo[]>();
+            private static readonly Dictionary<Type, MethodInfo> k_CachedResolveMethods = new Dictionary<Type, MethodInfo>();
+            private static readonly Type k_InjectAttributeType = typeof(Inject);
+            private static readonly HashSet<Type> k_ProcessedTypes = new HashSet<Type>();
+            private static MethodInfo k_ResolveMethod;
+
+            public static bool TryGetInjectableConstructor(Type type, out ConstructorInfo method)
+            {
+                CacheTypeMethods(type);
+                return k_CachedInjectableConstructors.TryGetValue(type, out method);
+            }
+
+            private static void CacheTypeMethods(Type type)
+            {
+                if (k_ProcessedTypes.Contains(type)) return;
+
+                var constructors = type.GetConstructors();
+                foreach (var constructorInfo in constructors)
+                {
+                    var foundInjectionSite = constructorInfo.IsDefined(k_InjectAttributeType);
+                    if (foundInjectionSite)
+                    {
+                        k_CachedInjectableConstructors[type] = constructorInfo;
+                        var methodParameters = constructorInfo.GetParameters();
+                        k_CachedMethodParameters[constructorInfo] = methodParameters;
+                        break;
+                    }
+                }
+
+                var methods = type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+                foreach (var methodInfo in methods)
+                {
+                    var foundInjectionSite = methodInfo.IsDefined(k_InjectAttributeType);
+                    if (foundInjectionSite)
+                    {
+                        k_CachedInjectableMethods[type] = methodInfo;
+                        var methodParameters = methodInfo.GetParameters();
+                        k_CachedMethodParameters[methodInfo] = methodParameters;
+                        break;
+                    }
+                }
+
+
+                k_ProcessedTypes.Add(type);
+            }
+
+            public static bool TryGetInjectableMethod(Type type, out MethodBase method)
+            {
+                CacheTypeMethods(type);
+                return k_CachedInjectableMethods.TryGetValue(type, out method);
+            }
+
+            public static ParameterInfo[] GetMethodParameters(MethodBase injectionMethod)
+            {
+                return k_CachedMethodParameters[injectionMethod];
+            }
+
+            public static MethodInfo GetTypedResolveMethod(Type parameterType)
+            {
+                if (!k_CachedResolveMethods.TryGetValue(parameterType, out var resolveMethod))
+                {
+                    if (k_ResolveMethod == null) k_ResolveMethod = typeof(DIScope).GetMethod("Resolve");
+                    resolveMethod = k_ResolveMethod.MakeGenericMethod(parameterType);
+                    k_CachedResolveMethods[parameterType] = resolveMethod;
+                }
+
+                return resolveMethod;
+            }
+        }
+
+        private struct LazyBindDescriptor
+        {
+            public readonly Type Type;
+            public readonly Type[] InterfaceTypes;
+
+            public LazyBindDescriptor(Type type, Type[] interfaceTypes)
+            {
+                Type = type;
+                InterfaceTypes = interfaceTypes;
+            }
+        }
+    }
+}

--- a/Assets/BossRoom/Scripts/Shared/Infrastructure/DIScope.cs.meta
+++ b/Assets/BossRoom/Scripts/Shared/Infrastructure/DIScope.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b94e4ad5a3244611919f20080f581f3f
+timeCreated: 1641583607

--- a/Assets/BossRoom/Scripts/Shared/Infrastructure/DisposableGroup.cs
+++ b/Assets/BossRoom/Scripts/Shared/Infrastructure/DisposableGroup.cs
@@ -9,7 +9,11 @@ namespace BossRoom.Scripts.Shared.Infrastructure
 
         public void Dispose()
         {
-            foreach (var disposable in m_Disposables) disposable.Dispose();
+            foreach (var disposable in m_Disposables)
+            {
+                disposable.Dispose();
+            }
+
             m_Disposables.Clear();
         }
 

--- a/Assets/BossRoom/Scripts/Shared/Infrastructure/DisposableGroup.cs
+++ b/Assets/BossRoom/Scripts/Shared/Infrastructure/DisposableGroup.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+namespace BossRoom.Scripts.Shared.Infrastructure
+{
+    public class DisposableGroup : IDisposable
+    {
+        private readonly List<IDisposable> m_Disposables = new List<IDisposable>();
+
+        public void Dispose()
+        {
+            foreach (var disposable in m_Disposables) disposable.Dispose();
+            m_Disposables.Clear();
+        }
+
+        public void Add(IDisposable disposable)
+        {
+            m_Disposables.Add(disposable);
+        }
+    }
+}

--- a/Assets/BossRoom/Scripts/Shared/Infrastructure/DisposableGroup.cs.meta
+++ b/Assets/BossRoom/Scripts/Shared/Infrastructure/DisposableGroup.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 18b0625f522c4f9d84cbe47febbf91da
+timeCreated: 1641609721


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR adds an implementation of a dependency injection container pattern (DIScope).
DIScope is only capable, for the sake of simplicity, of binding and resolving singletons.

The gist of DI is as follows: single responsibility principle, when applied to object instantiation, would suggest that if an object relies on the presence of certain dependencies, then finding those dependencies is outside the scope of instantiation itself. This gives us Dependency Injection Container - a class (With a special singleton reference to a Root scope) that will be responsible for providing dependencies, thus achieving a notion of Inversion of Control.

It effectively eliminates the need for singletons, allows to have more decoupled codebase that can be largely reliant on interface-based dependencies. DI also allows for easier testing of systems - we can easily swap out one implementation of an interface for another implementation and the only place where we'd need to touch the code is in the place where we declare dependencies and bind them to the DIScope.

So now we have this thing that is meant to provide dependencies, how do we author our code?


The code below showcases both the Binding stage (where we declare our dependencies which themselves can be interdependent on each-other) and an example of dependency injection and manual resolving:


```
/// <summary>
    /// Constructor injection
    /// That's how we would author regular C# classes that have dependencies that will be resolved with DI
    /// </summary>
    public class B
    {
        private readonly ITestInterface _a;

        [Inject]
        public B(ITestInterface a)
        {
            _a = a;
        }
    }
    
    /// <summary>
    /// Method injection for regular classes can be used to have a non-injected default constructor coupled with an [Inject] method,
    /// which allows to delay the moment of dependency resolution after the instantiation. Can be useful in certain cases.
    /// </summary>
    public class MethodInjectedClass
    {
        private ITestInterface _a;

        [Inject]
        private void InjectDependencies(ITestInterface a)
        {
            _a = a;
        }

        public MethodInjectedClass()
        {
            //non-injected constructor that will be invoked prior to the InjectDependencies method
        }
    }

    /// <summary>
    /// MonoBehaviour-derived classes can only have method injection
    /// </summary>
    public class MonobehWithDependencyOnOther : MonoBehaviour
    {
        private A _a;
        private MonobehDependency _mb;

        [Inject]
        private void InjectDependencies(A a, MonobehDependency mb)
        {
            _a = a;
            _mb = mb;
        }
    }
    
    
    public interface ITestInterface
    {

    }

    /// <summary>
    /// This class will be instantiated, but not injected by the DIScope, as it has no [Inject]-decorated constructor or method
    /// </summary>
    public class A : ITestInterface
    {

    }


    public class MonobehDependency : MonoBehaviour
    {
        //non-injected external dependency that we'd like to pipe using DIScope
        //it's implementation is not important at all.

        //IMPORTANT - DIScope can't create MonoBehaviours, so these should be created and provided to the DIScope manually.
        //also the lifetime of these objects is not tied to the DIScope - it only cleans up Disposables that it created.
    }
```

And this is how we would provide the dependencies to the di scope:

```
    public class DIDemo_Bootstrap : MonoBehaviour
    {

        [SerializeField] private MonobehDependency _monoBehDependency;
        
        private void Awake()
        {
            DontDestroyOnLoad(gameObject);

            //DIScope can be made a child of another DIScope - this way the dependencies will be looked up recursively from child to parent scope.
            //this would allow one to dispose of the child scope independently, cleaning up scene-specific references or something like that
            
            var scope = DIScope.RootScope;

            //lazy-binding, as in, DIScope will create instance of A when it's first asked to resolve an ITestInterface
            scope.BindAsSingle<A, ITestInterface>();
            //B is bound lazily, but it will be only resolvable through it's direct type - B
            scope.BindAsSingle<B>();

            //monobehaviours can't be created by DIScope, so we create it elsewhere and then bind it,
            //keeping in mind that killing that object is our responsibility, not DIScope's
            scope.BindInstanceAsSingle(_monoBehDependency);
            //and now we want to make the DIScope go through all of it's bound objects (excluding lazy-bound types) and injecting them
            //this process can to a certain extent solve the problem when there are several objects that need to have a reference to each other - it's resolved by method injection
            scope.FinalizeScopeConstruction();

            //after this it's safe to ask the scope to give us any objects (or to inject dependencies into objects)
            var a = scope.Resolve<ITestInterface>();
            
            var mbehWithDep = gameObject.AddComponent<MonobehWithDependencyOnOther>();
            scope.InjectIn(mbehWithDep);
            //and now mbehWithDep is fully functinal and has all of it's dependencies passed to it.
            //injecting a gameObject would inject all the components on all the children.
        }

        private void OnDestroy()
        {
            //cleanin up the root scope
            DIScope.RootScope.Dispose();
        }
    }
```

### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s):
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
