### PR TITLE
fix: populate lobby room name if creation room input field is empty (#522)

### DIFF
--- a/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyUIMediator.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyUIMediator.cs
@@ -28,6 +28,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         GameNetPortal m_GameNetPortal;
         ClientGameNetPortal m_ClientNetPortal;
 
+        const string k_DefaultLobbyName = "no-name";
+
         [Inject]
         void InjectDependenciesAndInitialize(
             LobbyServiceFacade lobbyServiceFacade,
@@ -63,6 +65,12 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
 
         public void CreateLobbyRequest(string lobbyName, bool isPrivate, int maxPlayers, OnlineMode onlineMode)
         {
+            // before sending request to lobby service, populate an empty lobby name, if necessary
+            if (string.IsNullOrEmpty(lobbyName))
+            {
+                lobbyName = k_DefaultLobbyName;
+            }
+
             m_LobbyServiceFacade.CreateLobbyAsync(lobbyName, maxPlayers, isPrivate, onlineMode, OnCreatedLobby, OnFailedLobbyCreateOrJoin);
             BlockUIWhileLoadingIsInProgress();
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
Cherry pick of [522](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/pull/522).
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
