### PR TITLE
fix: workaround for fixing the loading screen never going away on clients

### DIFF
--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ClientGameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ClientGameNetPortal.cs
@@ -142,17 +142,14 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
             }
         }
 
-        private void OnDisconnectReasonReceived(ConnectStatus status)
-        {
-            DisconnectReason.SetDisconnectReason(status);
-        }
-
-        private void OnDisconnectOrTimeout(ulong clientID)
+        void OnDisconnectOrTimeout(ulong clientID)
         {
             // This is also called on the Host when a different client disconnects. To make sure we only handle our own disconnection, verify that we are either
             // not a host (in which case we know this is about us) or that the clientID is the same as ours if we are the host.
             if (!NetworkManager.Singleton.IsHost || NetworkManager.Singleton.IsHost && NetworkManager.Singleton.LocalClientId == clientID)
             {
+                SceneLoaderWrapper.Instance.IsClosingClients = false; // disconnect done
+
                 //On a client disconnect we want to take them back to the main menu.
                 //We have to check here in SceneManager if our active scene is the main menu, as if it is, it means we timed out rather than a raw disconnect;
                 if (SceneManager.GetActiveScene().name != "MainMenu")
@@ -307,7 +304,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
         public static void ReceiveServerToClientSetDisconnectReason_CustomMessage(ulong clientID, FastBufferReader reader)
         {
             reader.ReadValueSafe(out ConnectStatus status);
-            Instance.OnDisconnectReasonReceived(status);
+            Instance.DisconnectReason.SetDisconnectReason(status);
+            SceneLoaderWrapper.Instance.IsClosingClients = true;
         }
     }
 }

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ServerGameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ServerGameNetPortal.cs
@@ -121,7 +121,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
             yield return null; // todo still needed? wait for UTP's update for it to send it's batched messages
             yield return null;
             SessionManager<SessionPlayerData>.Instance.OnUserDisconnectRequest();
-            Debug.Log("shutdown");
             m_Portal.NetManager.Shutdown();
             SceneLoaderWrapper.Instance.IsClosingClients = false;
         }

--- a/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/SceneLoaderWrapper.cs
+++ b/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/SceneLoaderWrapper.cs
@@ -105,7 +105,6 @@ namespace Unity.Multiplayer.Samples.Utilities
 
         void OnSceneEvent(SceneEvent sceneEvent)
         {
-            Debug.Log($"on scene event: {sceneEvent.SceneEventType}");
             // Only executes on client
             if (m_NetworkManager.IsClient)
             {

--- a/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/SceneLoaderWrapper.cs
+++ b/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/SceneLoaderWrapper.cs
@@ -88,9 +88,16 @@ namespace Unity.Multiplayer.Samples.Utilities
             }
         }
 
+        public bool IsClosingClients { get; set; }
+
         void OnSceneLoaded(Scene scene, LoadSceneMode loadSceneMode)
         {
-            if (m_NetworkManager == null || !m_NetworkManager.IsListening || m_NetworkManager.ShutdownInProgress || !m_NetworkManager.NetworkConfig.EnableSceneManagement)
+            // we're letting networked scene loading handle our loading screen, since there's still some loading happening after unity scene loading is done.
+            // in case we're offline, then we let unity's scene loader tell us when to turn off the loading screen.
+            var isOffline = m_NetworkManager == null || !m_NetworkManager.IsListening || m_NetworkManager.ShutdownInProgress || !m_NetworkManager.NetworkConfig.EnableSceneManagement;
+            // TODO this can be called while we're still in the WaitForSeconds(0.5) while shutting down host side. which means we'll still be in theory connected. Waiting on fix
+            // for this in MTT-2821
+            if (isOffline || IsClosingClients)
             {
                 m_ClientLoadingScreen.StopLoadingScreen();
             }
@@ -98,6 +105,7 @@ namespace Unity.Multiplayer.Samples.Utilities
 
         void OnSceneEvent(SceneEvent sceneEvent)
         {
+            Debug.Log($"on scene event: {sceneEvent.SceneEventType}");
             // Only executes on client
             if (m_NetworkManager.IsClient)
             {


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
This happens if the main menu scene switches too fast client side and we're done switching before we're actually disconnected.

This will need to be fixed for real when UTP fixes flushing transport side (MTT-2821).

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-2818](https://jira.unity3d.com/browse/MTT-2818)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Tested multiple times client and host leaving, host bring back clients to main menu, interchanging, client is now the host, leaves, brings other back to main menu.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
