### PR TITLE
fix: updaterunner item already added

### DIFF
--- a/Assets/BossRoom/Scripts/Shared/Infrastructure/UpdateRunner.cs
+++ b/Assets/BossRoom/Scripts/Shared/Infrastructure/UpdateRunner.cs
@@ -54,8 +54,11 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Infrastructure
             {
                 m_PendingHandlers.Enqueue(() =>
                 {
-                    m_Subscribers.Add(onUpdate);
-                    m_SubscriberData.Add(onUpdate, new SubscriberData(){Period = period, PeriodCurrent = 0});
+                    if (!m_Subscribers.Contains(onUpdate))
+                    {
+                        m_Subscribers.Add(onUpdate);
+                        m_SubscriberData.Add(onUpdate, new SubscriberData() {Period = period, PeriodCurrent = 0});
+                    }
                 });
             }
         }

--- a/Assets/BossRoom/Scripts/Shared/Infrastructure/UpdateRunner.cs
+++ b/Assets/BossRoom/Scripts/Shared/Infrastructure/UpdateRunner.cs
@@ -54,9 +54,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Infrastructure
             {
                 m_PendingHandlers.Enqueue(() =>
                 {
-                    if (!m_Subscribers.Contains(onUpdate))
+                    if (m_Subscribers.Add(onUpdate))
                     {
-                        m_Subscribers.Add(onUpdate);
                         m_SubscriberData.Add(onUpdate, new SubscriberData() {Period = period, PeriodCurrent = 0});
                     }
                 });


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added guarding that would prevent us from having an error when adding multiple instances of the same callback to the UpdateRunner. Previously it was possible to slip in such an operation.

### Related Pull Requests
<!-- related pull request placeholder -->
### Issue Number(s) (*)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
MTT-2838
Fixes issue(s):
MTT-2838

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    If an error is output to either the player or editor log file, please attach.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas or for the reviewer to focus on a particular area of the code.
-->
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
