### PR TITLE
Boss and run VFX Optimizations

### DIFF
--- a/Assets/BossRoom/VFX/Materials/FX_M_Tiling_Texture_03.mat
+++ b/Assets/BossRoom/VFX/Materials/FX_M_Tiling_Texture_03.mat
@@ -109,7 +109,7 @@ Material:
     - __dirty: 0
     m_Colors:
     - Color_8e2f4eba95c94467bc8a7e534d545e44: {r: 2.9960785, g: 2.9960785, b: 2.9960785, a: 1}
-    - Vector4_4b685ef7d8364ebe863c7e5e4849012a: {r: 1, g: 1, b: 3, a: 0}
+    - Vector4_4b685ef7d8364ebe863c7e5e4849012a: {r: 0.2, g: 1, b: 3, a: 0}
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _Color: {r: 2.9960785, g: 2.9960785, b: 2.9960785, a: 1}
     - _Color0: {r: 0.7490196, g: 0.7490196, b: 0.7490196, a: 0}

--- a/Assets/BossRoom/VFX/Meshes/FX_Ms_Billboard.fbx.meta
+++ b/Assets/BossRoom/VFX/Meshes/FX_Ms_Billboard.fbx.meta
@@ -40,9 +40,9 @@ ModelImporter:
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
     importVisibility: 0
-    importBlendShapes: 1
+    importBlendShapes: 0
     importCameras: 0
-    importLights: 1
+    importLights: 0
     fileIdsGeneration: 2
     swapUVChannels: 0
     generateSecondaryUV: 0

--- a/Assets/BossRoom/VFX/Meshes/FX_Ms_Ice.fbx.meta
+++ b/Assets/BossRoom/VFX/Meshes/FX_Ms_Ice.fbx.meta
@@ -8,7 +8,7 @@ ModelImporter:
     second: Ice_Anim
   externalObjects: {}
   materials:
-    materialImportMode: 2
+    materialImportMode: 0
     materialName: 0
     materialSearch: 1
     materialLocation: 1
@@ -71,10 +71,10 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
-    importVisibility: 1
-    importBlendShapes: 1
-    importCameras: 1
-    importLights: 1
+    importVisibility: 0
+    importBlendShapes: 0
+    importCameras: 0
+    importLights: 0
     fileIdsGeneration: 2
     swapUVChannels: 0
     generateSecondaryUV: 0
@@ -105,7 +105,7 @@ ModelImporter:
     blendShapeNormalImportMode: 1
     normalSmoothingSource: 0
   referencedClips: []
-  importAnimation: 1
+  importAnimation: 0
   humanDescription:
     serializedVersion: 3
     human: []
@@ -124,7 +124,7 @@ ModelImporter:
     skeletonHasParents: 1
   lastHumanDescriptionAvatarSource: {instanceID: 0}
   autoGenerateAvatarMappingIfUnspecified: 1
-  animationType: 2
+  animationType: 0
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 1

--- a/Assets/BossRoom/VFX/Meshes/FX_Sphere.fbx
+++ b/Assets/BossRoom/VFX/Meshes/FX_Sphere.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea0cd1db6dd7b34e011a7039b4d0da56f090014d946eee019491f4ac5e6ad5fb
+size 23680

--- a/Assets/BossRoom/VFX/Meshes/FX_Sphere.fbx.meta
+++ b/Assets/BossRoom/VFX/Meshes/FX_Sphere.fbx.meta
@@ -1,9 +1,14 @@
 fileFormatVersion: 2
-guid: 91b0ed7f23ce8d24483afa5ed1b440b8
+guid: 05f32049434f9e747aa5c636967a6ead
 ModelImporter:
   serializedVersion: 20200
   internalIDToNameTable: []
-  externalObjects: {}
+  externalObjects:
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: lambert1
+    second: {fileID: 2100000, guid: f6c369516d8e9794baf0c35e5916b823, type: 2}
   materials:
     materialImportMode: 0
     materialName: 0

--- a/Assets/BossRoom/VFX/Meshes/FX_tank_shield.fbx.meta
+++ b/Assets/BossRoom/VFX/Meshes/FX_tank_shield.fbx.meta
@@ -39,10 +39,10 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
-    importVisibility: 1
-    importBlendShapes: 1
-    importCameras: 1
-    importLights: 1
+    importVisibility: 0
+    importBlendShapes: 0
+    importCameras: 0
+    importLights: 0
     fileIdsGeneration: 2
     swapUVChannels: 0
     generateSecondaryUV: 0
@@ -85,7 +85,7 @@ ModelImporter:
     armStretch: 0.05
     legStretch: 0.05
     feetSpacing: 0
-    globalScale: 0.0001
+    globalScale: 0.01
     rootMotionBoneName: 
     hasTranslationDoF: 0
     hasExtraRoot: 0

