### PR TITLE
fix: Generate unique Profile ID on clone project

### DIFF
--- a/Assets/BossRoom/Scripts/Shared/ProfileManager.cs
+++ b/Assets/BossRoom/Scripts/Shared/ProfileManager.cs
@@ -1,6 +1,9 @@
 using UnityEngine;
 
 #if UNITY_EDITOR
+using System;
+using System.Security.Cryptography;
+using System.Text;
 using ParrelSync;
 #endif
 
@@ -31,17 +34,28 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared
 
                 return hardcodedProfileID;
             }
-#else
-        var arguments = System.Environment.GetCommandLineArgs();
-        for (int i = 0; i < arguments.Length; i++)
-        {
-            if (arguments[i] == AuthProfileCommandLineArg)
-            {
-                var profileId = arguments[i + 1];
-                return profileId;
-            }
-        }
+
+            // When running in the Editor and not a ParrelSync clone, make a unique ID
+            // from the Application.dataPath. This will work for cloning projects
+            // manually, or with Virtual Projects. Since only a single instance of
+            // the Editor can be open for a specific dataPath, uniqueness is ensured.
+            var hashedBytes = new MD5CryptoServiceProvider()
+                .ComputeHash(Encoding.UTF8.GetBytes(Application.dataPath));
+            Array.Resize(ref hashedBytes, 16);
+            return new Guid(hashedBytes).ToString("N");
+
 #endif
+
+            var arguments = System.Environment.GetCommandLineArgs();
+            for (int i = 0; i < arguments.Length; i++)
+            {
+                if (arguments[i] == AuthProfileCommandLineArg)
+                {
+                    var profileId = arguments[i + 1];
+                    return profileId;
+                }
+            }
+
             return "";
         }
     }

--- a/Assets/BossRoom/Scripts/Shared/ProfileManager.cs
+++ b/Assets/BossRoom/Scripts/Shared/ProfileManager.cs
@@ -30,10 +30,10 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared
 
 #if UNITY_EDITOR
 
-            // When running in the Editor and not a ParrelSync clone, make a unique ID
-            // from the Application.dataPath. This will work for cloning projects
-            // manually, or with Virtual Projects. Since only a single instance of
-            // the Editor can be open for a specific dataPath, uniqueness is ensured.
+            // When running in the Editor make a unique ID from the Application.dataPath.
+            // This will work for cloning projects manually, or with Virtual Projects.
+            // Since only a single instance of the Editor can be open for a specific
+            // dataPath, uniqueness is ensured.
             var hashedBytes = new MD5CryptoServiceProvider()
                 .ComputeHash(Encoding.UTF8.GetBytes(Application.dataPath));
             Array.Resize(ref hashedBytes, 16);

--- a/Assets/BossRoom/Scripts/Shared/ProfileManager.cs
+++ b/Assets/BossRoom/Scripts/Shared/ProfileManager.cs
@@ -19,21 +19,17 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared
 
         static string GetProfile()
         {
-#if UNITY_EDITOR
-
-            //The code below makes it possible for the clone instance to log in as a different user profile in Authentication service.
-            //This allows us to test services integration locally by utilising Parrelsync.
-            if (ClonesManager.IsClone())
+            var arguments = Environment.GetCommandLineArgs();
+            for (int i = 0; i < arguments.Length; i++)
             {
-                Debug.Log("This is a clone project.");
-                var customArguments = ClonesManager.GetArgument().Split(',');
-
-                //second argument is our custom ID, but if it's not set we would just use some default.
-
-                var hardcodedProfileID = customArguments.Length > 1 ? customArguments[1] : "defaultCloneID";
-
-                return hardcodedProfileID;
+                if (arguments[i] == AuthProfileCommandLineArg)
+                {
+                    var profileId = arguments[i + 1];
+                    return profileId;
+                }
             }
+
+#if UNITY_EDITOR
 
             // When running in the Editor and not a ParrelSync clone, make a unique ID
             // from the Application.dataPath. This will work for cloning projects
@@ -45,16 +41,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared
             return new Guid(hashedBytes).ToString("N");
 
 #endif
-
-            var arguments = System.Environment.GetCommandLineArgs();
-            for (int i = 0; i < arguments.Length; i++)
-            {
-                if (arguments[i] == AuthProfileCommandLineArg)
-                {
-                    var profileId = arguments[i + 1];
-                    return profileId;
-                }
-            }
 
             return "";
         }

--- a/Assets/BossRoom/Scripts/Shared/ProfileManager.cs
+++ b/Assets/BossRoom/Scripts/Shared/ProfileManager.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 using System;
 using System.Security.Cryptography;
 using System.Text;
-using ParrelSync;
 #endif
 
 namespace Unity.Multiplayer.Samples.BossRoom.Shared


### PR DESCRIPTION
### Description (*)
Running BossRoom on two instances locally, either when cloning the project manually, or when using Virtual Projects. When attempting to host in one Editor and then join a game in the other Editor, we get a conflict with the message "You have logged in elsewhere using the same account." since they are both trying to join using the same user ID.

When running in the Editor and not a ParrelSync clone, make a unique ID from the Application.dataPath. This will work for cloning projects manually, or with Virtual Projects. Since only a single instance of the Editor can be open for a specific dataPath, uniqueness is ensured.

### Related Pull Requests

### Issue Number(s) (*)

Fixes issue(s):
### Manual testing scenarios

### Questions or comments

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
