### PR TITLE
cherry pick fix: mage FX graphics not offset (#571)

### DIFF
--- a/Assets/BossRoom/Prefabs/CharGFX/PlayerGraphics_Mage.prefab
+++ b/Assets/BossRoom/Prefabs/CharGFX/PlayerGraphics_Mage.prefab
@@ -182,7 +182,7 @@ MonoBehaviour:
     m_PrefabSpawnDelaySeconds: 0
     m_PrefabCanBeAbortedUntilSecs: 0
     m_PrefabParent: {fileID: 1313590801738418481, guid: c94325ee327b53c49939f904d073f197, type: 3}
-    m_PrefabParentOffset: {x: 0, y: 0, z: 50}
+    m_PrefabParentOffset: {x: 0, y: 0, z: 0}
     m_DeParentPrefab: 0
     m_SoundEffect: {fileID: 8300000, guid: b239f215d2645db40ad6183403eb26df, type: 3}
     m_SoundStartDelaySeconds: 0


### PR DESCRIPTION
<!---
    Thank you for contributing to Unity.
    To help us process this pull request we recommend that you add the following information:
     - Summary and list of changes in the pull request,
     - Issue(s) related to the changes made such as GitHub or Jira,
     - Manual testing scenarios if available
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
Cherry pick of [571](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/pull/571).
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
