### PR TITLE
fix: only server finds navigation object, asserts refactored [MTT-3248]

### DIFF
--- a/Assets/BossRoom/Scripts/Client/UI/UIStateDisplayHandler.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/UIStateDisplayHandler.cs
@@ -79,11 +79,14 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
                 return;
             }
 
-            m_Camera = Camera.main;
+            m_Camera = GameObject.FindWithTag("MainCamera").GetComponent<Camera>();
+            Assert.IsNotNull(m_Camera);
+
             var canvasGameObject = GameObject.FindWithTag("GameCanvas");
             if (canvasGameObject)
             {
                 m_CanvasTransform = canvasGameObject.transform;
+                Assert.IsNotNull(m_CanvasTransform);
             }
 
             Assert.IsTrue(m_DisplayHealth || m_DisplayName, "Neither display fields are toggled on!");
@@ -91,7 +94,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
             {
                 Assert.IsNotNull(m_NetworkHealthState, "A NetworkHealthState component needs to be attached!");
             }
-            Assert.IsTrue(m_Camera != null && m_CanvasTransform != null);
 
             m_VerticalOffset = new Vector3(0f, m_VerticalScreenOffset, 0f);
 

--- a/Assets/BossRoom/Scripts/Client/UI/UIStateDisplayHandler.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/UIStateDisplayHandler.cs
@@ -79,15 +79,19 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
                 return;
             }
 
-            m_Camera = GameObject.FindWithTag("MainCamera").GetComponent<Camera>();
+            var cameraGameObject = GameObject.FindWithTag("MainCamera");
+            if (cameraGameObject)
+            {
+                m_Camera = cameraGameObject.GetComponent<Camera>();
+            }
             Assert.IsNotNull(m_Camera);
 
             var canvasGameObject = GameObject.FindWithTag("GameCanvas");
             if (canvasGameObject)
             {
                 m_CanvasTransform = canvasGameObject.transform;
-                Assert.IsNotNull(m_CanvasTransform);
             }
+            Assert.IsNotNull(m_CanvasTransform);
 
             Assert.IsTrue(m_DisplayHealth || m_DisplayName, "Neither display fields are toggled on!");
             if (m_DisplayHealth)

--- a/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacterMovement.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacterMovement.cs
@@ -54,9 +54,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
         public bool SpeedCheatActivated { get; set; }
 #endif
 
-        private void Awake()
+        void Awake()
         {
-            m_NavigationSystem = GameObject.FindGameObjectWithTag(NavigationSystem.NavigationSystemTag).GetComponent<NavigationSystem>();
             // disable this NetworkBehavior until it is spawned
             enabled = false;
         }
@@ -70,6 +69,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
 
                 // On the server enable navMeshAgent and initialize
                 m_NavMeshAgent.enabled = true;
+                m_NavigationSystem = GameObject.FindGameObjectWithTag(NavigationSystem.NavigationSystemTag).GetComponent<NavigationSystem>();
                 m_NavPath = new DynamicNavPath(m_NavMeshAgent, m_NavigationSystem);
             }
         }


### PR DESCRIPTION
### Description
This PR resolves an issue encountered when late-joining a lobby that was already mid-game. Granted, the scenario described was never reproduced, but it likely came from a scene init race condition on spawned characters (including imps/boss) and the navigation object inside the Boss Room scene. This moves that critical `GameObject.Find` to the NetworkObject's `OnNetworkSpawn()`, when both are guaranteed to have invoked `Awake()`. It also removes an unnecessary `GameObject.Find` calculation performed on clients.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[MTT-3248](https://jira.unity3d.com/browse/MTT-3248)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
