### PR TITLE
fix: null refs preventing users from quitting

### DIFF
--- a/Assets/BossRoom/Scripts/Shared/ApplicationController.cs
+++ b/Assets/BossRoom/Scripts/Shared/ApplicationController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using BossRoom.Scripts.Shared.Net.UnityServices.Auth;
 using Unity.Multiplayer.Samples.BossRoom.Client;
@@ -6,7 +7,6 @@ using Unity.Multiplayer.Samples.BossRoom.Shared.Infrastructure;
 using Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Infrastructure;
 using Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies;
 using Unity.Multiplayer.Samples.Utilities;
-using Unity.Netcode;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -88,7 +88,15 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared
         /// </summary>
         private IEnumerator LeaveBeforeQuit()
         {
-            m_LobbyServiceFacade.ForceLeaveLobbyAttempt();
+            // We want to quit anyways, so if anything happens while trying to leave the Lobby, log the exception then carry on
+            try
+            {
+                m_LobbyServiceFacade.ForceLeaveLobbyAttempt();
+            }
+            catch (Exception e)
+            {
+                Debug.LogError(e.Message);
+            }
             yield return null;
             Application.Quit();
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR simply adds a try/catch to LeaveBeforeQuit to make sure that we quit even if exceptions happen.

### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
Fixes issue(s): [MTT-2656](https://jira.unity3d.com/browse/MTT-2656)
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Sadly, we haven't found repro steps to MTT-2656
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
