### PR TITLE
Fix: Darker Eyebrows for Player Characters

### DIFF
--- a/Assets/BossRoom/Material/Characters/Hero_Eyes_sheet.mat
+++ b/Assets/BossRoom/Material/Characters/Hero_Eyes_sheet.mat
@@ -106,9 +106,9 @@ Material:
     - _UVSec: 0
     - _ZWrite: 0
     m_Colors:
-    - _BaseColor: {r: 0.5019608, g: 0.5019608, b: 0.5019608, a: 1}
+    - _BaseColor: {r: 0.248, g: 0.248, b: 0.248, a: 1}
     - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _EmissionColor: {r: 0.27450982, g: 0.27450982, b: 0.27450982, a: 1}
+    - _EmissionColor: {r: 0.135, g: 0.135, b: 0.135, a: 1}
     - _SpecColor: {r: 0.5, g: 0.5, b: 0.5, a: 0.5}
   m_BuildTextureStacks: []
 --- !u!114 &4340826014879142409


### PR DESCRIPTION
### Description (*)
A very small change but once I saw it I couldn't unsee it. Edited the material that handles the player character's eyebrows to make them darker. They match their lil icons better now. This should be in both develop and the GDC branch

Before:

![image](https://user-images.githubusercontent.com/89089503/158437463-6f8240dd-aae1-40ad-a78d-cda934fe9b17.png)
![image](https://user-images.githubusercontent.com/89089503/158437465-288207f8-8456-412a-a514-cd377ea5d5e9.png)
![image](https://user-images.githubusercontent.com/89089503/158437469-0e19791c-31c6-48d0-b4c4-35f8e99642af.png)

After:

![image](https://user-images.githubusercontent.com/89089503/158437280-8ad61ebc-c1f3-4adc-ba2a-5456198e0a7d.png)
![image](https://user-images.githubusercontent.com/89089503/158437284-6d3fb703-ce00-4f78-b3e3-191a75621b92.png)
![image](https://user-images.githubusercontent.com/89089503/158437288-fcb51941-76d8-4cd0-bccc-bede2e1d632f.png)



### Issue Number(s) (*)
[Jira ticket here](https://jira.unity3d.com/browse/MTT-2762)
