### PR TITLE
lobby fix: Removing quit when lobby detects host left.

### DIFF
--- a/Assets/BossRoom/Scripts/Client/UI/UIQuitPanel.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/UIQuitPanel.cs
@@ -13,6 +13,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
 
         ApplicationController m_ApplicationController;
 
+        private bool m_QuitMode = true;
+
         [Inject]
         private void InjectDependencies(ApplicationController applicationController)
         {
@@ -21,14 +23,21 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
 
         void OnEnable()
         {
-            m_QuitButtonText.text = NetworkManager.Singleton != null && NetworkManager.Singleton.IsListening ?
-                "Leave session?" :
-                "Exit Game?";
+            m_QuitMode = NetworkManager.Singleton == null || !NetworkManager.Singleton.IsListening;
+            m_QuitButtonText.text = m_QuitMode ? "Exit Game?" : "Leave session?";
         }
 
         public void Quit()
         {
-            m_ApplicationController.QuitGame();
+            if (m_QuitMode)
+            {
+                m_ApplicationController.QuitGame();
+            }
+            else
+            {
+                m_ApplicationController.LeaveSession();
+            }
+
             gameObject.SetActive(false);
         }
     }

--- a/Assets/BossRoom/Scripts/Shared/ApplicationController.cs
+++ b/Assets/BossRoom/Scripts/Shared/ApplicationController.cs
@@ -109,7 +109,11 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared
             }
             else
             {
+#if UNITY_EDITOR
+                UnityEditor.EditorApplication.isPlaying = false;
+#else
                 Application.Quit();
+#endif
             }
         }
     }

--- a/Assets/BossRoom/Scripts/Shared/ApplicationController.cs
+++ b/Assets/BossRoom/Scripts/Shared/ApplicationController.cs
@@ -93,28 +93,26 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared
             return canQuit;
         }
 
+        public void LeaveSession()
+        {
+            m_LobbyServiceFacade.ForceLeaveLobbyAttempt();
+
+            // first disconnect then return to menu
+            var gameNetPortal = GameNetPortal.Instance;
+            if (gameNetPortal != null)
+            {
+                gameNetPortal.RequestDisconnect();
+            }
+            SceneManager.LoadScene("MainMenu");
+        }
+
         public void QuitGame()
         {
-            if (NetworkManager.Singleton.IsListening)
-            {
-                m_LobbyServiceFacade.ForceLeaveLobbyAttempt();
-
-                // first disconnect then return to menu
-                var gameNetPortal = GameNetPortal.Instance;
-                if (gameNetPortal != null)
-                {
-                    gameNetPortal.RequestDisconnect();
-                }
-                SceneManager.LoadScene("MainMenu");
-            }
-            else
-            {
 #if UNITY_EDITOR
-                UnityEditor.EditorApplication.isPlaying = false;
+            UnityEditor.EditorApplication.isPlaying = false;
 #else
-                Application.Quit();
+            Application.Quit();
 #endif
-            }
         }
     }
 }

--- a/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LobbyServiceFacade.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LobbyServiceFacade.cs
@@ -127,7 +127,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
                     }
                     m_UnityServiceErrorMessagePub.Publish(new UnityServiceErrorMessage("Host left the lobby","Disconnecting."));
                     ForceLeaveLobbyAttempt();
-                    // no need to disconnect NGO, it should already be handled by NGO callback to disconnect
+                    // no need to disconnect Netcode, it should already be handled by Netcode's callback to disconnect
                 }
             }
         }

--- a/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LobbyServiceFacade.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LobbyServiceFacade.cs
@@ -115,6 +115,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
                 CurrentUnityLobby = lobby;
                 m_LocalLobby.ApplyRemoteData(lobby);
 
+                // as client, check if host is still in lobby
                 if (!m_LocalUser.IsHost)
                 {
                     foreach (var lobbyUser in m_LocalLobby.LobbyUsers)
@@ -126,7 +127,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
                     }
                     m_UnityServiceErrorMessagePub.Publish(new UnityServiceErrorMessage("Host left the lobby","Disconnecting."));
                     ForceLeaveLobbyAttempt();
-                    m_ApplicationController.QuitGame();
+                    // no need to disconnect NGO, it should already be handled by NGO callback to disconnect
                 }
             }
         }


### PR DESCRIPTION


<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Removing quit when lobby detects host left.
This should already be handled by NGO side callback (on disconnect)
Adding in-editor quit, to have the same behaviour as builds

### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s):
[MTT-2744](https://jira.unity3d.com/browse/MTT-2744)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Tested in char select scene, host quits.
2. Tested in game scene, host quits.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
