### PR TITLE
Fix: Broken Shader References [MTT-3681]

### DIFF
--- a/Assets/BossRoom/VFX/Materials/FX_M_GroundCrack_01.mat
+++ b/Assets/BossRoom/VFX/Materials/FX_M_GroundCrack_01.mat
@@ -8,13 +8,10 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: FX_M_GroundCrack_01
-  m_Shader: {fileID: -6465566751694194690, guid: 98d049a5b372986479d42cfc7e88f269, type: 3}
+  m_Shader: {fileID: -6465566751694194690, guid: 42787e4b9b9ce6049827a84217a0075e, type: 3}
   m_ValidKeywords:
   - _SURFACE_TYPE_TRANSPARENT
-  m_InvalidKeywords:
-  - _HASTEXTUREDISSOLVE_ON
-  - _STEPSUBTRACT_ON
-  - _VERTEXAOPACITY_ON
+  m_InvalidKeywords: []
   m_LightmapFlags: 0
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
@@ -36,7 +33,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - Texture2D_ebc59c3a4789414dbc640714ca8cd838:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: 60781adef564aeb439a036d89cc5545e, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _BumpMap:

--- a/Assets/BossRoom/VFX/Materials/FX_M_GroundCrack_02.mat
+++ b/Assets/BossRoom/VFX/Materials/FX_M_GroundCrack_02.mat
@@ -21,13 +21,10 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: FX_M_GroundCrack_02
-  m_Shader: {fileID: -6465566751694194690, guid: 98d049a5b372986479d42cfc7e88f269, type: 3}
+  m_Shader: {fileID: -6465566751694194690, guid: 42787e4b9b9ce6049827a84217a0075e, type: 3}
   m_ValidKeywords:
   - _SURFACE_TYPE_TRANSPARENT
-  m_InvalidKeywords:
-  - _HASTEXTUREDISSOLVE_ON
-  - _STEPSUBTRACT_ON
-  - _VERTEXAOPACITY_ON
+  m_InvalidKeywords: []
   m_LightmapFlags: 0
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
@@ -49,7 +46,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - Texture2D_ebc59c3a4789414dbc640714ca8cd838:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: 60781adef564aeb439a036d89cc5545e, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _BumpMap:

--- a/Assets/BossRoom/VFX/Materials/FX_M_ImpExplosionFire.mat
+++ b/Assets/BossRoom/VFX/Materials/FX_M_ImpExplosionFire.mat
@@ -8,20 +8,15 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: FX_M_ImpExplosionFire
-  m_Shader: {fileID: -6465566751694194690, guid: 98d049a5b372986479d42cfc7e88f269, type: 3}
+  m_Shader: {fileID: -6465566751694194690, guid: 42787e4b9b9ce6049827a84217a0075e, type: 3}
   m_ValidKeywords:
   - _ALPHAPREMULTIPLY_ON
   - _SURFACE_TYPE_TRANSPARENT
-  m_InvalidKeywords:
-  - _HASTEXTUREDISSOLVE_ON
-  - _SWITCH_ALPHA_ON
-  - _USEALPHACHANNEL_ON
-  - _USE_ALPHA_ON
-  - _VERTEXAOPACITY_ON
+  m_InvalidKeywords: []
   m_LightmapFlags: 0
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 3000
+  m_CustomRenderQueue: -1
   stringTagMap:
     RenderType: Transparent
   disabledShaderPasses:

