### PR TITLE
Fix/UI blocking pass

### DIFF
--- a/Assets/BossRoom/Prefabs/UI/IPPopup.prefab
+++ b/Assets/BossRoom/Prefabs/UI/IPPopup.prefab
@@ -351,7 +351,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -1014,7 +1014,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0.023529414, b: 0.04705883, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -1105,7 +1105,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0.023529414, b: 0.04705883, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -2086,7 +2086,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.17835717, g: 0.3161786, b: 0.45400003, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -3057,7 +3057,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -3558,7 +3558,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -3633,7 +3633,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -4513,7 +4513,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.17835717, g: 0.3161786, b: 0.45400003, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/Assets/BossRoom/Prefabs/UI/IPPopup.prefab
+++ b/Assets/BossRoom/Prefabs/UI/IPPopup.prefab
@@ -1226,7 +1226,6 @@ GameObject:
   - component: {fileID: 2057931095918228162}
   - component: {fileID: 3217480593287788585}
   - component: {fileID: 2242940246583725761}
-  - component: {fileID: 5835693888197301866}
   - component: {fileID: 4351232040011826679}
   m_Layer: 5
   m_Name: JoinButton
@@ -1295,21 +1294,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1.5
---- !u!114 &5835693888197301866
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3825292631697100053}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86fd4fbcc3fc84b228fc9c4cb612c32a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_TintColors:
-  - {r: 1, g: 1, b: 1, a: 1}
-  - {r: 1, g: 1, b: 1, a: 1}
 --- !u!114 &4351232040011826679
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2991,10 +2975,8 @@ MonoBehaviour:
   m_PlayerNameLabel: {fileID: 7328528642576607773}
   m_IPJoiningUI: {fileID: 4035387343632270047}
   m_IPHostingUI: {fileID: 6512829474060433337}
-  m_JoinTabButtonTinter: {fileID: 5835693888197301866}
   m_JoinTabButtonHighlightTinter: {fileID: 3300828701031786671}
   m_JoinTabButtonTabBlockerTinter: {fileID: 3953053990258396426}
-  m_HostTabButtonTinter: {fileID: 8675839305897455978}
   m_HostTabButtonHighlightTinter: {fileID: 1839781279224386958}
   m_HostTabButtonTabBlockerTinter: {fileID: 8260437346995034578}
   m_SignInSpinner: {fileID: 8543714399569277319}
@@ -4029,7 +4011,6 @@ GameObject:
   - component: {fileID: 4258862478995995494}
   - component: {fileID: 1519931548906777285}
   - component: {fileID: 4083683571038336106}
-  - component: {fileID: 8675839305897455978}
   - component: {fileID: 996135322976812024}
   m_Layer: 5
   m_Name: CreateButton
@@ -4098,21 +4079,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1.5
---- !u!114 &8675839305897455978
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8406754363237041140}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86fd4fbcc3fc84b228fc9c4cb612c32a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_TintColors:
-  - {r: 1, g: 1, b: 1, a: 1}
-  - {r: 1, g: 1, b: 1, a: 1}
 --- !u!114 &996135322976812024
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/BossRoom/Prefabs/UI/LobbyUI.prefab
+++ b/Assets/BossRoom/Prefabs/UI/LobbyUI.prefab
@@ -995,7 +995,6 @@ GameObject:
   - component: {fileID: 4996778416574021528}
   - component: {fileID: 1242736280487814429}
   - component: {fileID: 6028373986916100015}
-  - component: {fileID: 6915400021973830416}
   - component: {fileID: 60699266497995633}
   m_Layer: 5
   m_Name: JoinButton
@@ -1064,21 +1063,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1.5
---- !u!114 &6915400021973830416
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2280189352372853816}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86fd4fbcc3fc84b228fc9c4cb612c32a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_TintColors:
-  - {r: 1, g: 1, b: 1, a: 1}
-  - {r: 1, g: 1, b: 1, a: 1}
 --- !u!114 &60699266497995633
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1664,7 +1648,6 @@ GameObject:
   - component: {fileID: 282255004005152861}
   - component: {fileID: 5754057292363824191}
   - component: {fileID: 6125749772841147739}
-  - component: {fileID: 7081295359045549679}
   - component: {fileID: 1477683225176343646}
   m_Layer: 5
   m_Name: CreateButton