--- a/Assets/BossRoom/VFX/Meshes/Ms_HalfSphere.FBX
+++ b/Assets/BossRoom/VFX/Meshes/Ms_HalfSphere.FBX
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b5aba477ca2f51829d6d511bdab6d339287a0cb057b8d58ca97e22c5a2df7562
-size 141501
+oid sha256:773fb6c3e37709afb51c324b37667548c9f41fabd75d9a044303e8f5a3713ba3
+size 24640

--- a/Assets/BossRoom/VFX/Meshes/Ms_HalfSphere.FBX.meta
+++ b/Assets/BossRoom/VFX/Meshes/Ms_HalfSphere.FBX.meta
@@ -3,9 +3,14 @@ guid: d88fc32affa8ce843bebb38ee06a1354
 ModelImporter:
   serializedVersion: 20200
   internalIDToNameTable: []
-  externalObjects: {}
+  externalObjects:
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: lambert1
+    second: {fileID: 2100000, guid: f6c369516d8e9794baf0c35e5916b823, type: 2}
   materials:
-    materialImportMode: 2
+    materialImportMode: 0
     materialName: 0
     materialSearch: 1
     materialLocation: 1
@@ -39,10 +44,10 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
-    importVisibility: 1
-    importBlendShapes: 1
-    importCameras: 1
-    importLights: 1
+    importVisibility: 0
+    importBlendShapes: 0
+    importCameras: 0
+    importLights: 0
     fileIdsGeneration: 2
     swapUVChannels: 0
     generateSecondaryUV: 0
@@ -73,7 +78,7 @@ ModelImporter:
     blendShapeNormalImportMode: 1
     normalSmoothingSource: 0
   referencedClips: []
-  importAnimation: 1
+  importAnimation: 0
   humanDescription:
     serializedVersion: 3
     human: []
@@ -92,7 +97,7 @@ ModelImporter:
     skeletonHasParents: 1
   lastHumanDescriptionAvatarSource: {instanceID: 0}
   autoGenerateAvatarMappingIfUnspecified: 1
-  animationType: 2
+  animationType: 0
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 1

--- a/Assets/BossRoom/VFX/Prefabs/Boss/FX_Boss_Charge_Motion.prefab
+++ b/Assets/BossRoom/VFX/Prefabs/Boss/FX_Boss_Charge_Motion.prefab
@@ -5462,7 +5462,7 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     randomizeRotationDirection: 0
-    maxNumParticles: 1000
+    maxNumParticles: 3
     size3D: 1
     rotation3D: 1
     gravityModifier:
@@ -18539,8 +18539,8 @@ ParticleSystem:
         m_PreInfinity: 2
         m_PostInfinity: 2
         m_RotationOrder: 4
-    minVertexDistance: 0.05
-    textureMode: 0
+    minVertexDistance: 1
+    textureMode: 1
     ribbonCount: 1
     shadowBias: 0.5
     worldSpace: 0
@@ -24812,7 +24812,7 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     randomizeRotationDirection: 0
-    maxNumParticles: 1000
+    maxNumParticles: 3
     size3D: 1
     rotation3D: 1
     gravityModifier:

--- a/Assets/BossRoom/VFX/Prefabs/Boss/FX_Boss_Charge_arrow.prefab
+++ b/Assets/BossRoom/VFX/Prefabs/Boss/FX_Boss_Charge_arrow.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &840186157691765192
+--- !u!1 &5534066074145733308
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,45 +8,92 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2135725724969449102}
-  - component: {fileID: 8797138330288037240}
-  - component: {fileID: 4724724735665603943}
+  - component: {fileID: 27000756977628628}
+  - component: {fileID: 6541049777517503209}
   m_Layer: 0
-  m_Name: Plane (1)
+  m_Name: FX_Boss_Charge_arrow
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2135725724969449102
+--- !u!4 &27000756977628628
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 840186157691765192}
-  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
-  m_LocalPosition: {x: 0, y: 0.1, z: 5}
+  m_GameObject: {fileID: 5534066074145733308}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.2444744, y: 0, z: -5.597892}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6383592820307815153}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6541049777517503209
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5534066074145733308}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e80714725b908940a76375b52b8d53b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ParticleSystemsToTurnOffOnShutdown: []
+  m_AutoShutdownTime: -1
+  m_PostShutdownSelfDestructTime: -1
+--- !u!1 &7743794472255305046
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6383592820307815153}
+  - component: {fileID: 9036996552306951429}
+  - component: {fileID: 1749164748607442953}
+  m_Layer: 0
+  m_Name: Quad
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6383592820307815153
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7743794472255305046}
+  m_LocalRotation: {x: -0.70710576, y: 0.0000021532178, z: -0.000001989305, w: -0.7071079}
+  m_LocalPosition: {x: 0, y: 0.1, z: 5}
+  m_LocalScale: {x: 10, y: 10, z: 10}
   m_Children: []
   m_Father: {fileID: 27000756977628628}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
