### PR TITLE
fix: RTT text too small

### DIFF
--- a/Assets/BossRoom/Prefabs/Debug Overlay Canvas.prefab
+++ b/Assets/BossRoom/Prefabs/Debug Overlay Canvas.prefab
@@ -134,7 +134,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 40, y: 40}
-  m_SizeDelta: {x: 200, y: 400}
+  m_SizeDelta: {x: 240, y: 400}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &3464894946384537378
 MonoBehaviour:
@@ -157,8 +157,8 @@ MonoBehaviour:
   m_Spacing: 0
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 0
-  m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0

--- a/Assets/BossRoom/Scripts/Shared/Net/NetworkStats.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/NetworkStats.cs
@@ -1,9 +1,8 @@
 using System.Collections.Generic;
+using TMPro;
 using Unity.Netcode;
-using Unity.Netcode.Transports.UNET;
 using UnityEngine;
 using UnityEngine.Assertions;
-using UnityEngine.UI;
 
 namespace Unity.Multiplayer.Samples.BossRoom
 {
@@ -47,8 +46,8 @@ namespace Unity.Multiplayer.Samples.BossRoom
         ExponentialMovingAverageCalculator m_UtpRTT = new ExponentialMovingAverageCalculator(0);
 
         float m_LastPingTime;
-        Text m_TextStat;
-        Text m_TextHostType;
+        TextMeshProUGUI m_TextStat;
+        TextMeshProUGUI m_TextHostType;
 
         // When receiving pong client RPCs, we need to know when the initiating ping sent it so we can calculate its individual RTT
         int m_CurrentRTTPingId;
@@ -85,16 +84,16 @@ namespace Unity.Multiplayer.Samples.BossRoom
             InitializeTextLine("No Stat", out m_TextStat);
         }
 
-        void InitializeTextLine(string defaultText, out Text textComponent)
+        void InitializeTextLine(string defaultText, out TextMeshProUGUI textComponent)
         {
-            GameObject rootGO = new GameObject("UI Stat Text");
-            textComponent = rootGO.AddComponent<Text>();
+            var rootGO = new GameObject("UI Stat Text");
+            textComponent = rootGO.AddComponent<TextMeshProUGUI>();
+            textComponent.fontSize = 24;
             textComponent.text = defaultText;
-            textComponent.font = Font.CreateDynamicFontFromOSFont("Arial", 24);
-            textComponent.horizontalOverflow = HorizontalWrapMode.Overflow;
-            textComponent.alignment = TextAnchor.MiddleLeft;
+            textComponent.horizontalAlignment = HorizontalAlignmentOptions.Left;
+            textComponent.verticalAlignment = VerticalAlignmentOptions.Middle;
             textComponent.raycastTarget = false;
-            textComponent.resizeTextForBestFit = true;
+            textComponent.autoSizeTextContainer = true;
 
             var rectTransform = rootGO.GetComponent<RectTransform>();
             Editor.NetworkOverlay.Instance.AddToUI(rectTransform);


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
This fixes the sizing issue on the RTT text above the Client/Server type text. Text has also been converted to TMPro components.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-2831](https://jira.unity3d.com/browse/MTT-2831)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Host/Join game and read text on bottom left of screen.
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
