### PR TITLE
cherrypick fix: arrow not sending a clientrpc when despawned, vfx reset on spawn/despawn

### DIFF
--- a/Assets/BossRoom/Scripts/Client/Game/Entity/ClientProjectileVisualization.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Entity/ClientProjectileVisualization.cs
@@ -7,7 +7,10 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
     {
         [SerializeField]
         [Tooltip("Explosion prefab used when projectile hits enemy. This should have a fixed duration.")]
-        private SpecialFXGraphic m_OnHitParticlePrefab;
+        SpecialFXGraphic m_OnHitParticlePrefab;
+
+        [SerializeField]
+        TrailRenderer m_TrailRenderer;
 
         NetworkProjectileState m_NetState;
 
@@ -25,6 +28,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
                 return;
             }
 
+            m_TrailRenderer.Clear();
+
             m_Parent = transform.parent;
             transform.parent = null;
             m_NetState = m_Parent.GetComponent<NetworkProjectileState>();
@@ -36,6 +41,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
 
         public override void OnNetworkDespawn()
         {
+            m_TrailRenderer.Clear();
+
             if (m_NetState != null)
             {
                 transform.parent = m_Parent;
@@ -69,7 +76,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
             }
         }
 
-        private void OnEnemyHit(ulong enemyId)
+        void OnEnemyHit(ulong enemyId)
         {
             //in the future we could do quite fancy things, like deparenting the Graphics Arrow and parenting it to the target.
             //For the moment we play some particles (optionally), and cause the target to animate a hit-react.

--- a/Assets/BossRoom/Scripts/Server/Game/Entity/ServerProjectileLogic.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Entity/ServerProjectileLogic.cs
@@ -87,17 +87,21 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
 
         private void FixedUpdate()
         {
-            if (!m_Started) { return; } //don't do anything before OnNetworkSpawn has run.
-
-            Vector3 displacement = transform.forward * (m_ProjectileInfo.Speed_m_s * Time.fixedDeltaTime);
-            transform.position += displacement;
+            if (!m_Started)
+            {
+                return; //don't do anything before OnNetworkSpawn has run.
+            }
 
             if (m_DestroyAtSec < Time.fixedTime)
             {
                 // Time to return to the pool from whence it came.
-                NetworkObject networkObject = gameObject.GetComponent<NetworkObject>();
+                var networkObject = gameObject.GetComponent<NetworkObject>();
                 networkObject.Despawn();
+                return;
             }
+
+            var displacement = transform.forward * (m_ProjectileInfo.Speed_m_s * Time.fixedDeltaTime);
+            transform.position += displacement;
 
             if (!m_IsDead)
             {

--- a/Assets/BossRoom/VFX/Prefabs/Archer/fx_ArrowGraphics.prefab
+++ b/Assets/BossRoom/VFX/Prefabs/Archer/fx_ArrowGraphics.prefab
@@ -17,7 +17,7 @@ GameObject:
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!4 &3325143161705299546
 Transform:
@@ -96,6 +96,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_OnHitParticlePrefab: {fileID: 0}
+  m_TrailRenderer: {fileID: 939547987977570762}
 --- !u!1001 &8427704294362486480
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -160,5 +161,10 @@ PrefabInstance:
 --- !u!4 &757528979405128990 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 9112595075296351182, guid: 660b64eb444497d41af2c727909eb671, type: 3}
+  m_PrefabInstance: {fileID: 8427704294362486480}
+  m_PrefabAsset: {fileID: 0}
+--- !u!96 &939547987977570762 stripped
+TrailRenderer:
+  m_CorrespondingSourceObject: {fileID: 8790122182988832538, guid: 660b64eb444497d41af2c727909eb671, type: 3}
   m_PrefabInstance: {fileID: 8427704294362486480}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/BossRoom/VFX/Prefabs/Archer/fx_ChargedArrow1Graphics.prefab
+++ b/Assets/BossRoom/VFX/Prefabs/Archer/fx_ChargedArrow1Graphics.prefab
@@ -17,7 +17,7 @@ GameObject:
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!4 &3325143161705299546
 Transform:
@@ -96,6 +96,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_OnHitParticlePrefab: {fileID: 8618909711417914730, guid: dc9de50a71cc1854586afa8a275a6a6b, type: 3}
+  m_TrailRenderer: {fileID: 4385405951865464679}
 --- !u!1001 &4981226344026716285
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -164,5 +165,10 @@ PrefabInstance:
 --- !u!4 &4275796242942192563 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 9112595075296351182, guid: 660b64eb444497d41af2c727909eb671, type: 3}
+  m_PrefabInstance: {fileID: 4981226344026716285}
+  m_PrefabAsset: {fileID: 0}
+--- !u!96 &4385405951865464679 stripped
+TrailRenderer:
+  m_CorrespondingSourceObject: {fileID: 8790122182988832538, guid: 660b64eb444497d41af2c727909eb671, type: 3}
   m_PrefabInstance: {fileID: 4981226344026716285}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/BossRoom/VFX/Prefabs/Archer/fx_ChargedArrow2Graphics.prefab
+++ b/Assets/BossRoom/VFX/Prefabs/Archer/fx_ChargedArrow2Graphics.prefab
@@ -17,7 +17,7 @@ GameObject:
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!4 &3325143161705299546
 Transform:
@@ -96,6 +96,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_OnHitParticlePrefab: {fileID: -6745866273066112404, guid: ae64395b058ab5e4db24271fb6fadb93, type: 3}
+  m_TrailRenderer: {fileID: 4385405951379145903}
 --- !u!1001 &4981226344026716285
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -168,5 +169,10 @@ PrefabInstance:
 --- !u!4 &4275796242942192563 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 9112595075296351182, guid: 660b64eb444497d41af2c727909eb671, type: 3}
+  m_PrefabInstance: {fileID: 4981226344026716285}
+  m_PrefabAsset: {fileID: 0}
+--- !u!96 &4385405951379145903 stripped
+TrailRenderer:
+  m_CorrespondingSourceObject: {fileID: 8790122182468517074, guid: 660b64eb444497d41af2c727909eb671, type: 3}
   m_PrefabInstance: {fileID: 4981226344026716285}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/BossRoom/VFX/Prefabs/Archer/fx_ChargedArrow3Graphics.prefab
+++ b/Assets/BossRoom/VFX/Prefabs/Archer/fx_ChargedArrow3Graphics.prefab
@@ -17,7 +17,7 @@ GameObject:
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!4 &3325143161705299546
 Transform:
@@ -96,6 +96,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_OnHitParticlePrefab: {fileID: 4562743285343113751, guid: 274d5f31ee594904399cb65bae8ec339, type: 3}
+  m_TrailRenderer: {fileID: 4385405950053795736}
 --- !u!1001 &4981226344026716285
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -172,5 +173,10 @@ PrefabInstance:
 --- !u!4 &4275796242942192563 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 9112595075296351182, guid: 660b64eb444497d41af2c727909eb671, type: 3}
+  m_PrefabInstance: {fileID: 4981226344026716285}
+  m_PrefabAsset: {fileID: 0}
+--- !u!96 &4385405950053795736 stripped
+TrailRenderer:
+  m_CorrespondingSourceObject: {fileID: 8790122183726792677, guid: 660b64eb444497d41af2c727909eb671, type: 3}
   m_PrefabInstance: {fileID: 4981226344026716285}
   m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
Cherry pick of [557](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/pull/557).
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
