### PR TITLE
Fix: Flickering Artifacts on Boss Room Title in Post Game Scene [MTT-3687]

### DIFF
--- a/Assets/BossRoom/Scenes/PostGame.unity
+++ b/Assets/BossRoom/Scenes/PostGame.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a0aefe54499ec1481df314bcfe286f4273fe62f947d6e90fd152c40730d1a2f9
-size 61276
+oid sha256:80f61ce50c2df8f7e43e3d365fe8d2be8e4d9893fe614390015a324a4679c873
+size 67071


### PR DESCRIPTION
### Description
A tiny PR for a fix for the broken Boss Room title in the post game scene. Noticed that there were flickering pixelated artifacts during a playtest on a Samsung s10e. Further investigation showed the title image just not showing up at all on the J2. Fix was just changing the component type from raw image to image, matching exactly how it's set up in the main menu scene. 

### Issue Number(s)
[MTT-3687](https://jira.unity3d.com/browse/MTT-3687)

### Contribution checklist
 - [x] Tests have been added for boss room and/or utilities pack
 - [N/A] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
