### PR TITLE
Fix: Broken Material References on Decorative Pots [MTT-4750]

### DIFF
--- a/Assets/Prefabs/Dungeon/Dungeon Pieces/pots/env_pot_heavy.prefab
+++ b/Assets/Prefabs/Dungeon/Dungeon Pieces/pots/env_pot_heavy.prefab
@@ -184,7 +184,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 86655247656508045be3d53c1611c865, type: 2}
+  - {fileID: 2100000, guid: 08a6ed3e19879c844a1bb6d8f07e2653, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0


### PR DESCRIPTION
### Description
Fixed up a broken material reference on the LOD1 of the decorative pots

### Issue Number(s)
[[MTT-4750]](https://jira.unity3d.com/browse/MTT-4750)

### Contribution checklist
 [N/A] Tests have been added for boss room and/or utilities pack
 [N/A] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink

