### PR TITLE
fix: game frozen when client leaves in postgame [MTT-4342]

### DIFF
--- a/Assets/Scripts/Gameplay/GameState/ServerBossRoomState.cs
+++ b/Assets/Scripts/Gameplay/GameState/ServerBossRoomState.cs
@@ -79,25 +79,6 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
 
             m_Subscription = m_LifeStateChangedEventMessageSubscriber.Subscribe(OnLifeStateChangedEventMessage);
 
-            NetworkManager.Singleton.SceneManager.OnLoadComplete += OnServerLoadComplete;
-            NetworkManager.Singleton.SceneManager.OnUnloadComplete += OnServerUnloadComplete;
-        }
-
-        void OnNetworkDespawn()
-        {
-            m_Subscription?.Dispose();
-
-            NetworkManager.Singleton.SceneManager.OnLoadComplete -= OnServerLoadComplete;
-            NetworkManager.Singleton.SceneManager.OnUnloadComplete -= OnServerUnloadComplete;
-        }
-
-        void OnServerLoadComplete(ulong clientId, string sceneName, LoadSceneMode loadSceneMode)
-        {
-            if (clientId != NetworkManager.ServerClientId)
-            {
-                return;
-            }
-
             NetworkManager.Singleton.OnClientDisconnectCallback += OnClientDisconnect;
             NetworkManager.Singleton.SceneManager.OnLoadEventCompleted += OnLoadEventCompleted;
             NetworkManager.Singleton.SceneManager.OnSynchronizeComplete += OnSynchronizeComplete;
@@ -105,12 +86,9 @@ namespace Unity.Multiplayer.Samples.BossRoom.Server
             SessionManager<SessionPlayerData>.Instance.OnSessionStarted();
         }
 
-        void OnServerUnloadComplete(ulong clientId, string sceneName)
+        void OnNetworkDespawn()
         {
-            if (clientId != NetworkManager.ServerClientId)
-            {
-                return;
-            }
+            m_Subscription?.Dispose();
 
             NetworkManager.Singleton.OnClientDisconnectCallback -= OnClientDisconnect;
             NetworkManager.Singleton.SceneManager.OnLoadEventCompleted -= OnLoadEventCompleted;


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
This PR changes when we register and un-register to NGO callbacks within ServerBossRoomState, making it simpler and clearer. It is now only done once in OnNetworkSpawn and undone once in OnNetworkDespawn. Before this, it relied on OnLoadComplete to register those callbacks (which happens every time any scene is loaded, including the additive scenes) and on OnUnloadeComplete to un-register them (which only happens when an additive scene is unloaded). This meant that we would register to these callbacks multiple times and we would not un-register properly afterwards.

Here are the repro steps for the bug this is fixing:

1.Start a game with a host and at least one client
2.Progress through the game up to the postgame state
3.As a client, leave the game

No addition to changelog since this bug was introduced after the 1.3.0 release

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
[MTT-4342](https://jira.unity3d.com/browse/MTT-4342)

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink

