### PR TITLE
chore/fix: remove online mode and IP/port from lobbies [MTT-3214]

### DIFF
--- a/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyCreationUI.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyCreationUI.cs
@@ -11,7 +11,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         [SerializeField] Toggle m_IsPrivate;
         [SerializeField] CanvasGroup m_CanvasGroup;
         LobbyUIMediator m_LobbyUIMediator;
-        OnlineMode m_OnlineMode;
 
         void Awake()
         {
@@ -26,14 +25,12 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
 
         void EnableUnityRelayUI()
         {
-            m_OnlineMode = OnlineMode.UnityRelay;
-
             m_LoadingIndicatorObject.SetActive(false);
         }
 
         public void OnCreateClick()
         {
-            m_LobbyUIMediator.CreateLobbyRequest(m_LobbyNameInputField.text, m_IsPrivate.isOn, 8, m_OnlineMode);
+            m_LobbyUIMediator.CreateLobbyRequest(m_LobbyNameInputField.text, m_IsPrivate.isOn, 8);
         }
 
         public void Show()

--- a/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyListItemUI.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyListItemUI.cs
@@ -12,7 +12,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
     {
         [SerializeField] TextMeshProUGUI m_lobbyNameText;
         [SerializeField] TextMeshProUGUI m_lobbyCountText;
-        [SerializeField] TextMeshProUGUI m_OnlineModeText;
 
         LobbyUIMediator m_LobbyUIMediator;
         LocalLobby m_Data;
@@ -28,7 +27,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
             m_Data = data;
             m_lobbyNameText.SetText(data.LobbyName);
             m_lobbyCountText.SetText($"{data.PlayerCount}/{data.MaxPlayerCount}");
-            m_OnlineModeText.SetText(data.OnlineMode.ToString());
         }
 
         public void OnClick()

--- a/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyUIMediator.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyUIMediator.cs
@@ -62,7 +62,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
 
         //Lobby and Relay calls done from UI
 
-        public void CreateLobbyRequest(string lobbyName, bool isPrivate, int maxPlayers, OnlineMode onlineMode)
+        public void CreateLobbyRequest(string lobbyName, bool isPrivate, int maxPlayers)
         {
             // before sending request to lobby service, populate an empty lobby name, if necessary
             if (string.IsNullOrEmpty(lobbyName))
@@ -70,7 +70,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
                 lobbyName = k_DefaultLobbyName;
             }
 
-            m_LobbyServiceFacade.CreateLobbyAsync(lobbyName, maxPlayers, isPrivate, onlineMode, OnCreatedLobby, OnFailedLobbyCreateOrJoin);
+            m_LobbyServiceFacade.CreateLobbyAsync(lobbyName, maxPlayers, isPrivate, OnCreatedLobby, OnFailedLobbyCreateOrJoin);
             BlockUIWhileLoadingIsInProgress();
         }
 
@@ -132,18 +132,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
 
             m_GameNetPortal.PlayerName = m_LocalUser.DisplayName;
 
-            switch (m_LocalLobby.OnlineMode)
-            {
-                case OnlineMode.IpHost:
-                    Debug.Log($"Created lobby with ID: {m_LocalLobby.LobbyID} and code {m_LocalLobby.LobbyCode}, at IP:Port {m_LocalLobby.Data.IP}:{m_LocalLobby.Data.Port}");
-                    m_GameNetPortal.StartHost(m_LocalLobby.Data.IP, m_LocalLobby.Data.Port);
-                    break;
-
-                case OnlineMode.UnityRelay:
-                    Debug.Log($"Created lobby with ID: {m_LocalLobby.LobbyID} and code {m_LocalLobby.LobbyCode}, Internal Relay Join Code{m_LocalLobby.RelayJoinCode}");
-                    m_GameNetPortal.StartUnityRelayHost();
-                    break;
-            }
+            Debug.Log($"Created lobby with ID: {m_LocalLobby.LobbyID} and code {m_LocalLobby.LobbyCode}, Internal Relay Join Code{m_LocalLobby.RelayJoinCode}");
+            m_GameNetPortal.StartUnityRelayHost();
         }
 
         void OnJoinedLobby(Lobby remoteLobby)
@@ -151,18 +141,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
             m_LobbyServiceFacade.SetRemoteLobby(remoteLobby);
             m_GameNetPortal.PlayerName = m_LocalUser.DisplayName;
 
