### PR TITLE
feat: message to clients when host ends game session intentionally [MTT-3202]

### DIFF
--- a/Assets/BossRoom/Scripts/Client/UI/ConnectionStatusMessageUIManager.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/ConnectionStatusMessageUIManager.cs
@@ -48,6 +48,9 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
                 case ConnectStatus.GenericDisconnect:
                     PopupPanel.ShowPopupPanel("Disconnected From Host", "The connection to the host was lost.");
                     break;
+                case ConnectStatus.HostEndedSession:
+                    PopupPanel.ShowPopupPanel("Disconnected From Host", "The host has ended the game session.");
+                    break;
                 default:
                     Debug.LogWarning($"New ConnectStatus {status} has been added, but no connect message defined for it.");
                     break;

--- a/Assets/BossRoom/Scripts/Client/UI/UIQuitPanel.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/UIQuitPanel.cs
@@ -30,7 +30,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
             switch (m_QuitMode)
             {
                 case QuitMode.ReturnToMenu:
-                    m_ApplicationController.LeaveSession();
+                    m_ApplicationController.LeaveSession(true);
                     break;
                 case QuitMode.QuitApplication:
                     m_ApplicationController.QuitGame();

--- a/Assets/BossRoom/Scripts/Shared/ApplicationController.cs
+++ b/Assets/BossRoom/Scripts/Shared/ApplicationController.cs
@@ -112,15 +112,18 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared
             return canQuit;
         }
 
-        public void LeaveSession()
+        public void LeaveSession(bool UserRequested)
         {
             m_LobbyServiceFacade.EndTracking();
 
-            // first disconnect then return to menu
-            var gameNetPortal = GameNetPortal.Instance;
-            if (gameNetPortal != null)
+            if (UserRequested)
             {
-                gameNetPortal.RequestDisconnect();
+                // first disconnect then return to menu
+                var gameNetPortal = GameNetPortal.Instance;
+                if (gameNetPortal != null)
+                {
+                    gameNetPortal.RequestDisconnect();
+                }
             }
             SceneManager.LoadScene("MainMenu");
         }

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ClientGameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ClientGameNetPortal.cs
@@ -95,6 +95,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
             if (m_Portal.NetManager.IsClient)
             {
                 DisconnectReason.SetDisconnectReason(ConnectStatus.UserRequestedDisconnect);
+                m_Portal.NetManager.Shutdown();
             }
         }
 
@@ -147,7 +148,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
                         //disconnect that happened for some other reason than user UI interaction--should display a message.
                         DisconnectReason.SetDisconnectReason(ConnectStatus.GenericDisconnect);
                     }
-                    m_ApplicationController.LeaveSession();
+                    m_ApplicationController.LeaveSession(false);
                 }
                 else
                 {

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/GameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/GameNetPortal.cs
@@ -20,7 +20,8 @@ namespace Unity.Multiplayer.Samples.BossRoom
         LoggedInAgain,            //logged in on a separate client, causing this one to be kicked out.
         UserRequestedDisconnect,  //Intentional Disconnect triggered by the user.
         GenericDisconnect,        //server disconnected, but no specific reason given.
-        IncompatibleBuildType,      //client build type is incompatible with server.
+        IncompatibleBuildType,    //client build type is incompatible with server.
+        HostEndedSession,         //host intentionally ended the session.
     }
 
     public enum OnlineMode
@@ -245,7 +246,6 @@ namespace Unity.Multiplayer.Samples.BossRoom
             m_ClientPortal.OnUserDisconnectRequest();
             m_ServerPortal.OnUserDisconnectRequest();
             SessionManager<SessionPlayerData>.Instance.OnUserDisconnectRequest();
-            NetManager.Shutdown();
         }
 
         public string GetPlayerId()

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ServerGameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ServerGameNetPortal.cs
@@ -130,6 +130,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
             if (m_Portal.NetManager.IsHost)
             {
                 SendServerToAllClientsSetDisconnectReason(ConnectStatus.HostEndedSession);
+                // Wait before shutting down to make sure clients receive that message before they are disconnected
                 StartCoroutine(WaitToShutdown());
             }
             Clear();


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
This PR adds a message for when the host ends a game session voluntarily. It also makes sure that RequestDisconnect is only called when a disconnect is actually requested, so that it does not overwrite the disconnect reason that was received.
### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
[MTT-3202](https://jira.unity3d.com/browse/MTT-3202)
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