@@ -1733,21 +1716,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1.5
---- !u!114 &7081295359045549679
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3672577566589301672}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86fd4fbcc3fc84b228fc9c4cb612c32a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_TintColors:
-  - {r: 1, g: 1, b: 1, a: 1}
-  - {r: 1, g: 1, b: 1, a: 1}
 --- !u!114 &1477683225176343646
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4077,10 +4045,8 @@ MonoBehaviour:
   m_CanvasGroup: {fileID: 6889764071769254414}
   m_LobbyJoiningUI: {fileID: 3432713757992463987}
   m_LobbyCreationUI: {fileID: 5370165130166260100}
-  m_JoinToggle: {fileID: 6915400021973830416}
   m_JoinToggleHighlight: {fileID: 6752777071945805011}
   m_JoinToggleTabBlocker: {fileID: 4806072236846957327}
-  m_CreateToggle: {fileID: 7081295359045549679}
   m_CreateToggleHighlight: {fileID: 4585101913867269799}
   m_CreateToggleTabBlocker: {fileID: 1276364547110863194}
   m_PlayerNameLabel: {fileID: 7676773602323508701}

--- a/Assets/BossRoom/Prefabs/UI/LobbyUI.prefab
+++ b/Assets/BossRoom/Prefabs/UI/LobbyUI.prefab
@@ -127,7 +127,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.17835717, g: 0.3161786, b: 0.45400003, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -217,7 +217,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -1465,7 +1465,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0.023529414, b: 0.04705883, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -2454,7 +2454,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0.023529414, b: 0.04705883, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -3074,7 +3074,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -3149,7 +3149,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -3834,7 +3834,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -4298,7 +4298,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 20.3
+  m_fontSize: 33
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -4460,7 +4460,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 6773627913577560496}
   m_HandleRect: {fileID: 2234904744820987572}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -5105,7 +5105,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 20.3
+  m_fontSize: 33
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -5783,7 +5783,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.17835717, g: 0.3161786, b: 0.45400003, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/Assets/BossRoom/Prefabs/UI/SettingsPanelCanvas.prefab
+++ b/Assets/BossRoom/Prefabs/UI/SettingsPanelCanvas.prefab
@@ -1168,7 +1168,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
@@ -176,10 +176,10 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
                     var ray = m_MainCamera.ScreenPointToRay(Input.mousePosition);
                     if (Physics.RaycastNonAlloc(ray, k_CachedHit, k_MouseInputRaycastDistance, k_GroundLayerMask) > 0)
                     {
-                            m_NetworkCharacter.SendCharacterInputServerRpc(k_CachedHit[0].point);
+                        m_NetworkCharacter.SendCharacterInputServerRpc(k_CachedHit[0].point);
 
-                            //Send our client only click request
-                            ClientMoveEvent?.Invoke(k_CachedHit[0].point);
+                        //Send our client only click request
+                        ClientMoveEvent?.Invoke(k_CachedHit[0].point);
                     }
                 }
             }

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
@@ -174,14 +174,12 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
                 {
                     m_LastSentMove = Time.time;
                     var ray = m_MainCamera.ScreenPointToRay(Input.mousePosition);
+                    if (Physics.RaycastNonAlloc(ray, k_CachedHit, k_MouseInputRaycastDistance, k_GroundLayerMask) > 0)
                     {
-                        if (Physics.RaycastNonAlloc(ray, k_CachedHit, k_MouseInputRaycastDistance, k_GroundLayerMask) > 0)
-                        {
                             m_NetworkCharacter.SendCharacterInputServerRpc(k_CachedHit[0].point);
 
                             //Send our client only click request
                             ClientMoveEvent?.Invoke(k_CachedHit[0].point);
-                        }
                     }
                 }
             }

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
@@ -162,7 +162,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
 
             m_ActionRequestCount = 0;
             
-            if (EventSystem.current.IsPointerOverGameObject() || EventSystem.current.currentSelectedGameObject != null) 
+            if (EventSystem.current.currentSelectedGameObject != null) 
             {
                 return;
             }

--- a/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/Character/ClientInputSender.cs
@@ -161,6 +161,11 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
             }
 
             m_ActionRequestCount = 0;
+            
+            if (EventSystem.current.IsPointerOverGameObject() || EventSystem.current.currentSelectedGameObject != null) 
+            {
+                return;
+            }
 
             if (m_MoveRequest)
             {
@@ -169,12 +174,14 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
                 {
                     m_LastSentMove = Time.time;
                     var ray = m_MainCamera.ScreenPointToRay(Input.mousePosition);
-                    if (Physics.RaycastNonAlloc(ray, k_CachedHit, k_MouseInputRaycastDistance, k_GroundLayerMask) > 0)
                     {
-                        m_NetworkCharacter.SendCharacterInputServerRpc(k_CachedHit[0].point);
+                        if (Physics.RaycastNonAlloc(ray, k_CachedHit, k_MouseInputRaycastDistance, k_GroundLayerMask) > 0)
+                        {
+                            m_NetworkCharacter.SendCharacterInputServerRpc(k_CachedHit[0].point);
 
-                        //Send our client only click request
-                        ClientMoveEvent?.Invoke(k_CachedHit[0].point);
+                            //Send our client only click request
+                            ClientMoveEvent?.Invoke(k_CachedHit[0].point);
+                        }
                     }
                 }
             }

