### PR TITLE
fix: fixing send queue error

### DIFF
--- a/Assets/BossRoom/Prefabs/NetworkingManager.prefab
+++ b/Assets/BossRoom/Prefabs/NetworkingManager.prefab
@@ -45,12 +45,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_ProtocolType: 0
   m_MaxPacketQueueSize: 512
-  m_MaxPayloadSize: 16000
-  m_MaxSendQueueSize: 98304
+  m_MaxPayloadSize: 32000
+  m_MaxSendQueueSize: 50000000
   m_HeartbeatTimeoutMS: 500
   m_ConnectTimeoutMS: 1000
   m_MaxConnectAttempts: 60
-  m_DisconnectTimeoutMS: 30000
+  m_DisconnectTimeoutMS: 10000
   ConnectionData:
     Address: 127.0.0.1
     Port: 7777
@@ -99,13 +99,13 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ProtocolType: 1
-  m_MaxPacketQueueSize: 256
+  m_MaxPacketQueueSize: 512
   m_MaxPayloadSize: 32000
-  m_MaxSendQueueSize: 98304
+  m_MaxSendQueueSize: 50000000
   m_HeartbeatTimeoutMS: 500
   m_ConnectTimeoutMS: 1000
   m_MaxConnectAttempts: 60
-  m_DisconnectTimeoutMS: 30000
+  m_DisconnectTimeoutMS: 10000
   ConnectionData:
     Address: 127.0.0.1
     Port: 7777


### PR DESCRIPTION
### Description (*)
Increasing max send queue size to not overflow when there's a pause client side
Reducing timeout to 10 seconds instead of the 30 seconds default.
Putting all values equal between IP and Relay.

This will be cherrypicked to develop as well.

### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s):
[MTT-2356](https://jira.unity3d.com/browse/MTT-2356)

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
start client and host, connect to each other, character select, then full game. move around, get some imps following you, generate traffic.
pause client side for more than 10 seconds, wait for host to time you out.
(there's currently a bug open https://jira.unity3d.com/browse/MTT-2703 where the host will vomit errors when a client is disconnected by timeout)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
