### PR TITLE
Fix: Refactor of click target feedback

### DIFF
--- a/Assets/BossRoom/Models/ClickFeedbackController.controller
+++ b/Assets/BossRoom/Models/ClickFeedbackController.controller
@@ -1,0 +1,72 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1107 &-3408950728626638424
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: 8953144010422057453}
+    m_Position: {x: 210, y: 10, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: 8953144010422057453}
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ClickFeedbackController
+  serializedVersion: 5
+  m_AnimatorParameters: []
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -3408950728626638424}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1102 &8953144010422057453
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI_GroundClick
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: afc67a48ae8dfea4793e330e10545ddc, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 

--- a/Assets/BossRoom/Models/ClickFeedbackController.controller.meta
+++ b/Assets/BossRoom/Models/ClickFeedbackController.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11646ef5453865d459c8ec37484dbdf3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/BossRoom/Models/UI_GroundClick.anim
+++ b/Assets/BossRoom/Models/UI_GroundClick.anim
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20225d855c2b5c5457fcfb2a6eb7cbecffdb5b5f0696f3aaebe218f7e8d88ec2
+size 5249

--- a/Assets/BossRoom/Models/UI_GroundClick.anim.meta
+++ b/Assets/BossRoom/Models/UI_GroundClick.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: afc67a48ae8dfea4793e330e10545ddc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/BossRoom/Prefabs/Character/PlayerAvatar.prefab
+++ b/Assets/BossRoom/Prefabs/Character/PlayerAvatar.prefab
@@ -65,8 +65,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Animator: {fileID: 1829276847453002016}
-  m_ParameterSendBits: 0
-  m_SendRate: 0.1
 --- !u!114 &7209204667172237188
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -307,7 +305,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e363085af981a41fd816ab952a0a07c7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_PingIntervalSeconds: 0.1
 --- !u!114 &4354133789489545025
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -333,6 +330,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 331c67f15523ad7419792662b9768f44, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  moveRate: 0.05
   m_CharacterClassContainer: {fileID: 5230418375993597025}
   m_PhysicsWrapper: {fileID: 6116655102486013040}
 --- !u!114 &5043718152237111612

--- a/Assets/BossRoom/Prefabs/Click_Feedback.prefab
+++ b/Assets/BossRoom/Prefabs/Click_Feedback.prefab
@@ -11,8 +11,9 @@ GameObject:
   - component: {fileID: 2500332623759108304}
   - component: {fileID: 6101625250476277925}
   - component: {fileID: 6375111725193425194}
-  - component: {fileID: 7164482062141736850}
   - component: {fileID: 5754560017040867806}
+  - component: {fileID: 8568434976788884338}
+  - component: {fileID: 7961553494364404633}
   m_Layer: 0
   m_Name: Click_Feedback
   m_TagString: Untagged
