### PR TITLE
feat: bumping RNSM to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 *
 ### Changed
 * Hosts now delete their lobby when shutting down instead of only leaving it (#772) Since Boss Room doesn't support host migration, there is no need to keep the lobby alive after the host shuts down. This also changes how LobbyServiceExceptions are handled to prevent popup messages on clients trying to leave a lobby that is already deleted, following the best practices outlined in this doc : https://docs.unity.com/lobby/delete-a-lobby.html
-* 
+* Bumped RNSM to 1.1.0: Switched x axis units to seconds instead of frames now that it's available. This means adjusting the sample count to a lower value as well to 30 seconds, since the x axis was moving too slowly. (#788)
 ### Cleanup
 *
 ### Fixed

--- a/Packages/com.unity.multiplayer.samples.coop/Utilities/Net/RNSM/CustomNetStatsMonitorConfiguration.asset
+++ b/Packages/com.unity.multiplayer.samples.coop/Utilities/Net/RNSM/CustomNetStatsMonitorConfiguration.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5080a9b907bac3cbc409cf77779de83470afe1262c4c76f661e1453f39ac2a93
-size 5873
+oid sha256:a49a9ee7b8321910ba0662f14c28df614243eaf941cb9b6607312fa6084c3933
+size 6173

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -9,7 +9,7 @@
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.learn.iet-framework": "2.2.2",
     "com.unity.memoryprofiler": "0.5.0-preview.1",
-    "com.unity.multiplayer.tools": "1.0.0",
+    "com.unity.multiplayer.tools": "1.1.0",
     "com.unity.netcode.gameobjects": "1.1.0",
     "com.unity.performance.profile-analyzer": "1.1.1",
     "com.unity.postprocessing": "3.2.2",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -129,7 +129,7 @@
       }
     },
     "com.unity.multiplayer.tools": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
Bumped RNSM to 1.1.0
Switched x axis units to seconds instead of frames now that it's available. This means adjusting the sample count to a lower value as well to 30 seconds, since the x axis was moving too slowly.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 -  Tests have been added for boss room and/or utilities pack
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [ ] An Index entry has been added in readme.md if applicable

