### PR TITLE
fix: no popup when incompatible build types [MTT-3689]

### DIFF
--- a/Assets/BossRoom/Scripts/Game/ConnectionManagement/ClientGameNetPortal.cs
+++ b/Assets/BossRoom/Scripts/Game/ConnectionManagement/ClientGameNetPortal.cs
@@ -156,6 +156,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
                     case ConnectStatus.UserRequestedDisconnect:
                     case ConnectStatus.HostEndedSession:
                     case ConnectStatus.ServerFull:
+                    case ConnectStatus.IncompatibleBuildType:
                         m_ApplicationController.LeaveSession(false); // go through the normal leave flow
                         break;
                     case ConnectStatus.LoggedInAgain:


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
This PR simply adds handling of IncompatibleBuildType to ClientGameNetPortal.OnDisconnectOrTimeout. It wasn't originally added to the switch-case, which led to the NotImplementedException being thrown, instead of sending a ConnectStatus message like it used to.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
[MTT-3689](https://jira.unity3d.com/browse/MTT-3689)

### Contribution checklist
 - [n/a] Tests have been added for boss room and/or utilities pack
 - [n/a] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