@@ -29,9 +30,8 @@ Transform:
   m_GameObject: {fileID: 9137928905311479176}
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 2816127936030266596}
+  m_LocalScale: {x: 2.713, y: 2.713, z: 2.713}
+  m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
@@ -50,7 +50,7 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9137928905311479176}
-  m_Enabled: 0
+  m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
@@ -62,7 +62,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: bfad40b971740ef4381f47a69fd3348d, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -84,20 +84,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!64 &7164482062141736850
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9137928905311479176}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 4
-  m_Convex: 0
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!114 &5754560017040867806
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -111,65 +97,35 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_DisabledDelay: 0.75
---- !u!1001 &5569208290851949093
-PrefabInstance:
+--- !u!95 &8568434976788884338
+Animator:
+  serializedVersion: 3
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 2500332623759108304}
-    m_Modifications:
-    - target: {fileID: 6957808770263120477, guid: 7c2bd7eca3b96084f99aa3a945102b11, type: 3}
-      propertyPath: m_Name
-      value: GroundClickFX
-      objectReference: {fileID: 0}
-    - target: {fileID: 7664326125434658497, guid: 7c2bd7eca3b96084f99aa3a945102b11, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7664326125434658497, guid: 7c2bd7eca3b96084f99aa3a945102b11, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7664326125434658497, guid: 7c2bd7eca3b96084f99aa3a945102b11, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7664326125434658497, guid: 7c2bd7eca3b96084f99aa3a945102b11, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7664326125434658497, guid: 7c2bd7eca3b96084f99aa3a945102b11, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7664326125434658497, guid: 7c2bd7eca3b96084f99aa3a945102b11, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7664326125434658497, guid: 7c2bd7eca3b96084f99aa3a945102b11, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7664326125434658497, guid: 7c2bd7eca3b96084f99aa3a945102b11, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7664326125434658497, guid: 7c2bd7eca3b96084f99aa3a945102b11, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7664326125434658497, guid: 7c2bd7eca3b96084f99aa3a945102b11, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7664326125434658497, guid: 7c2bd7eca3b96084f99aa3a945102b11, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 7c2bd7eca3b96084f99aa3a945102b11, type: 3}
---- !u!4 &2816127936030266596 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7664326125434658497, guid: 7c2bd7eca3b96084f99aa3a945102b11, type: 3}
-  m_PrefabInstance: {fileID: 5569208290851949093}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9137928905311479176}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 11646ef5453865d459c8ec37484dbdf3, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!114 &7961553494364404633
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9137928905311479176}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 598271baef5b1d843990b429b974205f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  lerpSpeed: 0.03

--- a/Assets/BossRoom/Scripts/Client/ClientClickFeedback.cs
+++ b/Assets/BossRoom/Scripts/Client/ClientClickFeedback.cs
@@ -15,8 +15,9 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
         GameObject m_FeedbackObj;
 
         ClientInputSender m_ClientSender;
+        
+        ClickFeedbackLerper m_ClickFeedbackLerper;
 
-        const float k_HoverHeight = 0.15f;
 
         void Start()
         {
@@ -30,15 +31,13 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
             m_ClientSender.ClientMoveEvent += OnClientMove;
             m_FeedbackObj = Instantiate(m_FeedbackPrefab);
             m_FeedbackObj.SetActive(false);
+            m_ClickFeedbackLerper = m_FeedbackObj.GetComponent<ClickFeedbackLerper>();
         }
 
         void OnClientMove(Vector3 position)
         {
-            position.y += k_HoverHeight;
-
-            m_FeedbackObj.transform.position = position;
             m_FeedbackObj.SetActive(true);
-
+            m_ClickFeedbackLerper.SetTarget(position);
         }
 
         public override void OnDestroy()

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClickFeedbackLerper.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClickFeedbackLerper.cs
@@ -9,8 +9,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
 
         Vector3 m_TargetPosition;
 
-        Vector3 m_LerpedPosition;
-
         // The amount of offset to keep the click feedback object from intersecting with the floor
         const float k_HoverHeight = 0.15f;
         const float k_LerpTime = 0.04f;
@@ -22,7 +20,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
 
         void Update()
         {
-            transform.position = m_PositionLerper.LerpPosition(m_LerpedPosition, m_TargetPosition);
+            transform.position = m_PositionLerper.LerpPosition(transform.position, m_TargetPosition);
         }
 
         public void SetTarget(Vector3 clientInputPosition)

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClickFeedbackLerper.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClickFeedbackLerper.cs
@@ -1,0 +1,35 @@
+using Unity.Multiplayer.Samples.BossRoom.Visual;
+using UnityEngine;
+
+namespace Unity.Multiplayer.Samples.BossRoom.Client
+{
+    public class ClickFeedbackLerper : MonoBehaviour
+    {
+        PositionLerper m_PositionLerper;
+
+        Vector3 m_TargetPosition;
+
+        Vector3 m_LerpedPosition;
+
+        // The amount of offset to keep the click feedback object from intersecting with the floor
+        const float k_HoverHeight = 0.15f;
+        const float k_LerpTime = 0.04f;
+
+        void Start()
+        {
+            m_PositionLerper = new PositionLerper(Vector3.zero, k_LerpTime);
+        }
+
+        void Update()
+        {
+            transform.position = m_PositionLerper.LerpPosition(m_LerpedPosition, m_TargetPosition);
+        }
+
+        public void SetTarget(Vector3 clientInputPosition)
+        {
+            m_TargetPosition.x = clientInputPosition.x;
+            m_TargetPosition.y = k_HoverHeight;
+            m_TargetPosition.z = clientInputPosition.z;
+        }
+    }
+}

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClickFeedbackLerper.cs.meta
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClickFeedbackLerper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 598271baef5b1d843990b429b974205f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
@@ -14,9 +14,9 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
     {
         private const float k_MouseInputRaycastDistance = 100f;
 
-        //The movement input rate is capped at 50ms (or 20 fps). This provides a nice balance between responsiveness and
+        //The movement input rate is capped at 40ms (or 25 fps). This provides a nice balance between responsiveness and
         //upstream network conservation. This matters when holding down your mouse button to move.
-        private const float k_MoveSendRateSeconds = 0.05f; //20 fps.
+        private const float k_MoveSendRateSeconds = 0.04f; //25 fps.
 
 
         private const float k_TargetMoveTimeout = 0.45f;  //prevent moves for this long after targeting someone (helps prevent walking to the guy you clicked).

--- a/Assets/BossRoom/VFX/Materials/GroundClick.mat
+++ b/Assets/BossRoom/VFX/Materials/GroundClick.mat
@@ -128,7 +128,7 @@ Material:
     - _ColorMask: 15
     - _ColorMode: 3
     - _Cull: 2
-    - _Cutoff: 0.5
+    - _Cutoff: 0.123
     - _DetailNormalMapScale: 1
     - _DiffuseAmount: 0.2
     - _DistortionBlend: 0.5

--- a/Assets/BossRoom/VFX/Prefabs/UI/fx_GroundClickFX.prefab
+++ b/Assets/BossRoom/VFX/Prefabs/UI/fx_GroundClickFX.prefab
@@ -4792,7 +4792,7 @@ ParticleSystemRenderer:
   m_RenderAlignment: 1
   m_Pivot: {x: 0, y: 0, z: 0}
   m_Flip: {x: 0, y: 0, z: 0}
-  m_UseCustomVertexStreams: 1
+  m_UseCustomVertexStreams: 0
   m_EnableGPUInstancing: 1
   m_ApplyActiveColorSpace: 1
   m_AllowRoll: 1


### PR DESCRIPTION
### Description (*)
A bug fix turned refactor of the player click feedback target. Before, it was a particle system with a single plane mesh particle being scaled over life, just following the cursor's position every 20 frames. Now it is a quad with a snazzier scaling animation and interpolated following of the cursor, to create a smoother, more seamless look and feel. 

Fernando and I worked together on the interpolation, and part of the change was increasing the frequency of raycasts slightly for a smoother feel, let me know your thoughts on that for balancing performance and smoothness!

The red dot bug was seemingly an issue with the GPU dynamic instancing that particle systems use--it appeared with instancing turned on, and didn't with instancing turned off. It happened on every platform, in builds, and in editor, which further points to it being a weird bug with particle systems. I tried to debug with RenderDoc, but couldn't manage to capture a frame with the red dot, even using tricks like capturing multiple sequential frames--it only ever captured it rendering correctly. There were even times where both the red dot and the green target seemed to be rendering on the one particle mesh, which I think shouldn't be possible? I'd like to do some more digging into this, but for GDC and develop for now, implementing it in a different way feels like the way to go. 

Here are some videos of the difference!

Before:
https://user-images.githubusercontent.com/89089503/158853365-4986097e-c463-4ac6-af39-ef7f711aa2ac.mp4

After:
https://user-images.githubusercontent.com/89089503/158853408-fb1122a9-0592-45ba-aab2-327e28418616.mp4


### Issue Number(s) (*)
[Jira ticket 2456 here](https://jira.unity3d.com/browse/MTT-2456)
