### PR TITLE
fix: OnClientDisconnect callback not unregistering when leaving as host [MTT-2930]

### DIFF
--- a/Packages/com.unity.multiplayer.samples.coop/Utilities/Net/SessionManager.cs
+++ b/Packages/com.unity.multiplayer.samples.coop/Utilities/Net/SessionManager.cs
@@ -155,7 +155,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
                 return playerId;
             }
 
-            Debug.LogError($"No client guid found mapped to the given client ID: {clientId}");
+            Debug.LogError($"No client player ID found mapped to the given client ID: {clientId}");
             return null;
         }
 

--- a/Packages/com.unity.multiplayer.samples.coop/Utilities/Net/SessionManager.cs
+++ b/Packages/com.unity.multiplayer.samples.coop/Utilities/Net/SessionManager.cs
@@ -155,7 +155,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
                 return playerId;
             }
 
-            Debug.LogError($"No client player ID found mapped to the given client ID: {clientId}");
+            Debug.LogError($"No client guid found mapped to the given client ID: {clientId}");
             return null;
         }
 


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
This PR moves the registration of OnClientDisconnect in ServerGameNetPortal to the Start event, and the unregistration to OnDestroy. It also prevents OnClientDisconnect from doing anything if we are not the server, and makes sure everything is cleared and the lobby deleted when disconnecting or when ServerGameNetPortal is destroyed.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
[MTT-2930](https://jira.unity3d.com/browse/MTT-2930)
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
