### PR TITLE
feat: Adding build menus to automatically build all platforms for our platests

### DIFF
--- a/Assets/Scripts/Editor/BuildHelpers.cs
+++ b/Assets/Scripts/Editor/BuildHelpers.cs
@@ -168,7 +168,7 @@ internal static class BuildHelpers
         ToggleMenu(k_SkipAutoDeleteToggleName);
     }
 
-    static bool ToggleMenu(string menuName, bool? valueToSet=null)
+    static bool ToggleMenu(string menuName, bool? valueToSet = null)
     {
         bool toSet = !Menu.GetChecked(menuName);
         if (valueToSet != null)

--- a/Assets/Scripts/Editor/BuildHelpers.cs
+++ b/Assets/Scripts/Editor/BuildHelpers.cs
@@ -31,6 +31,7 @@ internal static class BuildHelpers
     const int k_MenuGroupingOtherToggles = 22;
 
     static BuildTarget s_CurrentEditorBuildTarget;
+    static BuildTargetGroup s_CurrentEditorBuildTargetGroup;
     static int s_NbBuildsDone;
 
     static string BuildPathRootDirectory => Path.Combine(Path.GetDirectoryName(Application.dataPath), "Builds", "Playtest");
@@ -86,12 +87,13 @@ internal static class BuildHelpers
     static void RestoreBuildTarget()
     {
         Debug.Log($"restoring editor to initial build target {s_CurrentEditorBuildTarget}");
-        EditorUserBuildSettings.SwitchActiveBuildTarget(s_CurrentEditorBuildTarget);
+        EditorUserBuildSettings.SwitchActiveBuildTarget(s_CurrentEditorBuildTargetGroup, s_CurrentEditorBuildTarget);
     }
 
     static void SaveCurrentBuildTarget()
     {
         s_CurrentEditorBuildTarget = EditorUserBuildSettings.activeBuildTarget;
+        s_CurrentEditorBuildTargetGroup = EditorUserBuildSettings.selectedBuildTargetGroup;
     }
 
     [MenuItem(k_AllToggleName, false, k_MenuGroupingPlatforms)]

--- a/Assets/Scripts/Editor/BuildHelpers.cs
+++ b/Assets/Scripts/Editor/BuildHelpers.cs
@@ -52,7 +52,9 @@ internal static class BuildHelpers
         Debug.Log($"Starting build: buildiOS?:{buildiOS} buildAndroid?:{buildAndroid} buildMacOS?:{buildMacOS} buildWindows?:{buildWindows}");
         if (string.IsNullOrEmpty(CloudProjectSettings.projectId) && !Menu.GetChecked(k_DisableProjectIDToggleName))
         {
-            throw new Exception($"Project ID was supposed to be setup and wasn't, make sure to set it up or disable project ID check with the [{k_DisableProjectIDToggleName}] menu");
+            string errorMessage = $"Project ID was supposed to be setup and wasn't, make sure to set it up or disable project ID check with the [{k_DisableProjectIDToggleName}] menu";
+            EditorUtility.DisplayDialog("Error Custom Build", errorMessage, "ok");
+            throw new Exception(errorMessage);
         }
 
         SaveCurrentBuildTarget();
@@ -64,9 +66,15 @@ internal static class BuildHelpers
 
             if (buildiOS) await BuildPlayerUtilityAsync(BuildTarget.iOS, "", true);
             if (buildAndroid) await BuildPlayerUtilityAsync(BuildTarget.Android, ".apk", true); // there's the possibility of an error where it
+
             // complains about NDK missing. Building manually on android then trying again seems to work? Can't find anything on this.
             if (buildMacOS) await BuildPlayerUtilityAsync(BuildTarget.StandaloneOSX, ".app", true);
             if (buildWindows) await BuildPlayerUtilityAsync(BuildTarget.StandaloneWindows64, ".exe", true);
+        }
+        catch
+        {
+            EditorUtility.DisplayDialog("Exception while building", "See console for details", "ok");
+            throw;
         }
         finally
         {

--- a/Assets/Scripts/Editor/BuildHelpers.cs
+++ b/Assets/Scripts/Editor/BuildHelpers.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.Build.Reporting;
+
+/// <summary>
+/// Utility menus to easily create our builds for our playtests. If you're just exploring this project, you shouldn't need those. They are mostly to make
+/// multiplatform build creation easier and is meant for internal usage.
+/// </summary>
+internal static class BuildHelpers
+{
+    const string k_MenuRoot = "Boss Room/Playtest Builds/";
+    const string k_Build = k_MenuRoot + "Build";
+    const string k_DeleteBuilds = k_MenuRoot + "Delete All Builds (keeps cache)";
+    const string k_AllToggleName = k_MenuRoot + "Toggle All";
+    const string k_MobileToggleName = k_MenuRoot + "Toggle Mobile";
+    const string k_IOSToggleName = k_MenuRoot + "Toggle iOS";
+    const string k_AndroidToggleName = k_MenuRoot + "Toggle Android";
+    const string k_DesktopToggleName = k_MenuRoot + "Toggle Desktop";
+    const string k_MacOSToggleName = k_MenuRoot + "Toggle MacOS";
+    const string k_WindowsToggleName = k_MenuRoot + "Toggle Windows";
+    const string k_DisableProjectIDToggleName = k_MenuRoot + "Skip Project ID Check"; // double negative in the name since menu is unchecked by default
+    const string k_SkipAutoDeleteToggleName = k_MenuRoot + "Skip Auto Delete Builds";
+
+    const int k_MenuGroupingBuild = 0; // to add separator in menus
+    const int k_MenuGroupingPlatforms = 11;
+    const int k_MenuGroupingOtherToggles = 22;
+
+    static BuildTarget s_CurrentEditorBuildTarget;
+    static int s_NbBuildsDone;
+
+    static string BuildPathRootDirectory => Path.Combine(Path.GetDirectoryName(Application.dataPath), "Builds", "Playtest");
+    static string BuildPathDirectory(string platformName) => Path.Combine(BuildPathRootDirectory, platformName);
+    public static string BuildPath(string platformName) => Path.Combine(BuildPathDirectory(platformName), "BossRoomPlaytest");
+
+    [MenuItem(k_Build, false, k_MenuGroupingBuild)]
+    static async void Build()
+    {
+        s_NbBuildsDone = 0;
+        bool buildiOS = Menu.GetChecked(k_IOSToggleName);
+        bool buildAndroid = Menu.GetChecked(k_AndroidToggleName);
+        bool buildMacOS = Menu.GetChecked(k_MacOSToggleName);
+        bool buildWindows = Menu.GetChecked(k_WindowsToggleName);
+
+        bool skipAutoDelete = Menu.GetChecked(k_SkipAutoDeleteToggleName);
+
+        Debug.Log($"Starting build: buildiOS?:{buildiOS} buildAndroid?:{buildAndroid} buildMacOS?:{buildMacOS} buildWindows?:{buildWindows}");
+        if (string.IsNullOrEmpty(CloudProjectSettings.projectId) && !Menu.GetChecked(k_DisableProjectIDToggleName))
+        {
+            throw new Exception($"Project ID was supposed to be setup and wasn't, make sure to set it up or disable project ID check with the [{k_DisableProjectIDToggleName}] menu");
+        }
+
+        SaveCurrentBuildTarget();
+
+        try
+        {
+            // deleting so we don't end up testing on outdated builds if there's a build failure
+            if (!skipAutoDelete) DeleteBuilds();
+
+            if (buildiOS) await BuildPlayerUtilityAsync(BuildTarget.iOS, "", true);
+            if (buildAndroid) await BuildPlayerUtilityAsync(BuildTarget.Android, ".apk", true); // there's the possibility of an error where it
+            // complains about NDK missing. Building manually on android then trying again seems to work? Can't find anything on this.
+            if (buildMacOS) await BuildPlayerUtilityAsync(BuildTarget.StandaloneOSX, ".app", true);
+            if (buildWindows) await BuildPlayerUtilityAsync(BuildTarget.StandaloneWindows64, ".exe", true);
+        }
+        finally
+        {
+            Debug.Log($"Count builds done: {s_NbBuildsDone}");
+            RestoreBuildTarget();
+        }
+    }
+
+    [MenuItem(k_Build, true)]
+    static bool CanBuild()
+    {
+        return Menu.GetChecked(k_IOSToggleName) ||
+            Menu.GetChecked(k_AndroidToggleName) ||
+            Menu.GetChecked(k_MacOSToggleName) ||
+            Menu.GetChecked(k_WindowsToggleName);
+    }
+
+    static void RestoreBuildTarget()
+    {
+        Debug.Log($"restoring editor to initial build target {s_CurrentEditorBuildTarget}");
+        EditorUserBuildSettings.SwitchActiveBuildTarget(s_CurrentEditorBuildTarget);
+    }
+
+    static void SaveCurrentBuildTarget()
+    {
+        s_CurrentEditorBuildTarget = EditorUserBuildSettings.activeBuildTarget;
+    }
+
+    [MenuItem(k_AllToggleName, false, k_MenuGroupingPlatforms)]
+    static void ToggleAll()
+    {
+        var newValue = ToggleMenu(k_AllToggleName);
+        ToggleMenu(k_DesktopToggleName, newValue);
+        ToggleMenu(k_MacOSToggleName, newValue);
+        ToggleMenu(k_WindowsToggleName, newValue);
+        ToggleMenu(k_MobileToggleName, newValue);
+        ToggleMenu(k_IOSToggleName, newValue);
+        ToggleMenu(k_AndroidToggleName, newValue);
+    }
+
+    [MenuItem(k_MobileToggleName, false, k_MenuGroupingPlatforms)]
+    static void ToggleMobile()
+    {
+        var newValue = ToggleMenu(k_MobileToggleName);
+        ToggleMenu(k_IOSToggleName, newValue);
+        ToggleMenu(k_AndroidToggleName, newValue);
+    }
+
+    [MenuItem(k_IOSToggleName, false, k_MenuGroupingPlatforms)]
+    static void ToggleiOS()
+    {
+        ToggleMenu(k_IOSToggleName);
+    }
+
+    [MenuItem(k_AndroidToggleName, false, k_MenuGroupingPlatforms)]
+    static void ToggleAndroid()
+    {
+        ToggleMenu(k_AndroidToggleName);
+    }
+
+    [MenuItem(k_DesktopToggleName, false, k_MenuGroupingPlatforms)]
+    static void ToggleDesktop()
+    {
+        var newValue = ToggleMenu(k_DesktopToggleName);
+        ToggleMenu(k_MacOSToggleName, newValue);
+        ToggleMenu(k_WindowsToggleName, newValue);
+    }
+
+    [MenuItem(k_MacOSToggleName, false, k_MenuGroupingPlatforms)]
+    static void ToggleMacOS()
+    {
+        ToggleMenu(k_MacOSToggleName);
+    }
+
+    [MenuItem(k_WindowsToggleName, false, k_MenuGroupingPlatforms)]
+    static void ToggleWindows()
+    {
+        ToggleMenu(k_WindowsToggleName);
+    }
+
+    [MenuItem(k_DisableProjectIDToggleName, false, k_MenuGroupingOtherToggles)]
+    static void ToggleProjectID()
+    {
+        ToggleMenu(k_DisableProjectIDToggleName);
+    }
+
+    [MenuItem(k_SkipAutoDeleteToggleName, false, k_MenuGroupingOtherToggles)]
+    static void ToggleAutoDelete()
+    {
+        ToggleMenu(k_SkipAutoDeleteToggleName);
+    }
+
+    static bool ToggleMenu(string menuName, bool? valueToSet=null)
+    {
+        bool toSet = !Menu.GetChecked(menuName);
+        if (valueToSet != null)
+        {
+            toSet = valueToSet.Value;
+        }
+
+        Menu.SetChecked(menuName, toSet);
+        return toSet;
+    }
+
+    static async Task BuildPlayerUtilityAsync(BuildTarget buildTarget = BuildTarget.NoTarget, string buildPathExtension = null, bool buildDebug = false)
+    {
+        s_NbBuildsDone++;
+        Debug.Log($"Starting build for {buildTarget.ToString()}");
+
+        await Task.Delay(100); // skipping some time to make sure debug logs are flushed before we build
+
+        // Debug.Log("sleeping");
+        // Thread.Sleep(5000);
+        // Debug.Log("done sleeping");
+        // return;
+
+        var buildPathToUse = BuildPath(buildTarget.ToString());
+        buildPathToUse += buildPathExtension;
+
+        var buildPlayerOptions = new BuildPlayerOptions();
+
+        List<string> scenesToInclude = new List<string>();
+        foreach (var scene in EditorBuildSettings.scenes)
+        {
+            if (scene.enabled)
+            {
+                scenesToInclude.Add(scene.path);
+            }
+        }
+
+        buildPlayerOptions.scenes = scenesToInclude.ToArray();
+        buildPlayerOptions.locationPathName = buildPathToUse;
+        buildPlayerOptions.target = buildTarget;
+        var buildOptions = BuildOptions.None;
+        if (buildDebug)
+        {
+            buildOptions |= BuildOptions.Development;
+        }
+
+        buildOptions |= BuildOptions.StrictMode;
+        buildPlayerOptions.options = buildOptions;
+
+        BuildReport report = BuildPipeline.BuildPlayer(buildPlayerOptions);
+        BuildSummary summary = report.summary;
+
+        if (summary.result == BuildResult.Succeeded)
+        {
+            Debug.Log($"Build succeeded: {summary.totalSize} bytes at {summary.outputPath}");
+        }
+        else
+        {
+            string debugString = buildDebug ? "debug" : "release";
+            throw new Exception($"Build failed for {debugString}:{buildTarget}! {report.summary.totalErrors} errors");
+        }
+    }
+
+    [MenuItem(k_DeleteBuilds, false, k_MenuGroupingBuild)]
+    public static void DeleteBuilds()
+    {
+        if (Directory.Exists(BuildPathRootDirectory))
+        {
+            Directory.Delete(BuildPathRootDirectory, recursive: true);
+            Debug.Log($"deleted {BuildPathRootDirectory}");
+        }
+        else
+        {
+            Debug.Log($"Build directory does not exist ({BuildPathRootDirectory}). No cleanup to do");
+        }
+    }
+}

--- a/Assets/Scripts/Editor/BuildHelpers.cs
+++ b/Assets/Scripts/Editor/BuildHelpers.cs
@@ -177,11 +177,6 @@ internal static class BuildHelpers
 
         await Task.Delay(100); // skipping some time to make sure debug logs are flushed before we build
 
-        // Debug.Log("sleeping");
-        // Thread.Sleep(5000);
-        // Debug.Log("done sleeping");
-        // return;
-
         var buildPathToUse = BuildPath(buildTarget.ToString());
         buildPathToUse += buildPathExtension;
 

--- a/Assets/Scripts/Editor/BuildHelpers.cs.meta
+++ b/Assets/Scripts/Editor/BuildHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3034a09a9ffb54a08be046bd5398a476
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

This adds a new "Boss Room/Playtest Builds" menu that contains different build options and toggles. This will allow to build all required platforms in one go without having to change build target manually and making sure project ID is setup.
This is meant as an internal tool for Unity folks, not for users (usual manual build flow for users must remain valid).

Not adding this to our release note as this is not meant for users.

This is not integrated in CI (yet). This can be called manually while waiting for future CI implementation.

<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
![Screen Shot 2022-12-14 at 6 00 52 PM](https://user-images.githubusercontent.com/71790295/207733825-eaaf486c-1ff4-47a5-a135-1690d8402dca.png)

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [ ] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [ ] An Index entry has been added in readme.md if applicable