--- a/Assets/BossRoom/Scripts/Client/UI/IPUIMediator.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/IPUIMediator.cs
@@ -24,13 +24,9 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
 
         [SerializeField] IPHostingUI m_IPHostingUI;
 
-        [SerializeField] UITinter m_JoinTabButtonTinter;
-
         [SerializeField] UITinter m_JoinTabButtonHighlightTinter;
         
         [SerializeField] UITinter m_JoinTabButtonTabBlockerTinter;
-
-        [SerializeField] UITinter m_HostTabButtonTinter;
 
         [SerializeField] UITinter m_HostTabButtonHighlightTinter;
         
@@ -122,10 +118,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         {
             m_IPJoiningUI.Show();
             m_IPHostingUI.Hide();
-            m_JoinTabButtonTinter.SetToColor(1);
             m_JoinTabButtonHighlightTinter.SetToColor(1);
             m_JoinTabButtonTabBlockerTinter.SetToColor(1);
-            m_HostTabButtonTinter.SetToColor(0);
             m_HostTabButtonHighlightTinter.SetToColor(0);
             m_HostTabButtonTabBlockerTinter.SetToColor(0);
         }
@@ -134,10 +128,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         {
             m_IPJoiningUI.Hide();
             m_IPHostingUI.Show();
-            m_JoinTabButtonTinter.SetToColor(0);
             m_JoinTabButtonHighlightTinter.SetToColor(0);
             m_JoinTabButtonTabBlockerTinter.SetToColor(0);
-            m_HostTabButtonTinter.SetToColor(1);
             m_HostTabButtonHighlightTinter.SetToColor(1);
             m_HostTabButtonTabBlockerTinter.SetToColor(1);
         }

--- a/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyUIMediator.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyUIMediator.cs
@@ -14,10 +14,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         [SerializeField] CanvasGroup m_CanvasGroup;
         [SerializeField] LobbyJoiningUI m_LobbyJoiningUI;
         [SerializeField] LobbyCreationUI m_LobbyCreationUI;
-        [SerializeField] UITinter m_JoinToggle;
         [SerializeField] UITinter m_JoinToggleHighlight;
         [SerializeField] UITinter m_JoinToggleTabBlocker;
-        [SerializeField] UITinter m_CreateToggle;
         [SerializeField] UITinter m_CreateToggleHighlight;
         [SerializeField] UITinter m_CreateToggleTabBlocker;
         [SerializeField] TextMeshProUGUI m_PlayerNameLabel;
@@ -194,10 +192,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         {
             m_LobbyJoiningUI.Show();
             m_LobbyCreationUI.Hide();
-            m_JoinToggle.SetToColor(1);
             m_JoinToggleHighlight.SetToColor(1);
             m_JoinToggleTabBlocker.SetToColor(1);
-            m_CreateToggle.SetToColor(0);
             m_CreateToggleHighlight.SetToColor(0);
             m_CreateToggleTabBlocker.SetToColor(0);
         }
@@ -206,10 +202,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         {
             m_LobbyJoiningUI.Hide();
             m_LobbyCreationUI.Show();
-            m_JoinToggle.SetToColor(0);
             m_JoinToggleHighlight.SetToColor(0);
             m_JoinToggleTabBlocker.SetToColor(0);
-            m_CreateToggle.SetToColor(1);
             m_CreateToggleHighlight.SetToColor(1);
             m_CreateToggleTabBlocker.SetToColor(1);
         }


### PR DESCRIPTION
### Description (*)
This PR is for a fix for the HUD UI buttons letting movement input through on mobile. After doing a bunch of looking through our settings, building, and testing, the one thing that works is a simple code fix. In fixed update, right before our movement input logic, I use the Event System to check if the pointer is over a game object or if there is currently a selected game object. If there is, we just return. If not, we do the movement logic.

I've also done a bit of clean up on our lobby UI, applying any overrides in the scene to the prefabs, unchecking the raycast target option on some of our graphics, and deleting some unneeded vars in the Lobby and IP UI Mediators leftover from the old lobby UI

Fixes issue(s):
[Here's the Jira ticket](https://jira.unity3d.com/browse/MTT-2890)
