### PR TITLE
fix: NetworkAnimator being called on clients

### DIFF
--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerAnimationHandler.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerAnimationHandler.cs
@@ -11,23 +11,22 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
         NetworkAnimator m_NetworkAnimator;
 
         [SerializeField]
-        private VisualizationConfiguration m_VisualizationConfiguration;
+        VisualizationConfiguration m_VisualizationConfiguration;
 
         [SerializeField]
         NetworkLifeState m_NetworkLifeState;
 
-        public NetworkAnimator NetworkAnimator
-        {
-            get => m_NetworkAnimator;
-            set => m_NetworkAnimator = value;
-        }
+        public NetworkAnimator NetworkAnimator => m_NetworkAnimator;
 
         public override void OnNetworkSpawn()
         {
-            m_NetworkLifeState.LifeState.OnValueChanged += OnLifeStateChanged;
+            if (IsServer)
+            {
+                m_NetworkLifeState.LifeState.OnValueChanged += OnLifeStateChanged;
+            }
         }
 
-        private void OnLifeStateChanged(LifeState previousValue, LifeState newValue)
+        void OnLifeStateChanged(LifeState previousValue, LifeState newValue)
         {
             switch (newValue)
             {
@@ -47,7 +46,10 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
 
         public override void OnNetworkDespawn()
         {
-            m_NetworkLifeState.LifeState.OnValueChanged -= OnLifeStateChanged;
+            if (IsServer)
+            {
+                m_NetworkLifeState.LifeState.OnValueChanged -= OnLifeStateChanged;
+            }
         }
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR removes the possibility of ServerAnimationHandler setting triggers on NetworkAnimator if it is not the server.
### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-2751](https://jira.unity3d.com/browse/MTT-2751)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Start a game with at least one client
2. Enter the BossRoom scene
3. See that the warnings are no longer occurring
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
