### PR TITLE
fix: populate lobby room name if creation room input field is empty

### DIFF
--- a/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyUIMediator.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyUIMediator.cs
@@ -1,4 +1,3 @@
-using System;
 using TMPro;
 using Unity.Multiplayer.Samples.BossRoom.Client;
 using Unity.Multiplayer.Samples.BossRoom.Shared.Infrastructure;

--- a/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyUIMediator.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyUIMediator.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Text;
 using TMPro;
 using Unity.Multiplayer.Samples.BossRoom.Client;
 using Unity.Multiplayer.Samples.BossRoom.Shared.Infrastructure;
@@ -6,6 +8,7 @@ using Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies;
 using Unity.Services.Authentication;
 using Unity.Services.Lobbies.Models;
 using UnityEngine;
+using Random = UnityEngine.Random;
 
 namespace Unity.Multiplayer.Samples.BossRoom.Visual
 {
@@ -61,6 +64,12 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
 
         public void CreateLobbyRequest(string lobbyName, bool isPrivate, int maxPlayers, OnlineMode onlineMode)
         {
+            // before sending request to lobby service, populate an empty lobby name, if necessary
+            if (string.IsNullOrEmpty(lobbyName))
+            {
+                lobbyName = GenerateRandomRoomKey();
+            }
+
             m_LobbyServiceFacade.CreateLobbyAsync(lobbyName, maxPlayers, isPrivate, onlineMode, OnCreatedLobby, OnFailedLobbyCreateOrJoin);
             BlockUIWhileLoadingIsInProgress();
         }
@@ -225,6 +234,22 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         void OnNetworkTimeout()
         {
             UnblockUIAfterLoadingIsComplete();
+        }
+
+        /// <summary>
+        /// Generates a random room key to use as a default value.
+        /// </summary>
+        /// <returns> A 6 character-long randomized string. </returns>
+        string GenerateRandomRoomKey()
+        {
+            var sb = new StringBuilder();
+            for (int i = 0; i < 6; i++)
+            {
+                var val = Convert.ToChar(Random.Range(65, 90));
+                sb.Append(val);
+            }
+
+            return sb.ToString();
         }
     }
 }

--- a/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyUIMediator.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyUIMediator.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text;
 using TMPro;
 using Unity.Multiplayer.Samples.BossRoom.Client;
 using Unity.Multiplayer.Samples.BossRoom.Shared.Infrastructure;
@@ -8,7 +7,6 @@ using Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies;
 using Unity.Services.Authentication;
 using Unity.Services.Lobbies.Models;
 using UnityEngine;
-using Random = UnityEngine.Random;
 
 namespace Unity.Multiplayer.Samples.BossRoom.Visual
 {
@@ -28,6 +26,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         NameGenerationData m_NameGenerationData;
         GameNetPortal m_GameNetPortal;
         ClientGameNetPortal m_ClientNetPortal;
+
+        const string k_DefaultLobbyName = "no-name";
 
         [Inject]
         void InjectDependenciesAndInitialize(
@@ -67,7 +67,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
             // before sending request to lobby service, populate an empty lobby name, if necessary
             if (string.IsNullOrEmpty(lobbyName))
             {
-                lobbyName = GenerateRandomRoomKey();
+                lobbyName = k_DefaultLobbyName;
             }
 
             m_LobbyServiceFacade.CreateLobbyAsync(lobbyName, maxPlayers, isPrivate, onlineMode, OnCreatedLobby, OnFailedLobbyCreateOrJoin);
@@ -234,22 +234,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         void OnNetworkTimeout()
         {
             UnblockUIAfterLoadingIsComplete();
-        }
-
-        /// <summary>
-        /// Generates a random room key to use as a default value.
-        /// </summary>
-        /// <returns> A 6 character-long randomized string. </returns>
-        string GenerateRandomRoomKey()
-        {
-            var sb = new StringBuilder();
-            for (int i = 0; i < 6; i++)
-            {
-                var val = Convert.ToChar(Random.Range(65, 90));
-                sb.Append(val);
-            }
-
-            return sb.ToString();
         }
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
Before sending a lobby create request, the lobby name will be populated with a default room name string.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-2748](https://jira.unity3d.com/browse/MTT-2748)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a lobby without populating the name input field with any characters.
2. Lobby will be created and will jump to CharSelect scene.
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
