### PR TITLE
MessageChannel - a pub-sub message-passing pattern

### DIFF
--- a/Assets/BossRoom/Scripts/Shared/Infrastructure/MessageChannel.cs
+++ b/Assets/BossRoom/Scripts/Shared/Infrastructure/MessageChannel.cs
@@ -33,9 +33,15 @@ namespace BossRoom.Scripts.Shared.Infrastructure
 
         public void Publish(T message)
         {
-            while (m_PendingHandlers.Count > 0) m_PendingHandlers.Dequeue()?.Invoke();
+            while (m_PendingHandlers.Count > 0)
+            {
+                m_PendingHandlers.Dequeue()?.Invoke();
+            }
 
-            foreach (var messageHandler in m_MessageHandlers) messageHandler?.Invoke(message);
+            foreach (var messageHandler in m_MessageHandlers)
+            {
+                messageHandler?.Invoke(message);
+            }
         }
 
         public IDisposable Subscribe(Action<T> handler)
@@ -48,7 +54,9 @@ namespace BossRoom.Scripts.Shared.Infrastructure
             void DoSubscribe(Action<T> _h)
             {
                 if (_h != null && !m_MessageHandlers.Contains(_h))
+                {
                     m_MessageHandlers.Add(_h);
+                }
             }
         }
 
@@ -80,7 +88,10 @@ namespace BossRoom.Scripts.Shared.Infrastructure
                 {
                     m_isDisposed = true;
 
-                    if (!m_MessageChannel.m_IsDisposed) m_MessageChannel.Unsubscribe(m_Handler);
+                    if (!m_MessageChannel.m_IsDisposed)
+                    {
+                        m_MessageChannel.Unsubscribe(m_Handler);
+                    }
 
                     m_Handler = null;
                     m_MessageChannel = null;

--- a/Assets/BossRoom/Scripts/Shared/Infrastructure/MessageChannel.cs
+++ b/Assets/BossRoom/Scripts/Shared/Infrastructure/MessageChannel.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine.Assertions;
+
+namespace BossRoom.Scripts.Shared.Infrastructure
+{
+    public interface IPublisher<T>
+    {
+        void Publish(T message);
+    }
+
+    public interface ISubscriber<T>
+    {
+        IDisposable Subscribe(Action<T> handler);
+    }
+
+    public class MessageChannel<T> : IDisposable, IPublisher<T>, ISubscriber<T>
+    {
+        private readonly List<Action<T>> m_MessageHandlers = new List<Action<T>>();
+
+        private readonly Queue<Action> m_PendingHandlers = new Queue<Action>();
+        private bool m_IsDisposed;
+
+        public void Dispose()
+        {
+            if (!m_IsDisposed)
+            {
+                m_IsDisposed = true;
+                m_MessageHandlers.Clear();
+                m_PendingHandlers.Clear();
+            }
+        }
+
+        public void Publish(T message)
+        {
+            while (m_PendingHandlers.Count > 0) m_PendingHandlers.Dequeue()?.Invoke();
+
+            foreach (var messageHandler in m_MessageHandlers) messageHandler?.Invoke(message);
+        }
+
+        public IDisposable Subscribe(Action<T> handler)
+        {
+            Assert.IsTrue(!m_MessageHandlers.Contains(handler), "Attempting to subscribe with the same handler more than once");
+            m_PendingHandlers.Enqueue(() => { DoSubscribe(handler); });
+            var subscription = new Subscription(this, handler);
+            return subscription;
+
+            void DoSubscribe(Action<T> _h)
+            {
+                if (_h != null && !m_MessageHandlers.Contains(_h))
+                    m_MessageHandlers.Add(_h);
+            }
+        }
+
+        private void Unsubscribe(Action<T> handler)
+        {
+            m_PendingHandlers.Enqueue(() => { DoUnsubscribe(handler); });
+
+            void DoUnsubscribe(Action<T> _h)
+            {
+                m_MessageHandlers.Remove(_h);
+            }
+        }
+
+        private class Subscription : IDisposable
+        {
+            private Action<T> m_Handler;
+            private bool m_isDisposed;
+            private MessageChannel<T> m_MessageChannel;
+
+            public Subscription(MessageChannel<T> messageChannel, Action<T> handler)
+            {
+                m_MessageChannel = messageChannel;
+                m_Handler = handler;
+            }
+
+            public void Dispose()
+            {
+                if (!m_isDisposed)
+                {
+                    m_isDisposed = true;
+
+                    if (!m_MessageChannel.m_IsDisposed) m_MessageChannel.Unsubscribe(m_Handler);
+
+                    m_Handler = null;
+                    m_MessageChannel = null;
+                }
+            }
+        }
+    }
+}

--- a/Assets/BossRoom/Scripts/Shared/Infrastructure/MessageChannel.cs.meta
+++ b/Assets/BossRoom/Scripts/Shared/Infrastructure/MessageChannel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 33dfcb5ccf8344b46826775bca225e34
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/BossRoom/Scripts/Shared/Infrastructure/MessageChannelDIExtenstions.cs
+++ b/Assets/BossRoom/Scripts/Shared/Infrastructure/MessageChannelDIExtenstions.cs
@@ -1,0 +1,10 @@
+namespace BossRoom.Scripts.Shared.Infrastructure
+{
+    public static class MessageChannelDIExtenstions
+    {
+        public static void BindMessageChannel<TMessage>(this DIScope scope)
+        {
+            scope.BindAsSingle< MessageChannel<TMessage>, IPublisher<TMessage>, ISubscriber<TMessage>>();
+        }
+    }
+}

--- a/Assets/BossRoom/Scripts/Shared/Infrastructure/MessageChannelDIExtenstions.cs.meta
+++ b/Assets/BossRoom/Scripts/Shared/Infrastructure/MessageChannelDIExtenstions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e692555a37bf413db8d4ae55270acabe
+timeCreated: 1643900294


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
MessasgeChannel is a pub-sub mechanism that is heavily inspired by https://github.com/Cysharp/MessagePipe (but is much simpler in implementation an can do drastically less than the big library).

Also adding DIScope extensions - this messaging system is particularly useful with DI and the extension provided allows to easily bind all the necessary interfaces to the DI Scope for easy retrieval of either publisher or subscriber interfaces to the message channel.

When we use DI to pass the Pub or Sub references to classes - we facilitate less strong coupling in our code.

Usage would look like this:

```
struct Msg
{
//some message
}

//...

scope.BindMessageChannel<Msg>();

//and after the scope is resolved we can fetch IPublisher or ISubbscriber like this:

    public class PubUserExample
    {
        private IPublisher<Msg> _msgPublisher;
        
        [Inject]
        public PubUserExample(IPublisher<Msg> msgPublisher)
        {
            _msgPublisher = msgPublisher;
        }
    }

    public class SubUserExample : IDisposable
    {
        private IDisposable _subscription;
        
        [Inject]
        public SubUserExample(ISubscriber<Msg> msgSubscriber)
        {
            _subscription = msgSubscriber.Subscribe(Callback);
        }

        private void Callback(Msg msg)
        {
            
        }
        
        public void Dispose()
        {
            _subscription?.Dispose();
        }
    }
 
```

### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s):
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
 - Buffered pub-sub channel could be added - it would remember the last message passed and would replay it to any new subscriber. 
 
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
