### PR TITLE
fix: fixing issue with iOS black screen where message queue constructor would get stripped out [MTT-2663]

### DIFF
--- a/Assets/BossRoom/Scripts/Shared/ApplicationController.cs
+++ b/Assets/BossRoom/Scripts/Shared/ApplicationController.cs
@@ -47,13 +47,13 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared
             scope.BindAsSingle<LocalLobby>();
 
             //this message channel is essential and persists for the lifetime of the lobby and relay services
-            scope.BindMessageChannel<UnityServiceErrorMessage>();
+            scope.BindMessageChannelInstance<UnityServiceErrorMessage>();
 
             //this message channel is essential and persists for the lifetime of the lobby and relay services
-            scope.BindMessageChannel<ConnectStatus>();
+            scope.BindMessageChannelInstance<ConnectStatus>();
 
             //buffered message channels hold the latest received message in buffer and pass to any new subscribers
-            scope.BindBufferedMessageChannel<LobbyListFetchedMessage>();
+            scope.BindBufferedMessageChannelInstance<LobbyListFetchedMessage>();
 
             //all the lobby service stuff, bound here so that it persists through scene loads
             scope.BindAsSingle<AuthenticationServiceFacade>(); //a manager entity that allows us to do anonymous authentication with unity services

--- a/Assets/BossRoom/Scripts/Shared/Infrastructure/DIScope.cs
+++ b/Assets/BossRoom/Scripts/Shared/Infrastructure/DIScope.cs
@@ -179,6 +179,18 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Infrastructure
             BindInstanceAsSingle(instance);
         }
 
+        public void BindInstanceAsSingle<TImplementation, TInterface, TInterface2, TInterface3>(TImplementation instance)
+            where TImplementation : class, TInterface, TInterface2, TInterface3
+            where TInterface : class
+            where TInterface2 : class
+            where TInterface3 : class
+        {
+            BindInstanceAsSingle<TInterface>(instance);
+            BindInstanceAsSingle<TInterface2>(instance);
+            BindInstanceAsSingle<TInterface3>(instance);
+            BindInstanceAsSingle(instance);
+        }
+
         void BindInstanceToType(object instance, Type type)
         {
             m_TypesToInstances[type] = instance;

--- a/Assets/BossRoom/Scripts/Shared/Infrastructure/PubSub/MessageChannelDIExtensions.cs
+++ b/Assets/BossRoom/Scripts/Shared/Infrastructure/PubSub/MessageChannelDIExtensions.cs
@@ -2,14 +2,14 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Infrastructure
 {
     public static class MessageChannelDIExtensions
     {
-        public static void BindMessageChannel<TMessage>(this DIScope scope)
+        public static void BindMessageChannelInstance<TMessage>(this DIScope scope)
         {
-            scope.BindAsSingle< MessageChannel<TMessage>, IPublisher<TMessage>, ISubscriber<TMessage>, IMessageChannel<TMessage>>();
+            scope.BindInstanceAsSingle<MessageChannel<TMessage>, IPublisher<TMessage>, ISubscriber<TMessage>, IMessageChannel<TMessage>>(new MessageChannel<TMessage>());
         }
 
-        public static void BindBufferedMessageChannel<TMessage>(this DIScope scope)
+        public static void BindBufferedMessageChannelInstance<TMessage>(this DIScope scope)
         {
-            scope.BindAsSingle< BufferedMessageChannel<TMessage>, IPublisher<TMessage>, ISubscriber<TMessage>, IBufferedMessageChannel<TMessage>>();
+            scope.BindInstanceAsSingle<BufferedMessageChannel<TMessage>, IPublisher<TMessage>, ISubscriber<TMessage>, IBufferedMessageChannel<TMessage>>(new BufferedMessageChannel<TMessage>());
         }
     }
 }


### PR DESCRIPTION


### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
Instead of trying to dynamically spawn message queues using reflection, we're now instantiating them manually in application controller. This way, they won't get stripped out by IL2CPP's code stripping (which can't be deactivated).
Another solution could have been to use ref types for messages instead of value types, since those won't get stripped in generic types. However this creates allocations each time we're sending a message internally which is no bueno.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
MTT-2663

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
