### PR TITLE
fix: wrong base class for ClientConnectedState [MTT-5293]

### DIFF
--- a/Assets/Scripts/ConnectionManagement/ConnectionMethod.cs
+++ b/Assets/Scripts/ConnectionManagement/ConnectionMethod.cs
@@ -21,6 +21,7 @@ namespace Unity.BossRoom.ConnectionManagement
         protected ConnectionManager m_ConnectionManager;
         readonly ProfileManager m_ProfileManager;
         protected readonly string m_PlayerName;
+        protected const string k_DtlsConnType = "dtls";
 
         public abstract Task SetupHostConnectionAsync();
 
@@ -128,7 +129,7 @@ namespace Unity.BossRoom.ConnectionManagement
 
             // Configure UTP with allocation
             var utp = (UnityTransport)m_ConnectionManager.NetworkManager.NetworkConfig.NetworkTransport;
-            utp.SetRelayServerData(new RelayServerData(joinedAllocation, OnlineState.k_DtlsConnType));
+            utp.SetRelayServerData(new RelayServerData(joinedAllocation, k_DtlsConnType));
         }
 
         public override async Task SetupHostConnectionAsync()
@@ -152,7 +153,7 @@ namespace Unity.BossRoom.ConnectionManagement
 
             // Setup UTP with relay connection info
             var utp = (UnityTransport)m_ConnectionManager.NetworkManager.NetworkConfig.NetworkTransport;
-            utp.SetRelayServerData(new RelayServerData(hostAllocation, OnlineState.k_DtlsConnType)); // This is with DTLS enabled for a secure connection
+            utp.SetRelayServerData(new RelayServerData(hostAllocation, k_DtlsConnType)); // This is with DTLS enabled for a secure connection
         }
     }
 }

--- a/Assets/Scripts/ConnectionManagement/ConnectionState/ClientConnectedState.cs
+++ b/Assets/Scripts/ConnectionManagement/ConnectionState/ClientConnectedState.cs
@@ -9,7 +9,7 @@ namespace Unity.BossRoom.ConnectionManagement
     /// Connection state corresponding to a connected client. When being disconnected, transitions to the
     /// ClientReconnecting state if no reason is given, or to the Offline state.
     /// </summary>
-    class ClientConnectedState : ConnectionState
+    class ClientConnectedState : OnlineState
     {
         [Inject]
         protected LobbyServiceFacade m_LobbyServiceFacade;
@@ -38,12 +38,6 @@ namespace Unity.BossRoom.ConnectionManagement
                 m_ConnectStatusPublisher.Publish(connectStatus);
                 m_ConnectionManager.ChangeState(m_ConnectionManager.m_Offline);
             }
-        }
-
-        public override void OnUserRequestedShutdown()
-        {
-            m_ConnectStatusPublisher.Publish(ConnectStatus.UserRequestedDisconnect);
-            m_ConnectionManager.ChangeState(m_ConnectionManager.m_Offline);
         }
     }
 }

--- a/Assets/Scripts/ConnectionManagement/ConnectionState/OnlineState.cs
+++ b/Assets/Scripts/ConnectionManagement/ConnectionState/OnlineState.cs
@@ -5,8 +5,6 @@ namespace Unity.BossRoom.ConnectionManagement
     /// </summary>
     abstract class OnlineState : ConnectionState
     {
-        public const string k_DtlsConnType = "dtls";
-
         public override void OnUserRequestedShutdown()
         {
             // This behaviour will be the same for every online state

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Fixed
 * EnemyPortals' VFX get disabled and re-enabled once the breakable crystals are broken (#784)
 * Elements inside the Tank's and Rogue's AnimatorTriggeredSpecialFX list have been revised to not loop AudioSource clips, ending the logging of multiple warnings to the console (#785)
+* ClientConnectedState now inherits from OnlineState instead of ClientConnectedState (#801)
 
 ## [2.0.4] - 2022-12-13
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Fixed
 * EnemyPortals' VFX get disabled and re-enabled once the breakable crystals are broken (#784)
 * Elements inside the Tank's and Rogue's AnimatorTriggeredSpecialFX list have been revised to not loop AudioSource clips, ending the logging of multiple warnings to the console (#785)
-* ClientConnectedState now inherits from OnlineState instead of ClientConnectedState (#801)
+* ClientConnectedState now inherits from OnlineState instead of the base ConnectionState (#801)
 
 ## [2.0.4] - 2022-12-13
 ### Changed


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
This fixes the ClientConnectedState class having the wrong base class. It now properly inherits from OnlineState instead of the base ConnectionState. This PR also moves the k_DtlsConnType constant to the ConnectionMethod class, where it is actually used.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
[MTT-5293](https://jira.unity3d.com/browse/MTT-5293)

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [ ] An Index entry has been added in readme.md if applicable

