### PR TITLE
fix: postgame menu button

### DIFF
--- a/Assets/BossRoom/Scripts/Client/UI/PostGameUI.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/PostGameUI.cs
@@ -15,7 +15,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
     /// </summary>
     public class PostGameUI : MonoBehaviour
     {
-        private ApplicationController m_ApplicationController;
+        ApplicationController m_ApplicationController;
 
         [SerializeField]
         private Light m_SceneLight;
@@ -42,7 +42,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         private Color m_LoseLightColor;
 
         [Inject]
-        private void InjectDependencies(ApplicationController applicationController)
+        void InjectDependencies(ApplicationController applicationController)
         {
             m_ApplicationController = applicationController;
         }

--- a/Assets/BossRoom/Scripts/Client/UI/PostGameUI.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/PostGameUI.cs
@@ -2,8 +2,11 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using TMPro;
+using Unity.Multiplayer.Samples.BossRoom.Shared;
+using Unity.Multiplayer.Samples.BossRoom.Shared.Infrastructure;
 using Unity.Multiplayer.Samples.Utilities;
 using Unity.Netcode;
+using UnityEngine.Assertions;
 
 namespace Unity.Multiplayer.Samples.BossRoom.Visual
 {
@@ -12,6 +15,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
     /// </summary>
     public class PostGameUI : MonoBehaviour
     {
+        private ApplicationController m_ApplicationController;
+
         [SerializeField]
         private Light m_SceneLight;
 
@@ -35,6 +40,18 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
 
         [SerializeField]
         private Color m_LoseLightColor;
+
+        [Inject]
+        private void InjectDependencies(ApplicationController applicationController)
+        {
+            m_ApplicationController = applicationController;
+        }
+
+        void Awake()
+        {
+            // This is needed because the post game UI is part of the PostGame scene so we need to manually inject dependencies on awake.
+            DIScope.RootScope.InjectIn(this);
+        }
 
         void Start()
         {
@@ -77,6 +94,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         public void OnPlayAgainClicked()
         {
             // this should only ever be called by the Host - so just go ahead and switch scenes
+            Assert.IsTrue(NetworkManager.Singleton.IsServer);
             SceneLoaderWrapper.Instance.LoadScene("CharSelect");
 
             // FUTURE: could be improved to better support a dedicated server architecture
@@ -84,11 +102,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
 
         public void OnMainMenuClicked()
         {
-            // Player is leaving this group - leave current network connection first
-            var gameNetPortal = GameObject.FindGameObjectWithTag("GameNetPortal").GetComponent<GameNetPortal>();
-            gameNetPortal.RequestDisconnect();
-
-            SceneLoaderWrapper.Instance.LoadScene("MainMenu");
+            m_ApplicationController.LeaveSession();
         }
     }
 }

--- a/Assets/BossRoom/Scripts/Shared/ApplicationController.cs
+++ b/Assets/BossRoom/Scripts/Shared/ApplicationController.cs
@@ -4,6 +4,7 @@ using Unity.Multiplayer.Samples.BossRoom.Client;
 using Unity.Multiplayer.Samples.BossRoom.Shared.Infrastructure;
 using Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Infrastructure;
 using Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies;
+using Unity.Multiplayer.Samples.Utilities;
 using Unity.Netcode;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -106,7 +107,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared
             {
                 gameNetPortal.RequestDisconnect();
             }
-            SceneManager.LoadScene("MainMenu");
+
+            SceneLoaderWrapper.Instance.LoadScene("MainMenu");
         }
 
         public void QuitGame()

--- a/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/SceneLoaderWrapper.cs
+++ b/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/SceneLoaderWrapper.cs
@@ -69,7 +69,7 @@ namespace Unity.Multiplayer.Samples.Utilities
         /// <param name="loadSceneMode">If LoadSceneMode.Single then all current Scenes will be unloaded before loading.</param>
         public void LoadScene(string sceneName, LoadSceneMode loadSceneMode = LoadSceneMode.Single)
         {
-            if (m_NetworkManager != null && m_NetworkManager.IsListening && m_NetworkManager.NetworkConfig.EnableSceneManagement)
+            if (m_NetworkManager != null && m_NetworkManager.IsListening && !m_NetworkManager.ShutdownInProgress && m_NetworkManager.NetworkConfig.EnableSceneManagement)
             {
                 if (m_NetworkManager.IsServer)
                 {
@@ -90,7 +90,7 @@ namespace Unity.Multiplayer.Samples.Utilities
 
         void OnSceneLoaded(Scene scene, LoadSceneMode loadSceneMode)
         {
-            if (m_NetworkManager == null || !m_NetworkManager.IsListening || !m_NetworkManager.NetworkConfig.EnableSceneManagement)
+            if (m_NetworkManager == null || !m_NetworkManager.IsListening || m_NetworkManager.ShutdownInProgress || !m_NetworkManager.NetworkConfig.EnableSceneManagement)
             {
                 m_ClientLoadingScreen.StopLoadingScreen();
             }


### PR DESCRIPTION
### Description (*)

Fixes a bug where pressing the "return to menu" button in the post game screen did not do anything when pressing the button. A repeated (2nd) press of the button would correctly load the menu scene.

When returning to the menu from the post game scene the active lobby was not quit so the lobby list still showed 2/6 players and did not allow the client to join the lobby again.

### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-2791](https://jira.unity3d.com/browse/MTT-2791)
### Manual testing scenarios
- Build and run a host (create a lobby session)
- Run a client in editor and join the host.
- Select characters and press ready
- Use the cheat window to go to the post game lobby
- Press the "return to menu" button on the client


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