---- !u!33 &8797138330288037240
+  m_LocalEulerAnglesHint: {x: 90, y: 180, z: -180}
+--- !u!33 &9036996552306951429
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 840186157691765192}
-  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &4724724735665603943
+  m_GameObject: {fileID: 7743794472255305046}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1749164748607442953
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 840186157691765192}
+  m_GameObject: {fileID: 7743794472255305046}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -81,49 +128,3 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &5534066074145733308
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 27000756977628628}
-  - component: {fileID: 6541049777517503209}
-  m_Layer: 0
-  m_Name: fx_bosscharge
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &27000756977628628
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5534066074145733308}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 2.2444744, y: 0, z: -5.597892}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 2135725724969449102}
-  m_Father: {fileID: 0}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6541049777517503209
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5534066074145733308}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8e80714725b908940a76375b52b8d53b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_ParticleSystemsToTurnOffOnShutdown: []
-  m_PostShutdownSelfDestructTime: -1

--- a/Assets/BossRoom/VFX/Prefabs/Shared Hero FX/FX_run_smoke.prefab
+++ b/Assets/BossRoom/VFX/Prefabs/Shared Hero FX/FX_run_smoke.prefab
@@ -27,7 +27,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7170051953345250386}
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: -0.4}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -116,8 +116,8 @@ ParticleSystem:
     startLifetime:
       serializedVersion: 2
       minMaxState: 3
-      scalar: 1.5
-      minScalar: 1
+      scalar: 0.75
+      minScalar: 0.5
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -285,8 +285,8 @@ ParticleSystem:
     startSize:
       serializedVersion: 2
       minMaxState: 3
-      scalar: 0.2
-      minScalar: 0.4
+      scalar: 0.3
+      minScalar: 0.3
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -601,7 +601,7 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     randomizeRotationDirection: 0
-    maxNumParticles: 100
+    maxNumParticles: 25
     size3D: 0
     rotation3D: 0
     gravityModifier:
@@ -4794,13 +4794,13 @@ ParticleSystemRenderer:
   m_Pivot: {x: 0, y: 0, z: 0}
   m_Flip: {x: 0, y: 0, z: 0}
   m_UseCustomVertexStreams: 0
-  m_EnableGPUInstancing: 1
+  m_EnableGPUInstancing: 0
   m_ApplyActiveColorSpace: 1
   m_AllowRoll: 1
   m_FreeformStretching: 0
   m_RotateWithStretchDirection: 1
   m_VertexStreams: 00010304
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+  m_Mesh: {fileID: -3506623107785647724, guid: 05f32049434f9e747aa5c636967a6ead, type: 3}
   m_Mesh1: {fileID: 0}
   m_Mesh2: {fileID: 0}
   m_Mesh3: {fileID: 0}


### PR DESCRIPTION
### Description (*)
This is an optimization pass on some VFX. These were done for the memory issues that were happening on iOS, but are a good optimization to have overall. It includes reducing the amount of geometry used for the boss charge effects, as well as for the running particle effects. Reducing the complexity of these effects will mitigate there being massive tri count spikes, especially when fighting the boss with a ton of imps running around. I've also adjusted the import settings for the VFX meshes to not include unnecessary things like cameras, lights, animations, materials, etc.

Here are some images of things changed:

Boss charge arrow geometry density before vs after:

![image](https://user-images.githubusercontent.com/89089503/157066793-f8b4f997-40d6-415b-a18d-248ee55f6901.png)
![image](https://user-images.githubusercontent.com/89089503/157066839-fa92db5b-f652-4a55-9e67-7ee94f71a3b6.png)

Boss charge motion effect geometry density before and after (from 7-8k tris to 2-3k tris):

![image](https://user-images.githubusercontent.com/89089503/157067152-471d8a10-ca98-4701-a744-6a6d61d23487.png)
![image](https://user-images.githubusercontent.com/89089503/157069561-208cd1d6-1df3-4b7a-93e8-8724df6c4738.png)

And from the run smoke effect (as well as capping the max particles of this system from 100 to 25):

![image](https://user-images.githubusercontent.com/89089503/157070662-5c0e3112-577c-4efa-98e4-8c05e5be851c.png)
![image](https://user-images.githubusercontent.com/89089503/157070632-23a5d7ed-ab85-4da2-a7b7-ea64cba5bd3d.png)


### Issue Number(s) (*)
Jira ticket [here](https://jira.unity3d.com/browse/MTT-2759)