### PR TITLE
fix: silencing errors that are not errors [MTT-2930] [MTT-3249]

### DIFF
--- a/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LobbyAPIInterface.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LobbyAPIInterface.cs
@@ -119,8 +119,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
             {
                 await ExceptionHandling(Lobbies.Instance.RemovePlayerAsync(lobbyId, requesterUasId));
             }
-            catch (Exception e)
-                when (e is LobbyServiceException {Reason: LobbyExceptionReason.PlayerNotFound})
+            catch (LobbyServiceException e)
+                when (e is {Reason: LobbyExceptionReason.PlayerNotFound})
             {
                 // If Player is not found, they have already left the lobby or have been kicked out. No need to throw here
             }

--- a/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LobbyAPIInterface.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LobbyAPIInterface.cs
@@ -115,7 +115,15 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
 
         public async Task RemovePlayerFromLobby(string requesterUasId, string lobbyId)
         {
-           await ExceptionHandling(Lobbies.Instance.RemovePlayerAsync(lobbyId, requesterUasId));
+            try
+            {
+                await ExceptionHandling(Lobbies.Instance.RemovePlayerAsync(lobbyId, requesterUasId));
+            }
+            catch (Exception e)
+                when (e is LobbyServiceException {Reason: LobbyExceptionReason.PlayerNotFound})
+            {
+                // If Player is not found, they have already left the lobby or have been kicked out. No need to throw here
+            }
         }
 
         public async Task<QueryResponse> QueryAllLobbies()

--- a/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LobbyServiceFacade.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LobbyServiceFacade.cs
@@ -286,7 +286,18 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
         {
             if (m_LocalUser.IsHost)
             {
-                await m_LobbyApiInterface.RemovePlayerFromLobby(uasId, lobbyId);
+                try
+                {
+                    await m_LobbyApiInterface.RemovePlayerFromLobby(uasId, lobbyId);
+                }
+                catch (Exception e)
+                {
+                    if (!(e is LobbyServiceException {Reason: LobbyExceptionReason.PlayerNotFound}))
+                    {
+                        throw;
+                    }
+                }
+
             }
             else
             {

--- a/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LobbyServiceFacade.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LobbyServiceFacade.cs
@@ -286,15 +286,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
         {
             if (m_LocalUser.IsHost)
             {
-                try
-                {
-                    await m_LobbyApiInterface.RemovePlayerFromLobby(uasId, lobbyId);
-                }
-                catch (Exception e)
-                    when (e is LobbyServiceException {Reason: LobbyExceptionReason.PlayerNotFound})
-                {
-                }
-
+                await m_LobbyApiInterface.RemovePlayerFromLobby(uasId, lobbyId);
             }
             else
             {

--- a/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LobbyServiceFacade.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Lobbies/LobbyServiceFacade.cs
@@ -291,11 +291,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies
                     await m_LobbyApiInterface.RemovePlayerFromLobby(uasId, lobbyId);
                 }
                 catch (Exception e)
+                    when (e is LobbyServiceException {Reason: LobbyExceptionReason.PlayerNotFound})
                 {
-                    if (!(e is LobbyServiceException {Reason: LobbyExceptionReason.PlayerNotFound}))
-                    {
-                        throw;
-                    }
                 }
 
             }

--- a/Packages/com.unity.multiplayer.samples.coop/Utilities/Net/SessionManager.cs
+++ b/Packages/com.unity.multiplayer.samples.coop/Utilities/Net/SessionManager.cs
@@ -142,7 +142,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
                 return playerId;
             }
 
-            Debug.LogError($"No client player ID found mapped to the given client ID: {clientId}");
+            Debug.Log($"No client player ID found mapped to the given client ID: {clientId}");
             return null;
         }
 
@@ -160,7 +160,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
                 return GetPlayerData(playerId);
             }
 
-            Debug.LogError($"No client player ID found mapped to the given client ID: {clientId}");
+            Debug.Log($"No client player ID found mapped to the given client ID: {clientId}");
             return null;
         }
 
@@ -176,7 +176,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
                 return data;
             }
 
-            Debug.LogError($"No PlayerData of matching player ID found: {playerId}");
+            Debug.Log($"No PlayerData of matching player ID found: {playerId}");
             return null;
         }
 


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
This is a quick PR to prevent RemovePlayerFromLobbyAsync from throwing a PlayerNotFound exception, which is something that is already handled. It also changes the error logs for when SessionManager does not find a player's session data to regular logs, since this is also already handled game-side through the null return value.
### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
[MTT-3249](https://jira.unity3d.com/browse/MTT-3249) & [MTT-2930](https://jira.unity3d.com/browse/MTT-2930)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
