### PR TITLE
fix: NetworkTransform reference on PickupPot re-hooked up

### DIFF
--- a/Assets/Prefabs/Game/PickUpPot.prefab
+++ b/Assets/Prefabs/Game/PickUpPot.prefab
@@ -91,7 +91,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 19d305a23aab66843ab49f61511c8662, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_NetworkTransform: {fileID: 0}
+  m_NetworkTransform: {fileID: 3829689126279177341}
   m_PositionConstraint: {fileID: 172480899766740213}
 --- !u!1818360608 &172480899766740213
 PositionConstraint:


### PR DESCRIPTION
### Description
PickupPot lost its reference to NetworkTransform component. This caused some NRE while dropping the pot. Simply just hooking up that reference again.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
Found while testing locally. No Jira as it's a trivial fix.
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink

