### PR TITLE
feat: reducing MaxPacketQueueSize to 256 [MTT-4595]

### DIFF
--- a/Assets/Prefabs/NetworkingManager.prefab
+++ b/Assets/Prefabs/NetworkingManager.prefab
@@ -45,7 +45,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ProtocolType: 0
-  m_MaxPacketQueueSize: 512
+  m_MaxPacketQueueSize: 256
   m_MaxPayloadSize: 32000
   m_MaxSendQueueSize: 50000000
   m_HeartbeatTimeoutMS: 500

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 * Configured the NetworkTransform components of every NetworkObject to reduce the bandwidth usage (#716). This prevents the unnecessary synchronization of data that clients do not need, i.e. a character's scale or y position. In the case of a character, it reduced the size of each update from 47B to 23B.
 * Instead of a NetworkBehaviour that carries a WinState netvar we now pass the win state on the server to the PostGame scene and it then stores that state in the netvar, eliminating the need to preserve a NetworkBehaviour-bearing gameObject across scenes. (#724)
 * Bump to NGO 1.0.1 (#720)
-* 
+* Reduced the MaxPacketQueueSize UTP parameter value from 512 to 256 (#728). This reduces the amount of memory used by UTP by around 1 MB. Boss Room does not need a bigger queue size than this because there can only be 7 clients connected to a host and UTP already limits the maximum number of in-flight packets to 32 per connection.
+*
 ### Removed
 *
 ### Fixed


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
This PR reduces the MaxPacketQueueSize UTP parameter to be 256 instead of its current 512. This slightly reduces the amount of memory needed for those queues, by around 1 MB. A higher value than this was not necessary since Boss Room only uses reliable channels for its RPCs and custom messages, and because we are limited by a maximum of 32 in-flight packets per connection anyways, it is impossible to have more than a total of 7*32=224 packets in flight in total. I put it slightly higher, at 256, to allow for internal traffic from UTP.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
[MTT-4595](https://jira.unity3d.com/browse/MTT-4595)

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink

