### PR TITLE
fix: VandalImp tossed item only affects players and damage bumped [MTT-4762]

### DIFF
--- a/Assets/Prefabs/Game/ImpTossedItem.prefab
+++ b/Assets/Prefabs/Game/ImpTossedItem.prefab
@@ -155,13 +155,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8bff02995bf9984488cdd9c4cda2c328, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_DamagePoints: 1
+  m_DamagePoints: 150
   m_HitRadius: 5
   m_KnockbackSpeed: 4.2
   m_KnockbackDuration: 0.4
   m_LayerMask:
     serializedVersion: 2
-    m_Bits: 72
+    m_Bits: 8
   m_DetonateAfterSeconds: 5
   m_DestroyAfterSeconds: 6
   detonatedCallback:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,6 @@ Additional documentation and release notes are available at [Multiplayer Documen
   * Removed DynamicNavObstacle - an unused class (#732)
   * Merged networked data classes into their Server counterparts. An example of that change is the contents of NetworkCharacterState getting moved into ServerCharacter, contents of NetworkDoorState getting moved into SwitchedDoor etc. (#732)
 * Engine version bump to 2021.3.10f1 (#740)
-* VandalImp's ImpTossedItem attack only damages PCs & damage raised (#743)
 ### Removed
 *
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
   * Removed DynamicNavObstacle - an unused class (#732)
   * Merged networked data classes into their Server counterparts. An example of that change is the contents of NetworkCharacterState getting moved into ServerCharacter, contents of NetworkDoorState getting moved into SwitchedDoor etc. (#732)
 * Engine version bump to 2021.3.10f1 (#740)
+* VandalImp's ImpTossedItem attack only damages PCs & damage raised (#743)
 ### Removed
 *
 ### Fixed


### PR DESCRIPTION
### Description
VandalImp tossed item only applies damage to PCs, and the damage has been increased significantly.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[MTT-4762](https://jira.unity3d.com/browse/MTT-4762)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ N/A] Tests have been added for boss room and/or utilities pack
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink

