### PR TITLE
fix: bad network warning not deleted on despawn

### DIFF
--- a/Assets/BossRoom/Scripts/Infrastructure/NetworkStats.cs
+++ b/Assets/BossRoom/Scripts/Infrastructure/NetworkStats.cs
@@ -175,6 +175,11 @@ namespace Unity.Multiplayer.Samples.BossRoom
             {
                 Destroy(m_TextHostType.gameObject);
             }
+
+            if (m_TextBadNetworkConditions != null)
+            {
+                Destroy(m_TextBadNetworkConditions.gameObject);
+            }
         }
     }
 }


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
Simple PR to make sure the UI element for the bad network conditions warning is properly destroyed at the end of a game.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
