### PR TITLE
fix: fixing warnings when doing golden path [MTT-4658]

### DIFF
--- a/Assets/Scripts/ConnectionManagement/ConnectionState/ClientConnectingState.cs
+++ b/Assets/Scripts/ConnectionManagement/ConnectionState/ClientConnectingState.cs
@@ -22,7 +22,9 @@ namespace Unity.Multiplayer.Samples.BossRoom
 
         public override void Enter()
         {
-            ConnectClient();
+#pragma warning disable 4014
+            ConnectClientAsync();
+#pragma warning restore 4014
         }
 
         public override void Exit() { }
@@ -45,7 +47,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
             m_ConnectionManager.ChangeState(m_ConnectionManager.m_DisconnectingWithReason);
         }
 
-        protected async Task ConnectClient()
+        protected async Task ConnectClientAsync()
         {
             bool success = true;
             if (m_LobbyServiceFacade.CurrentUnityLobby != null)

--- a/Assets/Scripts/ConnectionManagement/ConnectionState/ClientReconnectingState.cs
+++ b/Assets/Scripts/ConnectionManagement/ConnectionState/ClientReconnectingState.cs
@@ -88,7 +88,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
                 if (joiningLobby.Result.Success)
                 {
                     m_LobbyServiceFacade.SetRemoteLobby(joiningLobby.Result.Lobby);
-                    var connectingToRelay = ConnectClient();
+                    var connectingToRelay = ConnectClientAsync();
                     yield return new WaitUntil(() => connectingToRelay.IsCompleted);
                 }
                 else
@@ -99,7 +99,7 @@ namespace Unity.Multiplayer.Samples.BossRoom
             }
             else
             {
-                var connectingClient = ConnectClient();
+                var connectingClient = ConnectClientAsync();
                 yield return new WaitUntil(() => connectingClient.IsCompleted);
             }
         }


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
Removing warning around using an async call without an await that pops up when first starting the game. This seems the be the correct behaviour.
Renaming the method call to make sure we're aware of this if we decide to call this somewhere else.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

[MTT-4658](https://jira.unity3d.com/browse/MTT-4658)

### Contribution checklist
 - n/a Tests have been added for boss room and/or utilities pack
 - n/a Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink

