### PR TITLE
fix: hard coding frame rate

### DIFF
--- a/Assets/BossRoom/Scripts/Shared/ApplicationController.cs
+++ b/Assets/BossRoom/Scripts/Shared/ApplicationController.cs
@@ -69,6 +69,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared
 
             m_LocalLobby = scope.Resolve<LocalLobby>();
             m_LobbyServiceFacade = scope.Resolve<LobbyServiceFacade>();
+
+            Application.targetFrameRate = 120;
         }
 
         private void Start()


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
setting to 120 so it doesn't influence RTT too much, but still shaves off about 1/3 of CPU usage when running 2 builds on the same machine

We'll need to test this on Android, make sure this doesn't mess things up. @fernando-cortez @jilfranco-unity if one of you guys could test it on your devices, that'd be great :)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
