### PR TITLE
fix: can click through loading screen [MTT-4753]

### DIFF
--- a/Assets/Prefabs/UI/LoadingScreen.prefab
+++ b/Assets/Prefabs/UI/LoadingScreen.prefab
@@ -462,6 +462,7 @@ GameObject:
   - component: {fileID: 5535057700358825828}
   - component: {fileID: 5841466599347033389}
   - component: {fileID: 3127630062634103998}
+  - component: {fileID: 2516136186326398479}
   m_Layer: 5
   m_Name: LoadingScreen
   m_TagString: Untagged
@@ -543,7 +544,7 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 948382310089859896}
   m_Enabled: 1
-  m_Alpha: 1
+  m_Alpha: 0
   m_Interactable: 0
   m_BlocksRaycasts: 0
   m_IgnoreParentGroups: 0
@@ -582,6 +583,23 @@ MonoBehaviour:
   - {fileID: 6817560313460574097}
   m_LoadingProgressManager: {fileID: 0}
   m_PersistentPlayerRuntimeCollection: {fileID: 11400000, guid: 23c3465e22da67c4e812c4faf3adb1cb, type: 2}
+--- !u!114 &2516136186326398479
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 948382310089859896}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
 --- !u!1 &1057458229063515816
 GameObject:
   m_ObjectHideFlags: 0

--- a/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/ClientLoadingScreen.cs
+++ b/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/ClientLoadingScreen.cs
@@ -71,7 +71,7 @@ namespace Unity.Multiplayer.Samples.Utilities
 
         void Start()
         {
-            m_CanvasGroup.alpha = 0;
+            SetCanvasVisibility(false);
             m_LoadingProgressManager.onTrackersUpdated += OnProgressTrackersUpdated;
         }
 
@@ -130,7 +130,7 @@ namespace Unity.Multiplayer.Samples.Utilities
 
         public void StartLoadingScreen(string sceneName)
         {
-            m_CanvasGroup.alpha = 1;
+            SetCanvasVisibility(true);
             m_LoadingScreenRunning = true;
             UpdateLoadingScreen(sceneName);
             ReinitializeProgressBars();
@@ -220,6 +220,12 @@ namespace Unity.Multiplayer.Samples.Utilities
             }
         }
 
+        void SetCanvasVisibility(bool visible)
+        {
+            m_CanvasGroup.alpha = visible ? 1 : 0;
+            m_CanvasGroup.blocksRaycasts = visible;
+        }
+
         IEnumerator FadeOutCoroutine()
         {
             yield return new WaitForSeconds(m_DelayBeforeFadeOut);
@@ -233,7 +239,7 @@ namespace Unity.Multiplayer.Samples.Utilities
                 currentTime += Time.deltaTime;
             }
 
-            m_CanvasGroup.alpha = 0;
+            SetCanvasVisibility(false);
         }
     }
 }


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
This PR adds a graphic raycaster component to the loading screen prefab and makes it so raycast blocking is turned on while the screen is active.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
[MTT-4753](https://jira.unity3d.com/browse/MTT-4753)

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink

