### PR TITLE
fix: restoring lobby heartbeat [MTT-4210]

### DIFF
--- a/Assets/Scripts/ConnectionManagement/ConnectionState/ClientConnectedState.cs
+++ b/Assets/Scripts/ConnectionManagement/ConnectionState/ClientConnectedState.cs
@@ -1,4 +1,7 @@
 using System;
+using Unity.Multiplayer.Samples.BossRoom.Shared.Net.UnityServices.Lobbies;
+using UnityEngine;
+using VContainer;
 
 namespace Unity.Multiplayer.Samples.BossRoom
 {
@@ -8,7 +11,16 @@ namespace Unity.Multiplayer.Samples.BossRoom
     /// </summary>
     class ClientConnectedState : ConnectionState
     {
-        public override void Enter() { }
+        [Inject]
+        protected LobbyServiceFacade m_LobbyServiceFacade;
+
+        public override void Enter()
+        {
+            if (m_LobbyServiceFacade.CurrentUnityLobby != null)
+            {
+                m_LobbyServiceFacade.BeginTracking();
+            }
+        }
 
         public override void Exit() { }
 

--- a/Assets/Scripts/ConnectionManagement/ConnectionState/HostingState.cs
+++ b/Assets/Scripts/ConnectionManagement/ConnectionState/HostingState.cs
@@ -34,6 +34,11 @@ namespace Unity.Multiplayer.Samples.BossRoom
             //The "BossRoom" server always advances to CharSelect immediately on start. Different games
             //may do this differently.
             SceneLoaderWrapper.Instance.LoadScene("CharSelect", useNetworkSceneManager: true);
+
+            if (m_LobbyServiceFacade.CurrentUnityLobby != null)
+            {
+                m_LobbyServiceFacade.BeginTracking();
+            }
         }
 
         public override void Exit()


### PR DESCRIPTION
### Description
Fix to re-introduce lobby heartbeats such that lobby owners push lobby data on update intervals & non-owners receive individual lobby updates on said intervals. This resolves lobbies being destroyed on their own since data was not being pushed up to the service.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[MTT-4210](https://jira.unity3d.com/browse/MTT-4210)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink

