### PR TITLE
fix: removing redundant lobby refresh and unsubscribing from lobby queries [MTT-4018]

### DIFF
--- a/Assets/Scripts/Gameplay/UI/Lobby/LobbyJoiningUI.cs
+++ b/Assets/Scripts/Gameplay/UI/Lobby/LobbyJoiningUI.cs
@@ -141,7 +141,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
             m_CanvasGroup.alpha = 1f;
             m_CanvasGroup.blocksRaycasts = true;
             m_JoinCodeField.text = "";
-            OnRefresh();
             m_UpdateRunner.Subscribe(PeriodicRefresh, 10f);
         }
 

--- a/Assets/Scripts/Gameplay/UI/Lobby/LobbyUIMediator.cs
+++ b/Assets/Scripts/Gameplay/UI/Lobby/LobbyUIMediator.cs
@@ -220,6 +220,8 @@ namespace Unity.Multiplayer.Samples.BossRoom.Visual
         {
             m_CanvasGroup.alpha = 0f;
             m_CanvasGroup.blocksRaycasts = false;
+            m_LobbyCreationUI.Hide();
+            m_LobbyJoiningUI.Hide();
         }
 
         public void ToggleJoinLobbyUI()


### PR DESCRIPTION
### Description
This PR removes a redundant query for lobbies to be refreshed when the lobby UI is shown. When the UI is shown, a manual refresh is invoked, as well as a repeating query which is invoked immediately (this is the one that is throttled). Just the repeating refresh is left over.

The reason it was not reproduceable when the Joining UI was closed and reopened was because the query job was not unsubscribed when the close button on the UI was invoked. A subsequent opening of the joining UI would try to create a repeating query job which was refused, and so only the manual refresh was invoked (leading to no rate limiting).
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[MTT-4018](https://jira.unity3d.com/browse/MTT-4018)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink

