### PR TITLE
fix: relogin when auth token is stale [MTT-3253]

### DIFF
--- a/Assets/BossRoom/Scripts/Client/Game/State/ClientMainMenuState.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/State/ClientMainMenuState.cs
@@ -55,7 +55,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
                     unityAuthenticationInitOptions.SetProfile(profile);
                 }
 
-                await authServiceFacade.SignInAsync(unityAuthenticationInitOptions);
+                await authServiceFacade.InitializeAndSignInAsync(unityAuthenticationInitOptions);
                 OnAuthSignIn();
             }
             catch (Exception)

--- a/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyUIMediator.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyUIMediator.cs
@@ -76,7 +76,14 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
 
             BlockUIWhileLoadingIsInProgress();
 
-            await m_AuthenticationServiceFacade.ReloginIfNecessary();
+            bool playerIsAuthorized = await m_AuthenticationServiceFacade.EnsurePlayerIsAuthorized();
+
+            if (!playerIsAuthorized)
+            {
+                UnblockUIAfterLoadingIsComplete();
+                return;
+            }
+
             var lobbyCreationAttempt = await m_LobbyServiceFacade.TryCreateLobbyAsync(lobbyName, maxPlayers, isPrivate);
 
             if (lobbyCreationAttempt.Success)
@@ -107,8 +114,14 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
                 BlockUIWhileLoadingIsInProgress();
             }
 
+            bool playerIsAuthorized = await m_AuthenticationServiceFacade.EnsurePlayerIsAuthorized();
 
-            await m_AuthenticationServiceFacade.ReloginIfNecessary();
+            if (!playerIsAuthorized)
+            {
+                UnblockUIAfterLoadingIsComplete();
+                return;
+            }
+
             await m_LobbyServiceFacade.RetrieveAndPublishLobbyListAsync();
             UnblockUIAfterLoadingIsComplete();
         }
