### PR TITLE
fix: setting players unready when one leaves or joins

### DIFF
--- a/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
+++ b/Assets/BossRoom/Scripts/Server/Game/State/ServerCharSelectState.cs
@@ -135,26 +135,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
                 StopCoroutine(m_WaitToEndLobbyCoroutine);
             }
             CharSelectData.IsLobbyClosed.Value = false;
-            // Set all players unready so they can react to this cancellation
-            SetAllUnready();
-        }
-
-        void SetAllUnready()
-        {
-            for (int i = 0; i < CharSelectData.LobbyPlayers.Count; ++i)
-            {
-                // Set all locked players to active so that they have to confirm their choice again
-                if (CharSelectData.LobbyPlayers[i].SeatState == CharSelectData.SeatState.LockedIn)
-                {
-                    CharSelectData.LobbyPlayers[i] = new CharSelectData.LobbyPlayerState(
-                        CharSelectData.LobbyPlayers[i].ClientId,
-                        CharSelectData.LobbyPlayers[i].PlayerName,
-                        CharSelectData.LobbyPlayers[i].PlayerNumber,
-                        CharSelectData.SeatState.Active,
-                        CharSelectData.LobbyPlayers[i].SeatIdx,
-                        CharSelectData.LobbyPlayers[i].LastChangeTime);
-                }
-            }
         }
 
         void SaveLobbyResults()
@@ -283,17 +263,10 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
                 }
             }
 
-
-            if (CharSelectData.IsLobbyClosed.Value)
+            if (!CharSelectData.IsLobbyClosed.Value)
             {
-                // If lobby is closing and waiting to start the game, cancel so that other players can react to it, and
-                // wait for the player coming back if they want to.
-                CancelCloseLobby();
-            }
-            else
-            {
-                // If it is not closing, set everyone as unready for the same reason
-                SetAllUnready();
+                // If the lobby is not already closing, close if the remaining players are all ready
+                CloseLobbyIfReady();
             }
         }
     }


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
This PR reverts a feature that is sometimes interpreted as a bug to reduce confusion. Now, during character select, players will no longer be set as unready when a new player joins or when one leaves during the closing of the lobby.
### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