-            switch (m_LocalLobby.OnlineMode)
-            {
-                case OnlineMode.IpHost:
-                    Debug.Log($"Joined lobby with code: {m_LocalLobby.LobbyCode}, at IP:Port {m_LocalLobby.Data.IP}:{m_LocalLobby.Data.Port}");
-                    m_ClientNetPortal.StartClient(m_LocalLobby.Data.IP, m_LocalLobby.Data.Port);
-                    break;
-
-                case OnlineMode.UnityRelay:
-                    Debug.Log($"Joined lobby with code: {m_LocalLobby.LobbyCode}, Internal Relay Join Code{m_LocalLobby.RelayJoinCode}");
-                    m_ClientNetPortal.StartClientUnityRelayModeAsync(m_LocalLobby.RelayJoinCode, OnRelayJoinFailed);
-                    break;
-            }
+            Debug.Log($"Joined lobby with code: {m_LocalLobby.LobbyCode}, Internal Relay Join Code{m_LocalLobby.RelayJoinCode}");
+            m_ClientNetPortal.StartClientUnityRelayModeAsync(m_LocalLobby.RelayJoinCode, OnRelayJoinFailed);
 
             void OnRelayJoinFailed(string message)
             {

--- a/Assets/BossRoom/Scripts/Client/UI/RoomNameBox.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/RoomNameBox.cs
@@ -1,5 +1,4 @@
 using System;
-using Unity.Multiplayer.Samples.BossRoom;
 using UnityEngine;
 using TMPro;
 using Unity.Multiplayer.Samples.BossRoom.Shared.Infrastructure;
@@ -24,6 +23,11 @@ public class RoomNameBox : MonoBehaviour
         UpdateUI(localLobby);
     }
 
+    void Awake()
+    {
+        gameObject.SetActive(false);
+    }
+
     private void OnDestroy()
     {
         m_LocalLobby.changed -= UpdateUI;
@@ -31,22 +35,12 @@ public class RoomNameBox : MonoBehaviour
 
     private void UpdateUI(LocalLobby localLobby)
     {
-        switch (localLobby.OnlineMode)
+        if (!string.IsNullOrEmpty(localLobby.LobbyCode))
         {
-            case OnlineMode.IpHost:
-            case OnlineMode.UnityRelay:
-                m_LobbyCode = localLobby.LobbyCode;
-                m_RoomNameText.text = $"Lobby Code: {m_LobbyCode}";
-                m_CopyToClipboardButton.gameObject.SetActive(true);
-                break;
-            case OnlineMode.Unset:
-                //this can happen if we launch the game while circumventing lobby logic
-                m_LobbyCode = "";
-                m_RoomNameText.text = $"-----------";
-                m_CopyToClipboardButton.gameObject.SetActive(false);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
+            m_LobbyCode = localLobby.LobbyCode;
+            m_RoomNameText.text = $"Lobby Code: {m_LobbyCode}";
+            gameObject.SetActive(true);
+            m_CopyToClipboardButton.gameObject.SetActive(true);
         }
     }
 

--- a/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LobbyServiceFacade.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LobbyServiceFacade.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Unity.Multiplayer.Samples.BossRoom.Shared.Infrastructure;
 using Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Infrastructure;
 using Unity.Services.Authentication;
@@ -145,7 +144,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
         /// <summary>
         /// Attempt to create a new lobby and then join it.
         /// </summary>
-        public void CreateLobbyAsync(string lobbyName, int maxPlayers, bool isPrivate, OnlineMode onlineMode, Action<Lobby> onSuccess, Action onFailure)
+        public void CreateLobbyAsync(string lobbyName, int maxPlayers, bool isPrivate, Action<Lobby> onSuccess, Action onFailure)
         {
             if (!m_RateLimitHost.CanCall)
             {
@@ -156,12 +155,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
 
             m_RateLimitHost.PutOnCooldown();
 
-            var initialLobbyData = new Dictionary<string, DataObject>()
-            {
-                {"OnlineMode", new DataObject(DataObject.VisibilityOptions.Public, ((int)onlineMode).ToString())}
-            };
-
-            m_LobbyApiInterface.CreateLobbyAsync(AuthenticationService.Instance.PlayerId, lobbyName, maxPlayers, isPrivate, m_LocalUser.GetDataForUnityServices(), initialLobbyData, onSuccess, onFailure);
+            m_LobbyApiInterface.CreateLobbyAsync(AuthenticationService.Instance.PlayerId, lobbyName, maxPlayers, isPrivate, m_LocalUser.GetDataForUnityServices(), null, onSuccess, onFailure);
         }
 
         /// <summary>
@@ -351,7 +345,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
             }
 
             //we would want to lock lobbies from appearing in queries if we're in relay mode and the relay isn't fully set up yet
-            var shouldLock = m_LocalLobby.OnlineMode == OnlineMode.UnityRelay && string.IsNullOrEmpty(m_LocalLobby.RelayJoinCode);
+            var shouldLock = string.IsNullOrEmpty(m_LocalLobby.RelayJoinCode);
 
             m_LobbyApiInterface.UpdateLobbyAsync(CurrentUnityLobby.Id, dataCurr, shouldLock, OnComplete, onFailure);
 

--- a/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LocalLobby.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LocalLobby.cs
@@ -45,10 +45,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
             public bool Private { get; set; }
             public int MaxPlayerCount { get; set; }
 
-            public OnlineMode OnlineMode { get; set; }
-            public string IP { get; set; }
-            public int Port { get; set; }
-
             public LobbyData(LobbyData existing)
             {
                 LobbyID = existing.LobbyID;
@@ -57,9 +53,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
                 LobbyName = existing.LobbyName;
                 Private = existing.Private;
                 MaxPlayerCount = existing.MaxPlayerCount;
-                OnlineMode = existing.OnlineMode;
-                IP = existing.IP;
-                Port = existing.Port;
             }
 
             public LobbyData(string lobbyCode)
@@ -70,9 +63,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
                 LobbyName = null;
                 Private = false;
                 MaxPlayerCount = -1;
-                OnlineMode = OnlineMode.Unset;
-                IP = string.Empty;
-                Port = 0;
             }
         }
 
@@ -184,18 +174,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
             }
         }
 
-        public OnlineMode OnlineMode
-        {
-            get => m_Data.OnlineMode;
-            set
-            {
-                if (m_Data.OnlineMode != value)
-                {   m_Data.OnlineMode = value;
-                    OnChanged();
-                }
-            }
-        }
-
         public void CopyDataFrom(LobbyData data, Dictionary<string, LocalLobbyUser> currUsers)
         {
             m_Data = data;
@@ -239,10 +217,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
         public Dictionary<string, DataObject> GetDataForUnityServices() =>
             new Dictionary<string, DataObject>()
             {
-                {"RelayJoinCode", new DataObject(DataObject.VisibilityOptions.Public,  RelayJoinCode)},
-                {"OnlineMode", new DataObject(DataObject.VisibilityOptions.Public, ((int)Data.OnlineMode).ToString())},
-                {"IP", new DataObject(DataObject.VisibilityOptions.Public, Data.IP)},
-                {"Port", new DataObject(DataObject.VisibilityOptions.Public,  Data.Port.ToString())},
+                {"RelayJoinCode", new DataObject(DataObject.VisibilityOptions.Public,  RelayJoinCode)}
             };
 
         public void ApplyRemoteData(Lobby lobby)
@@ -257,16 +232,10 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
             if (lobby.Data != null)
             {
                 info.RelayJoinCode = lobby.Data.ContainsKey("RelayJoinCode") ? lobby.Data["RelayJoinCode"].Value : null; // By providing RelayCode through the lobby data with Member visibility, we ensure a client is connected to the lobby before they could attempt a relay connection, preventing timing issues between them.
-                info.OnlineMode = lobby.Data.ContainsKey("OnlineMode") ? (OnlineMode) int.Parse(lobby.Data["OnlineMode"].Value) : OnlineMode.Unset;
-                info.IP = lobby.Data.ContainsKey("IP") ? lobby.Data["IP"].Value : string.Empty;
-                info.Port =  lobby.Data.ContainsKey("Port") ? int.Parse(lobby.Data["Port"].Value) : 0;
             }
             else
             {
                 info.RelayJoinCode = null;
-                info.OnlineMode = OnlineMode.Unset;
-                info.IP = string.Empty;
-                info.Port = 0;
             }
 
             var lobbyUsers = new Dictionary<string, LocalLobbyUser>();


### PR DESCRIPTION
### Description
This PR removes IP/Port and OnlineMode from lobbies since direct IP flow has been moved into its own debug flow and lobbies are relay-based. A suspicion here is that old lobbies won't be able to connect to these new lobbies.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[MTT-3214](https://jira.unity3d.com/browse/MTT-3214)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
