### PR TITLE
fix: unregister profile manager callback [MTT-3585]

### DIFF
--- a/Assets/BossRoom/Scripts/Game/Client/State/ClientMainMenuState.cs
+++ b/Assets/BossRoom/Scripts/Game/Client/State/ClientMainMenuState.cs
@@ -109,6 +109,12 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
             }
         }
 
+        public override void OnDestroy()
+        {
+            m_ProfileManager.onProfileChanged -= OnProfileChanged;
+            base.OnDestroy();
+        }
+
         async void OnProfileChanged()
         {
             m_LobbyButton.interactable = false;


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
This PR simply unregisters the callback to ProfileManager.OnProfileChanged when ClientMainMenuState is destroyed.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
[MTT-3585](https://jira.unity3d.com/browse/MTT-3585)

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
