### PR TITLE
fix: nav mesh floating patches removed

### DIFF
--- a/Assets/BossRoom/Scenes/BossRoom/NavMesh-DungeonNavMesh.asset
+++ b/Assets/BossRoom/Scenes/BossRoom/NavMesh-DungeonNavMesh.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e7f9713c4f16ffe30f974af089548b561fc8130a158201d377026b399f6f01b5
-size 52304
+oid sha256:a5acef8fbea9f4f215a4e14e582edabc3debd25963ff9921d582d40096fb588f
+size 50228


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
This PR brings a QoL fix for navigation. The nav mesh in the game scene had floaters due to some objects not being excluded outright from the bake, as seen below:

![Screenshot 2022-03-10 150335](https://user-images.githubusercontent.com/75813458/157904129-617eb510-f8d5-4ee1-8dde-fbb978878cd5.png)

The new bake:

![Screenshot 2022-03-11 110341](https://user-images.githubusercontent.com/75813458/157904255-bcde7c2c-49a2-4299-ab2f-cda3360650da.png)

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): This is a QoL PR which came about from working on [MTT-2412](https://jira.unity3d.com/browse/MTT-2412).
This is a cherrypick-able fix that should be in develop as well.

A subsequent PR will actually address the issue of the Rogue being able to dash to tops of columns.

Edit: the prefabs that were modified here initially will instead be modified in the rogue dash fix PR.
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
