### PR TITLE
fix: while updating lobby, query count wasn't always back to 0

### DIFF
--- a/Assets/BossRoom/Scripts/Client/UI/PopupPanel.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/PopupPanel.cs
@@ -93,8 +93,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         {
             if (m_IsPopupShown)
             {
-                Debug.Log("Trying to show popup, but another popup is already being shown.");
-                Debug.Log($"{titleText}. {mainText}");
+                Debug.LogWarning($"Trying to show popup, but another popup is already being shown. Popup: {titleText}. {mainText}");
                 return -1;
             }
 

--- a/Assets/BossRoom/Scripts/Client/UI/UnityServicesUIHandler.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/UnityServicesUIHandler.cs
@@ -36,7 +36,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
                 }
             }
 
-            PopupPanel.ShowPopupPanel("Service error", errorMessage);
+            PopupPanel.ShowPopupPanel("Service error: "+error.Title, errorMessage);
         }
 
         void OnDestroy()

--- a/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/JoinedLobbyContentHeartbeat.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/JoinedLobbyContentHeartbeat.cs
@@ -74,11 +74,11 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
 
                 if (m_LocalUser.IsHost)
                 {
-                    m_AwaitingQueryCount++;
-                    m_LobbyServiceFacade.UpdateLobbyDataAsync(m_LocalLobby.GetDataForUnityServices(), OnSuccess, null);
+                    m_AwaitingQueryCount++; // todo this should disapear once we use await correctly. This causes issues at the moment if OnSuccess isn't called properly
+                    m_LobbyServiceFacade.UpdateLobbyDataAsync(m_LocalLobby.GetDataForUnityServices(), OnSuccess, () => m_AwaitingQueryCount--);
                 }
                 m_AwaitingQueryCount++;
-                m_LobbyServiceFacade.UpdatePlayerDataAsync(m_LocalUser.GetDataForUnityServices(), OnSuccess, null);
+                m_LobbyServiceFacade.UpdatePlayerDataAsync(m_LocalUser.GetDataForUnityServices(), OnSuccess, () => m_AwaitingQueryCount--);
             }
 
             void OnSuccess()


### PR DESCRIPTION


<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
fixing issue where it's possible if there's an exception during updating lobby, query count never goes back to 0
adding some better error logging and popups.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): No issue, this was discovered quickly. If a new issue was created, it'd be closed anyway as soon as this is merged. No release notes needed for this PR, as this is related to lobby which is new anyway.

