### PR TITLE
fix: client writing to NetworkVariable inside ServerCharacterMovement

### DIFF
--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacterMovement.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacterMovement.cs
@@ -151,12 +151,14 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
 
         private void FixedUpdate()
         {
+            if (!IsServer)
+            {
+                return;
+            }
+
             PerformMovement();
 
-            if (IsServer)
-            {
-                m_NetworkCharacterState.MovementStatus.Value = GetMovementStatus();
-            }
+            m_NetworkCharacterState.MovementStatus.Value = GetMovementStatus();
         }
 
         public override void OnNetworkDespawn()

--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacterMovement.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacterMovement.cs
@@ -153,7 +153,10 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
         {
             PerformMovement();
 
-            m_NetworkCharacterState.MovementStatus.Value = GetMovementStatus();
+            if (IsServer)
+            {
+                m_NetworkCharacterState.MovementStatus.Value = GetMovementStatus();
+            }
         }
 
         public override void OnNetworkDespawn()


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
Simple `IsServer` check inside `ServerCharacterMovement` to prevent client writing to `NetworkVariable` error from appearing when the application is closed.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
### Related Pull Requests
Similar null guard on application exit (https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/pull/516).
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-2475](https://jira.unity3d.com/browse/MTT-2475)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a build and connect to another player via lobbies
2. Close the client's app entirely when inside the game scene after character select.
3. Notice no errors from `ServerCharacterMovement` are added to player log.
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
