### PR TITLE
refactor: replacing custom pool implementation with ObjectPool [MTT-6263]

### DIFF
--- a/Assets/Scripts/Infrastructure/NetworkObjectPool.cs
+++ b/Assets/Scripts/Infrastructure/NetworkObjectPool.cs
@@ -9,16 +9,15 @@ using UnityEngine.Pool;
 namespace Unity.BossRoom.Infrastructure
 {
     /// <summary>
-    /// Object Pool for networked objects, used for controlling how objects are spawned by Netcode. Netcode by default will allocate new memory when spawning new
-    /// objects. With this Networked Pool, we're using custom spawning to reuse objects.
+    /// Object Pool for networked objects, used for controlling how objects are spawned by Netcode. Netcode by default
+    /// will allocate new memory when spawning new objects. With this Networked Pool, we're using the ObjectPool to
+    /// reuse objects.
     /// Boss Room uses this for projectiles. In theory it should use this for imps too, but we wanted to show vanilla spawning vs pooled spawning.
-    /// Hooks to NetworkManager's prefab handler to intercept object spawning and do custom actions
+    /// Hooks to NetworkManager's prefab handler to intercept object spawning and do custom actions.
     /// </summary>
     public class NetworkObjectPool : NetworkBehaviour
     {
-        static NetworkObjectPool s_Instance;
-
-        public static NetworkObjectPool Singleton { get { return s_Instance; } }
+        public static NetworkObjectPool Singleton { get; private set; }
 
         [SerializeField]
         List<PoolConfigObject> PooledPrefabsList;
@@ -31,13 +30,13 @@ namespace Unity.BossRoom.Infrastructure
 
         public void Awake()
         {
-            if (s_Instance != null && s_Instance != this)
+            if (Singleton != null && Singleton != this)
             {
                 Destroy(gameObject);
             }
             else
             {
-                s_Instance = this;
+                Singleton = this;
             }
         }
 
@@ -113,7 +112,7 @@ namespace Unity.BossRoom.Infrastructure
         /// <summary>
         /// Builds up the cache for a prefab.
         /// </summary>
-        private void RegisterPrefabInternal(GameObject prefab, int prewarmCount)
+        void RegisterPrefabInternal(GameObject prefab, int prewarmCount)
         {
             m_Prefabs.Add(prefab);
 

--- a/Assets/Scripts/Infrastructure/NetworkObjectPool.cs
+++ b/Assets/Scripts/Infrastructure/NetworkObjectPool.cs
@@ -110,8 +110,6 @@ namespace Unity.BossRoom.Infrastructure
         /// </summary>
         void RegisterPrefabInternal(GameObject prefab, int prewarmCount)
         {
-            m_Prefabs.Add(prefab);
-
             NetworkObject CreateFunc()
             {
                 return CreateInstance(prefab).GetComponent<NetworkObject>();
@@ -134,6 +132,9 @@ namespace Unity.BossRoom.Infrastructure
                 Destroy(networkObject.gameObject);
             }
 
+            m_Prefabs.Add(prefab);
+
+            // Create the pool
             m_PooledObjects[prefab] = new ObjectPool<NetworkObject>((CreateFunc), ActionOnGet, ActionOnRelease, ActionOnDestroy, defaultCapacity: prewarmCount);
 
             // Populate the pool
@@ -142,7 +143,6 @@ namespace Unity.BossRoom.Infrastructure
             {
                 prewarmNetworkObjects.Add(m_PooledObjects[prefab].Get());
             }
-
             foreach (var networkObject in prewarmNetworkObjects)
             {
                 m_PooledObjects[prefab].Release(networkObject);

--- a/Assets/Scripts/Infrastructure/NetworkObjectPool.cs
+++ b/Assets/Scripts/Infrastructure/NetworkObjectPool.cs
@@ -103,14 +103,12 @@ namespace Unity.BossRoom.Infrastructure
 
             void ActionOnGet(NetworkObject networkObject)
             {
-                var go = networkObject.gameObject;
-                go.SetActive(true);
+                networkObject.gameObject.SetActive(true);
             }
 
             void ActionOnRelease(NetworkObject networkObject)
             {
-                var go = networkObject.gameObject;
-                go.SetActive(false);
+                networkObject.gameObject.SetActive(false);
             }
 
             void ActionOnDestroy(NetworkObject networkObject)
@@ -149,8 +147,9 @@ namespace Unity.BossRoom.Infrastructure
         {
             var networkObject = m_PooledObjects[prefab].Get();
 
-            networkObject.transform.position = position;
-            networkObject.transform.rotation = rotation;
+            var noTransform = networkObject.transform;
+            noTransform.position = position;
+            noTransform.rotation = rotation;
 
             return networkObject;
         }
@@ -176,8 +175,7 @@ namespace Unity.BossRoom.Infrastructure
 
         NetworkObject INetworkPrefabInstanceHandler.Instantiate(ulong ownerClientId, Vector3 position, Quaternion rotation)
         {
-            var netObject = m_Pool.GetNetworkObject(m_Prefab, position, rotation);
-            return netObject;
+            return m_Pool.GetNetworkObject(m_Prefab, position, rotation);
         }
 
         void INetworkPrefabInstanceHandler.Destroy(NetworkObject networkObject)

--- a/Assets/Scripts/Infrastructure/NetworkObjectPool.cs
+++ b/Assets/Scripts/Infrastructure/NetworkObjectPool.cs
@@ -74,6 +74,12 @@ namespace Unity.BossRoom.Infrastructure
         /// <summary>
         /// Gets an instance of the given prefab from the pool. The prefab must be registered to the pool.
         /// </summary>
+        /// <remarks>
+        /// To spawn a NetworkObject from one of the pools, this must be called on the server, then the instance
+        /// returned from it must be spawned on the server. This method will then also be called on the client by the
+        /// PooledPrefabInstanceHandler when the client receives a spawn message for a prefab that has been registered
+        /// here.
+        /// </remarks>
         /// <param name="prefab"></param>
         /// <param name="position">The position to spawn the object at.</param>
         /// <param name="rotation">The rotation to spawn the object with.</param>

--- a/Assets/Scripts/Infrastructure/NetworkObjectPool.cs
+++ b/Assets/Scripts/Infrastructure/NetworkObjectPool.cs
@@ -26,8 +26,6 @@ namespace Unity.BossRoom.Infrastructure
 
         Dictionary<GameObject, ObjectPool<NetworkObject>> m_PooledObjects = new Dictionary<GameObject, ObjectPool<NetworkObject>>();
 
-        bool m_HasInitialized = false;
-
         public void Awake()
         {
             if (Singleton != null && Singleton != this)
@@ -170,20 +168,18 @@ namespace Unity.BossRoom.Infrastructure
         /// <summary>
         /// Registers all objects in <see cref="PooledPrefabsList"/> to the cache.
         /// </summary>
-        public void InitializePool()
+        void InitializePool()
         {
-            if (m_HasInitialized) return;
             foreach (var configObject in PooledPrefabsList)
             {
                 RegisterPrefabInternal(configObject.Prefab, configObject.PrewarmCount);
             }
-            m_HasInitialized = true;
         }
 
         /// <summary>
         /// Unregisters all objects in <see cref="PooledPrefabsList"/> from the cache.
         /// </summary>
-        public void ClearPool()
+        void ClearPool()
         {
             foreach (var prefab in m_Prefabs)
             {
@@ -192,7 +188,6 @@ namespace Unity.BossRoom.Infrastructure
             }
             m_PooledObjects.Clear();
             m_Prefabs.Clear();
-            m_HasInitialized = false;
         }
     }
 

--- a/Assets/Scripts/Infrastructure/NetworkObjectPool.cs
+++ b/Assets/Scripts/Infrastructure/NetworkObjectPool.cs
@@ -64,16 +64,6 @@ namespace Unity.BossRoom.Infrastructure
         /// Gets an instance of the given prefab from the pool. The prefab must be registered to the pool.
         /// </summary>
         /// <param name="prefab"></param>
-        /// <returns></returns>
-        public NetworkObject GetNetworkObject(GameObject prefab)
-        {
-            return GetNetworkObjectInternal(prefab, Vector3.zero, Quaternion.identity);
-        }
-
-        /// <summary>
-        /// Gets an instance of the given prefab from the pool. The prefab must be registered to the pool.
-        /// </summary>
-        /// <param name="prefab"></param>
         /// <param name="position">The position to spawn the object at.</param>
         /// <param name="rotation">The rotation to spawn the object with.</param>
         /// <returns></returns>
@@ -91,28 +81,13 @@ namespace Unity.BossRoom.Infrastructure
         }
 
         /// <summary>
-        /// Adds a prefab to the list of spawnable prefabs.
-        /// </summary>
-        /// <param name="prefab">The prefab to add.</param>
-        /// <param name="prewarmCount"></param>
-        public void AddPrefab(GameObject prefab, int prewarmCount = 0)
-        {
-            var networkObject = prefab.GetComponent<NetworkObject>();
-
-            Assert.IsNotNull(networkObject, $"{nameof(prefab)} must have {nameof(networkObject)} component.");
-            Assert.IsFalse(m_Prefabs.Contains(prefab), $"Prefab {prefab.name} is already registered in the pool.");
-
-            RegisterPrefabInternal(prefab, prewarmCount);
-        }
-
-        /// <summary>
         /// Builds up the cache for a prefab.
         /// </summary>
         void RegisterPrefabInternal(GameObject prefab, int prewarmCount)
         {
             NetworkObject CreateFunc()
             {
-                return CreateInstance(prefab).GetComponent<NetworkObject>();
+                return Instantiate(prefab).GetComponent<NetworkObject>();
             }
 
             void ActionOnGet(NetworkObject networkObject)
@@ -150,12 +125,6 @@ namespace Unity.BossRoom.Infrastructure
 
             // Register Netcode Spawn handlers
             NetworkManager.Singleton.PrefabHandler.AddHandler(prefab, new PooledPrefabInstanceHandler(prefab, this));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        GameObject CreateInstance(GameObject prefab)
-        {
-            return Instantiate(prefab);
         }
 
         /// <summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 * Replaced our polling for lobby updates with a subscription to the new Websocket based LobbyEvents (#805). This saves up a significant amount of bandwidth usage to and from the service, since updates are infrequent in this game. Now clients and hosts only use up bandwidth on the Lobby service when it is needed. With polling, we used to send a GET request per client once every 2s. The responses were between ~550 bytes and 900 bytes, so if we suppose an average of 725 bytes and 100 000 concurrent users (CCU), this amounted to around 725B * 30 calls per minute * 100 000 CCU = 2.175 GB per minute. Scaling this to a month would get us 93.96 TB per month. In our case, since the only changes to the lobbies happen when a user connects or disconnects, most of that data was not necessary and can be saved to reduce bandwidth usage. Since the cost of using the Lobby service depends on bandwidth usage, this would also save money on an actual game.
+* Replaced our custom pool implementation using queues with ObjectPool (#824)
 * 
 ### Cleanup
 * Clarified a TODO comment inside ClientCharacter, detailing how anticipation should only be executed on owning client players (#786)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Changed
 * Replaced our polling for lobby updates with a subscription to the new Websocket based LobbyEvents (#805). This saves up a significant amount of bandwidth usage to and from the service, since updates are infrequent in this game. Now clients and hosts only use up bandwidth on the Lobby service when it is needed. With polling, we used to send a GET request per client once every 2s. The responses were between ~550 bytes and 900 bytes, so if we suppose an average of 725 bytes and 100 000 concurrent users (CCU), this amounted to around 725B * 30 calls per minute * 100 000 CCU = 2.175 GB per minute. Scaling this to a month would get us 93.96 TB per month. In our case, since the only changes to the lobbies happen when a user connects or disconnects, most of that data was not necessary and can be saved to reduce bandwidth usage. Since the cost of using the Lobby service depends on bandwidth usage, this would also save money on an actual game.
-* Replaced our custom pool implementation using queues with ObjectPool (#824)
 * Simplified reconnection flow by offloading responsibility to ConnectionMethod (#804). Now the ClientReconnectingState uses the ConnectionMethod it is configured with to handle setting up reconnection (i.e. reconnecting to the Lobby before trying to reconnect to the Relay server if it is using Relay and Lobby). It can now also fail early and stop retrying if the lobby doesn't exist anymore.
+* Replaced our custom pool implementation using queues with ObjectPool (#824)
 
 ### Cleanup
 * Clarified a TODO comment inside ClientCharacter, detailing how anticipation should only be executed on owning client players (#786)


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
This PR replaces our custom pool implementation using queues with the `ObjectPool` collection. It also removes the methods `InitializePool` and `ClearPool` and moves their content in `OnNetworkSpawn` and `OnNetworkDespawn`

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
[MTT-6263](https://jira.unity3d.com/browse/MTT-6263) & [MTT-4696](https://jira.unity3d.com/browse/MTT-4696)

### Contribution checklist
 - [n/a] Tests have been added for boss room and/or utilities pack
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [n/a] An Index entry has been added in readme.md if applicable

