### PR TITLE
fix: Alpha4 input press doesn't open emote drawer on UI [MTT-3236]

### DIFF
--- a/Assets/BossRoom/Scripts/Client/UI/HeroActionBar.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/HeroActionBar.cs
@@ -197,6 +197,11 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
             // If we have another player selected, see if their aliveness state has changed,
             // and if so, update the interactiveness of the basic-action button
 
+            if (Input.GetKeyUp(KeyCode.Alpha4))
+            {
+                m_ButtonInfo[ActionButtonType.EmoteBar].Button.OnPointerUpEvent.Invoke();
+            }
+
             if (!m_SelectedPlayerNetState) { return; }
 
             bool isAliveNow = m_SelectedPlayerNetState.NetworkLifeState.LifeState.Value == LifeState.Alive;


### PR DESCRIPTION
### Description
Input was never detected for opening emote drawer. An input check for Alpha4 has been added to `HeroActionBar` to open/close emote drawer.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[MTT-3236](https://jira.unity3d.com/browse/MTT-3236)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
