### PR TITLE
fix: disabling NetworkBehaviours instead of destroying them [MTT-4481]

### DIFF
--- a/Assets/Scripts/Gameplay/Input/ClientClickFeedback.cs
+++ b/Assets/Scripts/Gameplay/Input/ClientClickFeedback.cs
@@ -23,7 +23,7 @@ namespace Unity.Multiplayer.Samples.BossRoom.Client
         {
             if (NetworkManager.Singleton.LocalClientId != OwnerClientId)
             {
-                Destroy(this);
+                enabled = false;
                 return;
             }
 

--- a/Assets/Scripts/Utils/NetworkOverlay/NetworkStats.cs
+++ b/Assets/Scripts/Utils/NetworkOverlay/NetworkStats.cs
@@ -72,7 +72,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
             bool isClientOnly = IsClient && !IsServer;
             if (!IsOwner && isClientOnly) // we don't want to track player ghost stats, only our own
             {
-                Destroy(this);
+                enabled = false;
                 return;
             }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,13 @@ Additional documentation and release notes are available at [Multiplayer Documen
 * NetworkedMessageChannels can now be subscribed to before initiating a connection (#670)
 * Refactored connection management into simpler state machine (#666)
 * Merged GameState bridge classes (the ones that contained no or limited functionality) (#697) This cleans up our sometimes too verbose code split.
-* Some NetworkBehaviours are disabled instead of being destroyed (#718) - This preserves the index order for NetworkBehaviours between server and clients, resulting in no indexing issue for sending/receiving RPCs.
+* 
 ### Removed
 *
 ### Fixed
 * Subscribing to a message channel while unsubscribing is pending (#675)
 * Using ```Visible``` instead of ```Enabled``` to make sure RNSM continues updating when off (#702)
+* Some NetworkBehaviours are disabled instead of being destroyed (#718) - This preserves the index order for NetworkBehaviours between server and clients, resulting in no indexing issue for sending/receiving RPCs.
 
 ## [v1.3.0-pre] - 2022-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 * NetworkedMessageChannels can now be subscribed to before initiating a connection (#670)
 * Refactored connection management into simpler state machine (#666)
 * Merged GameState bridge classes (the ones that contained no or limited functionality) (#697) This cleans up our sometimes too verbose code split.
-* 
+* Some NetworkBehaviours are disabled instead of being destroyed (#718) - This preserves the index order for NetworkBehaviours between server and clients, resulting in no indexing issue for sending/receiving RPCs.
 ### Removed
 *
 ### Fixed


### PR DESCRIPTION
### Description
This PR preserves the NetworkBehaviour index order between server and clients, such that indexing issues do not occur. NetworkBehaviours were being destroyed based on Owner status and so there was a mismatch on sending/receiving RPCs. Instead, NetworkBehaviours are simply disabled.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[MTT-4481](https://jira.unity3d.com/browse/MTT-4481)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink

