### PR TITLE
fix: arrow despawned rpc [MTT-3134]

### DIFF
--- a/Assets/BossRoom/Scripts/Server/Game/Entity/ServerProjectileLogic.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Entity/ServerProjectileLogic.cs
@@ -82,6 +82,11 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
             m_NpcLayer = LayerMask.NameToLayer("NPCs");
         }
 
+        public override void OnNetworkDespawn()
+        {
+            m_Started = false;
+        }
+
         void FixedUpdate()
         {
             if (!m_Started)


### PR DESCRIPTION
### Description
Without repro steps for the attached ticket, this PR should address the issue for RPCs sent from an arrow on the host. Basically, OnNetworkDespawn() never cleared a flag that prevented any FixedUpdate() logic, thus potentially sending an RPC on a despawned object. This has now been taken care of and will be extensively tested in next test session.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[[MTT](https://jira.unity3d.com/browse/MTT-3134)](https://jira.unity3d.com/browse/MTT-3134)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
