### PR TITLE
fix: same player number for multiple players in second playthrough

### DIFF
--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
@@ -189,16 +189,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
         {
             for (int possiblePlayerNum = 0; possiblePlayerNum < CharSelectData.k_MaxLobbyPlayers; ++possiblePlayerNum)
             {
-                bool found = false;
-                foreach (CharSelectData.LobbyPlayerState playerState in CharSelectData.LobbyPlayers)
-                {
-                    if (playerState.PlayerNum == possiblePlayerNum)
-                    {
-                        found = true;
-                        break;
-                    }
-                }
-                if (!found)
+                if (IsPlayerNumAvailable(possiblePlayerNum))
                 {
                     return possiblePlayerNum;
                 }
@@ -207,15 +198,30 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
             return -1;
         }
 
+        bool IsPlayerNumAvailable(int playerNum)
+        {
+            bool found = false;
+            foreach (CharSelectData.LobbyPlayerState playerState in CharSelectData.LobbyPlayers)
+            {
+                if (playerState.PlayerNum == playerNum)
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            return !found;
+        }
+
         private void SeatNewPlayer(ulong clientId)
         {
             SessionPlayerData? sessionPlayerData = SessionManager<SessionPlayerData>.Instance.GetPlayerData(clientId);
             if (sessionPlayerData.HasValue)
             {
                 var playerData = sessionPlayerData.Value;
-                if (playerData.PlayerNum == -1)
+                if (playerData.PlayerNum == -1 || !IsPlayerNumAvailable(playerData.PlayerNum))
                 {
-                    // If no player num already assigned, get an available one.
+                    // If no player num already assigned or if player num is no longer available, get an available one.
                     playerData.PlayerNum = GetAvailablePlayerNum();
                 }
                 if (playerData.PlayerNum == -1)


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR adds verification that player number is available before re-assigning it to a reconnecting player, preventing the occasional scenario where we would have two players with the same player number.
### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-2645](https://jira.unity3d.com/browse/MTT-2645)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Here are some repro steps for the bug this PR is fixing:
1. Start hosting a game and join with a client using a parrelsync clone
2. After going through character selection and moving to the BossRoom scene, join with another parrelsync clone
3. Use the GoToPostGame cheat
4. Pause the first clone to connect, then, with the host, hit Play Again
5. After the second clone loads the Character Selection scene, unpause the first clone
6. Now both clones are P2 (with this fix, now we have a P2 and a P3 instead)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
