### PR TITLE
fix: username changing before game

### DIFF
--- a/Assets/BossRoom/Scripts/Client/Game/State/ClientMainMenuState.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/State/ClientMainMenuState.cs
@@ -93,7 +93,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
                 Debug.Log($"Signed in. Unity Player ID {AuthenticationService.Instance.PlayerId}");
 
                 localUser.ID = AuthenticationService.Instance.PlayerId;
-                localUser.DisplayName = m_NameGenerationData.GenerateName();
                 // The local LobbyUser object will be hooked into UI before the LocalLobby is populated during lobby join, so the LocalLobby must know about it already when that happens.
                 localLobby.AddUser(localUser);
             }


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR removes regenerating player name after authentication is done.
### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-2650](https://jira.unity3d.com/browse/MTT-2650)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open the game, not the name at the bottom of the Lobby UI
2. Create a lobby
3. Select a character, see that your name is the same one as before
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
