### PR TITLE
Fix: Background missing in Post Game scene

### DIFF
--- a/Assets/BossRoom/Scenes/PostGame.unity
+++ b/Assets/BossRoom/Scenes/PostGame.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd1d4d660dc8b525b4fa61276e8fae1c00acddfa88aa51f9201d2e398fafad5d
-size 53433
+oid sha256:b15a806b20f415bc943660419f8784e215e1f6c03f45fb10db7a6153d459fa95
+size 53437


### PR DESCRIPTION
### Description (*)
This change moves the post game background (it was still there, just off camera) to be lined up with the camera's view, that way you see the background rather than a black screen.

Before:
![image](https://user-images.githubusercontent.com/89089503/152867782-b0aa9676-f9d8-4578-a10c-6982d3b1ad8e.png)

After:
![image](https://user-images.githubusercontent.com/89089503/152867888-c1745645-8060-4ae9-ac96-4bfdb0fb30a8.png)


### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
[Ticket here](https://jira.unity3d.com/browse/MTT-2321)

### Manual testing scenarios
1. Go to post game (either by losing, winning, using cheat, or host disconnect)
2. Scene background now shows up properly

