### PR TITLE
fix: loading progress bars mismatch [MTT-3616]

### DIFF
--- a/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/ClientLoadingScreen.cs
+++ b/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/ClientLoadingScreen.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Unity.Netcode;
 using UnityEngine;
+using UnityEngine.Assertions;
 using UnityEngine.UI;
 
 namespace Unity.Multiplayer.Samples.Utilities
@@ -65,6 +66,7 @@ namespace Unity.Multiplayer.Samples.Utilities
         void Awake()
         {
             DontDestroyOnLoad(this);
+            Assert.AreEqual(m_OtherPlayersProgressBars.Count, m_OtherPlayerNamesTexts.Count, "There should be the same number of progress bars and name labels");
         }
 
         void Start()
@@ -151,6 +153,12 @@ namespace Unity.Multiplayer.Samples.Utilities
                 RemoveOtherPlayerProgressBar(clientId);
             }
 
+            for (var i = 0; i < m_OtherPlayersProgressBars.Count; i++)
+            {
+                m_OtherPlayersProgressBars[i].gameObject.SetActive(false);
+                m_OtherPlayerNamesTexts[i].gameObject.SetActive(false);
+            }
+
             var index = 0;
 
             foreach (var progressTracker in m_LoadingProgressManager.ProgressTrackers)
@@ -166,12 +174,14 @@ namespace Unity.Multiplayer.Samples.Utilities
         protected virtual void UpdateOtherPlayerProgressBar(ulong clientId, int progressBarIndex)
         {
             m_LoadingProgressBars[clientId].ProgressBar = m_OtherPlayersProgressBars[progressBarIndex];
+            m_LoadingProgressBars[clientId].ProgressBar.gameObject.SetActive(true);
             m_LoadingProgressBars[clientId].NameText = m_OtherPlayerNamesTexts[progressBarIndex];
+            m_LoadingProgressBars[clientId].NameText.gameObject.SetActive(true);
         }
 
         protected virtual void AddOtherPlayerProgressBar(ulong clientId, NetworkedLoadingProgressTracker progressTracker)
         {
-            if (m_LoadingProgressBars.Count < m_OtherPlayersProgressBars.Count)
+            if (m_LoadingProgressBars.Count < m_OtherPlayersProgressBars.Count && m_LoadingProgressBars.Count < m_OtherPlayerNamesTexts.Count)
             {
                 var index = m_LoadingProgressBars.Count;
                 m_LoadingProgressBars[clientId] = new LoadingProgressBar(m_OtherPlayersProgressBars[index], m_OtherPlayerNamesTexts[index]);


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
This PR fixes the issue where the progress bars in the loading screen would not be properly deactivated and reactivated when a new scene load occurred after a client disconnected.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
[MTT-3616](https://jira.unity3d.com/browse/MTT-3616)

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
