### PR TITLE
chore: Removing (now) redundant cached NetworkBehaviour status

### DIFF
--- a/Assets/Scripts/Gameplay/GameplayObjects/Character/ClientCharacter.cs
+++ b/Assets/Scripts/Gameplay/GameplayObjects/Character/ClientCharacter.cs
@@ -63,8 +63,6 @@ namespace Unity.BossRoom.Gameplay.GameplayObjects.Character
 
         Quaternion m_LerpedRotation;
 
-        bool m_IsHost;
-
         float m_CurrentSpeed;
 
         /// <summary>
@@ -119,8 +117,6 @@ namespace Unity.BossRoom.Gameplay.GameplayObjects.Character
             }
 
             enabled = true;
-
-            m_IsHost = IsHost;
 
             m_ClientActionViz = new ClientActionPlayer(this);
 
@@ -268,7 +264,7 @@ namespace Unity.BossRoom.Gameplay.GameplayObjects.Character
             // the game camera tracks a GameObject moving in the Update loop and therefore eliminate any camera jitter,
             // this graphics GameObject's position is smoothed over time on the host. Clients do not need to perform any
             // positional smoothing since NetworkTransform will interpolate position updates on the root GameObject.
-            if (m_IsHost)
+            if (IsHost)
             {
                 // Note: a cached position (m_LerpedPosition) and rotation (m_LerpedRotation) are created and used as
                 // the starting point for each interpolation since the root's position and rotation are modified in

--- a/Assets/Scripts/Utils/NetworkOverlay/NetworkStats.cs
+++ b/Assets/Scripts/Utils/NetworkOverlay/NetworkStats.cs
@@ -61,14 +61,10 @@ namespace Unity.BossRoom.Utils
 
         ClientRpcParams m_PongClientParams;
 
-        bool m_IsServer;
-
         string m_TextToDisplay;
 
         public override void OnNetworkSpawn()
         {
-            m_IsServer = IsServer;
-
             bool isClientOnly = IsClient && !IsServer;
             if (!IsOwner && isClientOnly) // we don't want to track player ghost stats, only our own
             {
@@ -98,7 +94,7 @@ namespace Unity.BossRoom.Utils
 
         void FixedUpdate()
         {
-            if (!m_IsServer)
+            if (!IsServer)
             {
                 if (Time.realtimeSinceStartup - m_LastPingTime > k_PingIntervalSeconds)
                 {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ## [unreleased] - yyyy-mm-dd
 ### Cleanup
 * Clarified a TODO comment inside ClientCharacter, detailing how anticipation should only be executed on owning client players (#786)
+* Removed now unnecessary cached NetworkBehaviour status on some components, since they now do not allocate memory (#799)
 
 ### Fixed
 * EnemyPortals' VFX get disabled and re-enabled once the breakable crystals are broken (#784)


### PR DESCRIPTION
### Description
Quick PR to remove cached NetworkBehaviour status checks that were previously allocating memory. This has since been optimized NGO-side.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[MTT-5239](https://jira.unity3d.com/browse/MTT-5239)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [ ] An Index entry has been added in readme.md if applicable