--- a/Assets/BossRoom/VFX/Materials/FX_M_Shockwave.mat
+++ b/Assets/BossRoom/VFX/Materials/FX_M_Shockwave.mat
@@ -50,7 +50,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: d9f6107e662e5d94aa53dd7a751eae5c, type: 3}
+        m_Texture: {fileID: 2800000, guid: 1f91c1c935857f14c903efecdae77724, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTexture:
@@ -99,6 +99,7 @@ Material:
     - _CastShadows: 0
     - _Cull: 2
     - _Cutoff: 0.5
+    - _Depth_Blend: 0
     - _DetailNormalMapScale: 1
     - _DstBlend: 1
     - _Float0: 0.21
@@ -118,6 +119,7 @@ Material:
     - _Switch_Alpha: 1
     - _UVSec: 0
     - _UseAlpha: 1
+    - _UseSoftParticles: 0
     - _ZTest: 4
     - _ZWrite: 0
     - _ZWriteControl: 0

--- a/Assets/BossRoom/VFX/Materials/FX_M_SmokeDissolveMultip.mat
+++ b/Assets/BossRoom/VFX/Materials/FX_M_SmokeDissolveMultip.mat
@@ -8,22 +8,16 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: FX_M_SmokeDissolveMultip
-  m_Shader: {fileID: -6465566751694194690, guid: a3e81e7fd4270c34082df8fbadb8d9dc, type: 3}
+  m_Shader: {fileID: -6465566751694194690, guid: 500cf73690d12844cb03f790a7b81174, type: 3}
   m_ValidKeywords:
   - _DISSOLVE_TYPE_CUSTOM
   - _DIS_RED
   - _SURFACE_TYPE_TRANSPARENT
-  m_InvalidKeywords:
-  - _DISSOLVETYPE_CUSTOM
-  - _DISSOLVETYPE_UV
-  - _DISSOLVE_UV
-  - _DISTYPE_DISSOLVETEXRED
-  - _INVERTDISSOLVE_ON
-  - _KEYWORD0_ON
+  m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 3500
+  m_CustomRenderQueue: -1
   stringTagMap:
     RenderType: Transparent
   disabledShaderPasses:
@@ -34,6 +28,18 @@ Material:
     m_TexEnvs:
     - Texture2D_0b5d110ddc9e4bc8b32a41de9af27498:
         m_Texture: {fileID: 2800000, guid: 8a5b3af15db0b3d4e9b5fd91fe2e7c30, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - Texture2D_0d51a7f662f34825885706c5f9f5b378:
+        m_Texture: {fileID: 2800000, guid: 8a5b3af15db0b3d4e9b5fd91fe2e7c30, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - Texture2D_a49f118ec4654c468718c10acb0d11fb:
+        m_Texture: {fileID: 2800000, guid: 1ee97322756ea2c489f9311bd5c9f72d, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - Texture2D_ebc59c3a4789414dbc640714ca8cd838:
+        m_Texture: {fileID: 2800000, guid: 60781adef564aeb439a036d89cc5545e, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _BumpMap:
@@ -102,6 +108,17 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
+    - Boolean_3d21c72f19314834bd7b68bd1945e5ed: 0
+    - Boolean_3f723681939f4ad0be5abc28767056a0: 0
+    - Boolean_b14a61a83cf04832bfc5e28ac9dc002f: 0
+    - Boolean_b2d3c01bbc4040b69679a702e03700d7: 0
+    - Boolean_e207d7c3c7c54fe9a2fedb5c72933240: 0
+    - Boolean_e207d7c3c7c54fe9a2fedb5c72933240_1: 0
+    - Boolean_ebca1713bc2a4fcea5fa60c01ccce53f: 0
+    - Vector1_1: 0.15
+    - Vector1_49a02738d71c4444862d3f695e709242: 1
+    - Vector1_ffa04a928dac4de2b4be502e4caee4d3: 1
+    - Vector1_ffa04a928dac4de2b4be502e4caee4d3_1: 1
     - _AlphaClip: 0
     - _Blend: 2
     - _BumpScale: 1
@@ -139,6 +156,10 @@ Material:
     - _ZWriteControl: 0
     - __dirty: 0
     m_Colors:
+    - Color_1808cb51d9804f419fb05b86068c676a: {r: 1, g: 1, b: 1, a: 0}
+    - Vector4_1: {r: 1, g: 1, b: 0, a: 0}
+    - Vector4_1d8f01040b1f48af90ee158d67035434: {r: 1, g: 1, b: 0, a: 0}
+    - Vector4_2: {r: 1, g: 1, b: 0, a: 0}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _DissolveTileSpeed: {r: 1, g: 1, b: 1, a: 0}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/BossRoom/VFX/Materials/FX_M_Snowflake_Additive.mat
+++ b/Assets/BossRoom/VFX/Materials/FX_M_Snowflake_Additive.mat
@@ -9,17 +9,19 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: FX_M_Snowflake_Additive
   m_Shader: {fileID: -6465566751694194690, guid: a9ba79dc821093a4c9041bcede85096b, type: 3}
-  m_ValidKeywords: []
+  m_ValidKeywords:
+  - _SURFACE_TYPE_TRANSPARENT
   m_InvalidKeywords:
   - _USE_ALPHA_ON
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2000
+  m_CustomRenderQueue: 3000
   stringTagMap:
-    RenderType: Opaque
+    RenderType: Transparent
   disabledShaderPasses:
   - SHADOWCASTER
+  - DepthOnly
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -40,7 +42,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: fa9d4375ce230e1488b5a2680fd71074, type: 3}
+        m_Texture: {fileID: 2800000, guid: 2531e297c5750b84b82bd0824557163f, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTexture:
@@ -89,7 +91,8 @@ Material:
     - _CastShadows: 0
     - _Cull: 2
     - _Cutoff: 0.5
-    - _DstBlend: 0
+    - _Depth_Blend: 0
+    - _DstBlend: 10
     - _EnvironmentReflections: 1
     - _GlossMapScale: 0
     - _Glossiness: 0
@@ -102,14 +105,15 @@ Material:
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _Surface: 0
+    - _SrcBlend: 5
+    - _Surface: 1
     - _Switch_Alpha: 0
     - _UseAlpha: 0
+    - _UseSoftParticles: 0
     - _Use_alpha: 1
     - _WorkflowMode: 1
     - _ZTest: 4
-    - _ZWrite: 1
+    - _ZWrite: 0
     - _ZWriteControl: 0
     - __dirty: 0
     m_Colors:

--- a/Assets/BossRoom/VFX/Materials/FX_M_Sparks.mat
+++ b/Assets/BossRoom/VFX/Materials/FX_M_Sparks.mat
@@ -63,7 +63,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 1fb59c6b40f44364395bf58cc2ae9980, type: 3}
+        m_Texture: {fileID: 2800000, guid: 83a6f5a72f632d34aa353b2f9bf0143c, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTexture:
@@ -111,6 +111,7 @@ Material:
     - _CastShadows: 0
     - _Cull: 2
     - _Cutoff: 0.5
+    - _Depth_Blend: 0
     - _DetailNormalMapScale: 1
     - _DstBlend: 1
     - _GlossMapScale: 1
@@ -129,6 +130,7 @@ Material:
     - _Switch_Alpha: 1
     - _UVSec: 0
     - _UseAlpha: 1
+    - _UseSoftParticles: 0
     - _ZTest: 4
     - _ZWrite: 0
     - _ZWriteControl: 0

--- a/Assets/BossRoom/VFX/Materials/FX_M_StylizeSmoke_02.mat
+++ b/Assets/BossRoom/VFX/Materials/FX_M_StylizeSmoke_02.mat
@@ -21,13 +21,10 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: FX_M_StylizeSmoke_02
-  m_Shader: {fileID: -6465566751694194690, guid: 98d049a5b372986479d42cfc7e88f269, type: 3}
+  m_Shader: {fileID: -6465566751694194690, guid: 42787e4b9b9ce6049827a84217a0075e, type: 3}
   m_ValidKeywords:
   - _SURFACE_TYPE_TRANSPARENT
-  m_InvalidKeywords:
-  - _HASTEXTUREDISSOLVE_ON
-  - _STEPSUBTRACT_ON
-  - _VERTEXAOPACITY_ON
+  m_InvalidKeywords: []
   m_LightmapFlags: 0
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
@@ -49,7 +46,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - Texture2D_ebc59c3a4789414dbc640714ca8cd838:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: 60781adef564aeb439a036d89cc5545e, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _BumpMap:

--- a/Assets/BossRoom/VFX/Materials/FX_M_StylizeSmoke_Falldown.mat
+++ b/Assets/BossRoom/VFX/Materials/FX_M_StylizeSmoke_Falldown.mat
@@ -21,7 +21,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: FX_M_StylizeSmoke_Falldown
-  m_Shader: {fileID: -6465566751694194690, guid: 98d049a5b372986479d42cfc7e88f269, type: 3}
+  m_Shader: {fileID: -6465566751694194690, guid: 42787e4b9b9ce6049827a84217a0075e, type: 3}
   m_ValidKeywords:
   - _SURFACE_TYPE_TRANSPARENT
   m_InvalidKeywords: []

--- a/Assets/BossRoom/VFX/Materials/FX_M_Trail_01.mat
+++ b/Assets/BossRoom/VFX/Materials/FX_M_Trail_01.mat
@@ -41,7 +41,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: fa9d4375ce230e1488b5a2680fd71074, type: 3}
+        m_Texture: {fileID: 2800000, guid: e57bc50ae448d2c43bd33a470ad32940, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTexture:
@@ -90,6 +90,7 @@ Material:
     - _CastShadows: 0
     - _Cull: 2
     - _Cutoff: 0.5
+    - _Depth_Blend: 0
     - _DstBlend: 10
     - _EnvironmentReflections: 1
     - _GlossMapScale: 0
@@ -107,6 +108,7 @@ Material:
     - _Surface: 1
     - _Switch_Alpha: 1
     - _UseAlpha: 1
+    - _UseSoftParticles: 0
     - _Use_alpha: 1
     - _WorkflowMode: 1
     - _ZTest: 8

--- a/Assets/BossRoom/VFX/Materials/FX_M_Trail_02.mat
+++ b/Assets/BossRoom/VFX/Materials/FX_M_Trail_02.mat
@@ -41,7 +41,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: fa9d4375ce230e1488b5a2680fd71074, type: 3}
+        m_Texture: {fileID: 2800000, guid: f64f5e31b8af18540be7b69d43c85aa4, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTexture:
@@ -90,6 +90,7 @@ Material:
     - _CastShadows: 0
     - _Cull: 2
     - _Cutoff: 0.5
+    - _Depth_Blend: 0
     - _DstBlend: 10
     - _EnvironmentReflections: 1
     - _GlossMapScale: 0
@@ -107,6 +108,7 @@ Material:
     - _Surface: 1
     - _Switch_Alpha: 1
     - _UseAlpha: 1
+    - _UseSoftParticles: 0
     - _Use_alpha: 1
     - _WorkflowMode: 1
     - _ZTest: 8

--- a/Assets/BossRoom/VFX/Materials/FX_M_Wave_01.mat
+++ b/Assets/BossRoom/VFX/Materials/FX_M_Wave_01.mat
@@ -122,7 +122,7 @@ Material:
     - _SrcBlend: 5
     - _Surface: 1
     - _UVSec: 0
-    - _UseAlpha: 1
+    - _UseAlpha: 0
     - _UseSoftParticles: 0
     - _ZTest: 4
     - _ZWrite: 0


### PR DESCRIPTION
### Description
Fixed up some broken shader references in these materials. Spurred by noticing the broken ref on the fall down VFX that plays when a character is defeated in our last playtest. I think these got messed up in the big shader/material consolidation, but I didn't notice because they're not all used in game. It's still good to have these materials though since they're hooked into other currently unused prefabs (like the frost bolt for the mage, which could be cool to implement in the future?)

### Issue Number(s)
https://jira.unity3d.com/browse/MTT-3681

### Contribution checklist
 - [x] Tests have been added for boss room and/or utilities pack
 - [N/A] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
