### PR TITLE
fix: scene loading issue when shutting down [MTT-2828]

### DIFF
--- a/Assets/BossRoom/Scenes/PostGame.unity
+++ b/Assets/BossRoom/Scenes/PostGame.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4c11f84c175b1dd9496d25f84bd4e0c29ca64c90df9346d1f26578dfef5523f6
-size 56409
+oid sha256:8396657ee40387e39344857a6fdaf264df857bf1386f7f766e830dfc97b2270e
+size 56639

--- a/Assets/BossRoom/Scripts/Client/UI/PostGameUI.cs
+++ b/Assets/BossRoom/Scripts/Client/UI/PostGameUI.cs
@@ -1,5 +1,7 @@
 using UnityEngine;
 using TMPro;
+using Unity.Multiplayer.Samples.BossRoom.Shared;
+using Unity.Multiplayer.Samples.BossRoom.Shared.Infrastructure;
 using Unity.Multiplayer.Samples.Utilities;
 using Unity.Netcode;
 
@@ -33,6 +35,14 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
 
         [SerializeField]
         private Color m_LoseLightColor;
+
+        ApplicationController m_ApplicationController;
+
+        [Inject]
+        void InjectDependencies(ApplicationController applicationController)
+        {
+            m_ApplicationController = applicationController;
+        }
 
         void Start()
         {
@@ -75,18 +85,14 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         public void OnPlayAgainClicked()
         {
             // this should only ever be called by the Host - so just go ahead and switch scenes
-            SceneLoaderWrapper.Instance.LoadScene("CharSelect");
+            SceneLoaderWrapper.Instance.LoadScene("CharSelect", useNetworkSceneManager: true);
 
             // FUTURE: could be improved to better support a dedicated server architecture
         }
 
         public void OnMainMenuClicked()
         {
-            // Player is leaving this group - leave current network connection first
-            var gameNetPortal = GameObject.FindGameObjectWithTag("GameNetPortal").GetComponent<GameNetPortal>();
-            gameNetPortal.RequestDisconnect();
-
-            SceneLoaderWrapper.Instance.LoadScene("MainMenu");
+            m_ApplicationController.LeaveSession(true);
         }
     }
 }

--- a/Assets/BossRoom/Scripts/DebugCheats/DebugCheatsManager.cs
+++ b/Assets/BossRoom/Scripts/DebugCheats/DebugCheatsManager.cs
@@ -283,7 +283,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Debug
         [ServerRpc(RequireOwnership = false)]
         void GoToPostGameServerRpc(ServerRpcParams serverRpcParams = default)
         {
-            SceneLoaderWrapper.Instance.LoadScene("PostGame", LoadSceneMode.Single);
+            SceneLoaderWrapper.Instance.LoadScene("PostGame", useNetworkSceneManager: true);
             LogCheatUsedClientRPC(serverRpcParams.Receive.SenderClientId, "GoToPostGame");
         }
 

--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerBossRoomState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerBossRoomState.cs
@@ -259,7 +259,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
 
             SetWinState(gameWon ? WinState.Win : WinState.Loss);
 
-            SceneLoaderWrapper.Instance.LoadScene("PostGame");
+            SceneLoaderWrapper.Instance.LoadScene("PostGame", useNetworkSceneManager: true);
         }
     }
 }

--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
@@ -176,7 +176,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
         IEnumerator WaitToEndLobby()
         {
             yield return new WaitForSeconds(3);
-            SceneLoaderWrapper.Instance.LoadScene("BossRoom");
+            SceneLoaderWrapper.Instance.LoadScene("BossRoom", useNetworkSceneManager: true);
         }
 
         public override void OnNetworkDespawn()

--- a/Assets/BossRoom/Scripts/Shared/ApplicationController.cs
+++ b/Assets/BossRoom/Scripts/Shared/ApplicationController.cs
@@ -126,7 +126,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Shared
                     gameNetPortal.RequestDisconnect();
                 }
             }
-            SceneLoaderWrapper.Instance.LoadScene("MainMenu");
+            SceneLoaderWrapper.Instance.LoadScene("MainMenu", useNetworkSceneManager: false);
         }
 
         public void QuitGame()

--- a/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ServerGameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Shared/Net/ConnectionManagement/ServerGameNetPortal.cs
@@ -295,7 +295,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
 
             //The "BossRoom" server always advances to CharSelect immediately on start. Different games
             //may do this differently.
-            SceneLoaderWrapper.Instance.LoadScene("CharSelect");
+            SceneLoaderWrapper.Instance.LoadScene("CharSelect", useNetworkSceneManager: true);
         }
 
     }

--- a/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/SceneLoaderWrapper.cs
+++ b/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/SceneLoaderWrapper.cs
@@ -70,20 +70,24 @@ namespace Unity.Multiplayer.Samples.Utilities
         /// method also triggers the start of the loading screen.
         /// </summary>
         /// <param name="sceneName">Name or path of the Scene to load.</param>
+        /// <param name="useNetworkSceneManager">If true, uses NetworkSceneManager, else uses SceneManager</param>
         /// <param name="loadSceneMode">If LoadSceneMode.Single then all current Scenes will be unloaded before loading.</param>
-        public void LoadScene(string sceneName, LoadSceneMode loadSceneMode = LoadSceneMode.Single)
+        public void LoadScene(string sceneName, bool useNetworkSceneManager, LoadSceneMode loadSceneMode = LoadSceneMode.Single)
         {
-            if (IsSpawned && IsNetworkSceneManagementEnabled && !NetworkManager.ShutdownInProgress)
+            if (useNetworkSceneManager)
             {
-                if (NetworkManager.IsServer)
+                if (IsSpawned && IsNetworkSceneManagementEnabled && !NetworkManager.ShutdownInProgress)
                 {
-                    // If is active server and NetworkManager uses scene management, load scene using NetworkManager's SceneManager
-                    NetworkManager.SceneManager.LoadScene(sceneName, loadSceneMode);
+                    if (NetworkManager.IsServer)
+                    {
+                        // If is active server and NetworkManager uses scene management, load scene using NetworkManager's SceneManager
+                        NetworkManager.SceneManager.LoadScene(sceneName, loadSceneMode);
+                    }
                 }
             }
             else
             {
-                // If offline, load using SceneManager
+                // Load using SceneManager
                 var loadOperation = SceneManager.LoadSceneAsync(sceneName, loadSceneMode);
                 if (loadSceneMode == LoadSceneMode.Single)
                 {


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
This PR adds a parameter to decide if we load through NetworkSceneManager or SceneManager when we call SceneLoaderWrapper.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
[MTT-2828](https://jira.unity3d.com/browse/MTT-2828)
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