@@ -117,7 +130,14 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         {
             BlockUIWhileLoadingIsInProgress();
 
-            await m_AuthenticationServiceFacade.ReloginIfNecessary();
+            bool playerIsAuthorized = await m_AuthenticationServiceFacade.EnsurePlayerIsAuthorized();
+
+            if (!playerIsAuthorized)
+            {
+                UnblockUIAfterLoadingIsComplete();
+                return;
+            }
+
             var result = await m_LobbyServiceFacade.TryJoinLobbyAsync(null, lobbyCode);
 
             if (result.Success)
@@ -134,7 +154,14 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         {
             BlockUIWhileLoadingIsInProgress();
 
-            await m_AuthenticationServiceFacade.ReloginIfNecessary();
+            bool playerIsAuthorized = await m_AuthenticationServiceFacade.EnsurePlayerIsAuthorized();
+
+            if (!playerIsAuthorized)
+            {
+                UnblockUIAfterLoadingIsComplete();
+                return;
+            }
+
             var result = await m_LobbyServiceFacade.TryJoinLobbyAsync(lobby.LobbyID, lobby.LobbyCode);
 
             if (result.Success)
@@ -151,7 +178,14 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         {
             BlockUIWhileLoadingIsInProgress();
 
-            await m_AuthenticationServiceFacade.ReloginIfNecessary();
+            bool playerIsAuthorized = await m_AuthenticationServiceFacade.EnsurePlayerIsAuthorized();
+
+            if (!playerIsAuthorized)
+            {
+                UnblockUIAfterLoadingIsComplete();
+                return;
+            }
+
             var result = await m_LobbyServiceFacade.TryQuickJoinLobbyAsync();
 
             if (result.Success)

--- a/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyUIMediator.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/Lobby/LobbyUIMediator.cs
@@ -1,4 +1,5 @@
 using System;
+using BossRoom.Scripts.Shared.Net.UnityServices.Auth;
 using TMPro;
 using Unity.Multiplayer.Samples.BossRoom.Client;
 using Unity.Multiplayer.Samples.BossRoom.Shared.Infrastructure;
@@ -21,6 +22,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         [SerializeField] TextMeshProUGUI m_PlayerNameLabel;
         [SerializeField] GameObject m_LoadingSpinner;
 
+        AuthenticationServiceFacade m_AuthenticationServiceFacade;
         LobbyServiceFacade m_LobbyServiceFacade;
         LocalLobbyUser m_LocalUser;
         LocalLobby m_LocalLobby;
@@ -32,6 +34,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
 
         [Inject]
         void InjectDependenciesAndInitialize(
+            AuthenticationServiceFacade authenticationServiceFacade,
             LobbyServiceFacade lobbyServiceFacade,
             LocalLobbyUser localUser,
             LocalLobby localLobby,
@@ -40,6 +43,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
             ClientGameNetPortal clientGameNetPortal
         )
         {
+            m_AuthenticationServiceFacade = authenticationServiceFacade;
             m_NameGenerationData = nameGenerationData;
             m_LocalUser = localUser;
             m_LobbyServiceFacade = lobbyServiceFacade;
@@ -72,6 +76,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
 
             BlockUIWhileLoadingIsInProgress();
 
+            await m_AuthenticationServiceFacade.ReloginIfNecessary();
             var lobbyCreationAttempt = await m_LobbyServiceFacade.TryCreateLobbyAsync(lobbyName, maxPlayers, isPrivate);
 
             if (lobbyCreationAttempt.Success)
@@ -102,6 +107,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
                 BlockUIWhileLoadingIsInProgress();
             }
 
+
+            await m_AuthenticationServiceFacade.ReloginIfNecessary();
             await m_LobbyServiceFacade.RetrieveAndPublishLobbyListAsync();
             UnblockUIAfterLoadingIsComplete();
         }
@@ -110,6 +117,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         {
             BlockUIWhileLoadingIsInProgress();
 
+            await m_AuthenticationServiceFacade.ReloginIfNecessary();
             var result = await m_LobbyServiceFacade.TryJoinLobbyAsync(null, lobbyCode);
 
             if (result.Success)
@@ -126,6 +134,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         {
             BlockUIWhileLoadingIsInProgress();
 
+            await m_AuthenticationServiceFacade.ReloginIfNecessary();
             var result = await m_LobbyServiceFacade.TryJoinLobbyAsync(lobby.LobbyID, lobby.LobbyCode);
 
             if (result.Success)
@@ -142,6 +151,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         {
             BlockUIWhileLoadingIsInProgress();
 
+            await m_AuthenticationServiceFacade.ReloginIfNecessary();
             var result = await m_LobbyServiceFacade.TryQuickJoinLobbyAsync();
 
             if (result.Success)

--- a/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Auth/AuthenticationServiceFacade.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Auth/AuthenticationServiceFacade.cs
@@ -18,7 +18,7 @@ namespace BossRoom.Scripts.Shared.Net.UnityServices.Auth
             m_UnityServiceErrorMessagePublisher = unityServiceErrorMessagePublisher;
         }
 
-        public async Task SignInAsync(InitializationOptions initializationOptions)
+        public async Task InitializeAndSignInAsync(InitializationOptions initializationOptions)
         {
             try
             {
@@ -35,8 +35,24 @@ namespace BossRoom.Scripts.Shared.Net.UnityServices.Auth
                 m_UnityServiceErrorMessagePublisher.Publish(new UnityServiceErrorMessage("Authentication Error", reason, UnityServiceErrorMessage.Service.Authentication, e));
                 throw;
             }
-
-
         }
+
+        public async Task ReloginIfNecessary()
+        {
+            try
+            {
+                if (!AuthenticationService.Instance.IsAuthorized)
+                {
+                    await AuthenticationService.Instance.SignInAnonymouslyAsync();
+                }
+            }
+            catch (Exception e)
+            {
+                var reason = $"{e.Message} ({e.InnerException?.Message})";
+                m_UnityServiceErrorMessagePublisher.Publish(new UnityServiceErrorMessage("Authentication Error", reason, UnityServiceErrorMessage.Service.Authentication, e));
+                throw;
+            }
+        }
+
     }
 }

--- a/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Auth/AuthenticationServiceFacade.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/UnityServices/Auth/AuthenticationServiceFacade.cs
@@ -37,17 +37,28 @@ namespace BossRoom.Scripts.Shared.Net.UnityServices.Auth
             }
         }
 
-        public async Task ReloginIfNecessary()
+        public async Task<bool> EnsurePlayerIsAuthorized()
         {
+            if (AuthenticationService.Instance.IsAuthorized)
+            {
+                return true;
+            }
+
             try
             {
-                if (!AuthenticationService.Instance.IsAuthorized)
-                {
-                    await AuthenticationService.Instance.SignInAnonymouslyAsync();
-                }
+                await AuthenticationService.Instance.SignInAnonymouslyAsync();
+                return true;
+            }
+            catch (AuthenticationException e)
+            {
+                var reason = $"{e.Message} ({e.InnerException?.Message})";
+                m_UnityServiceErrorMessagePublisher.Publish(new UnityServiceErrorMessage("Authentication Error", reason, UnityServiceErrorMessage.Service.Authentication, e));
+                //not rethrowing for authentication exceptions - any failure to authenticate is considered "handled failure"
+                return false;
             }
             catch (Exception e)
             {
+                //all other exceptions should still bubble up as unhandled ones
                 var reason = $"{e.Message} ({e.InnerException?.Message})";
                 m_UnityServiceErrorMessagePublisher.Publish(new UnityServiceErrorMessage("Authentication Error", reason, UnityServiceErrorMessage.Service.Authentication, e));
                 throw;


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
Added a relogin function to the AuthenticationServiceFacade - it checks if we're no longer authenticated to do api calls and then re-signs in.

This is to prevent HTTP 401 when our token expires.

In order to prevent any potential issues when the UI was left hanging for a long time - we do a relogin attempt (which immediately bounces, if it's not needed) before any of the lobby calls from the UI. 

UI now also handles the failure to reconnect - it would unlock the UI's but would NOT do the lobby calls that require us to be authenticated. UI resets itself to try again, essentially. 

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
MTT-3253
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
