### PR TITLE
fix: clients not displaying popup messages when host quits application inside post-game scene [MTT-3395]

### DIFF
--- a/Assets/BossRoom/Scripts/Client/Game/State/ClientPostGameState.cs
+++ b/Assets/BossRoom/Scripts/Client/Game/State/ClientPostGameState.cs
@@ -10,19 +10,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
     {
         public override GameState ActiveState { get { return GameState.PostGame; } }
 
-        protected override void Start()
-        {
-            base.Start();
-
-            //it is common for the user to get dumped back to main menu from here (i.e., if the host decides not to play again), and
-            //it is a little funny to display a "Connection to Host Lost" message in that case. The best thing would probably be to
-            //display a "Host Abandoned the Game" message, but this would require some more plumbing (an RPC from the host before it quit,
-            //containing that information).
-            //In the meantime, we just set "UserRequested" to suppress the Disconnected error popup.
-            var portalGO = GameObject.FindGameObjectWithTag("GameNetPortal");
-            portalGO.GetComponent<ClientGameNetPortal>().DisconnectReason.SetDisconnectReason(ConnectStatus.UserRequestedDisconnect);
-        }
-
         public override void OnNetworkSpawn()
         {
             if (!IsClient)


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
This PR removes the setting of DisconnectReason to UserDisconnectReason by clients when entering post game scene. Now that the host sends a reason when it disconnects purposefully, I think it is no longer weird for clients to display this message when the host quits the application instead. When the host disconnects purposefully, the clients displays "Disconnected From Host: The host has ended the game session.", and with this PR, they will now display "Disconnected From Host: The connection to the host was lost." when the host quits without disconnecting first.
### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
[MTT-3395](https://jira.unity3d.com/browse/MTT-3395)
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
