### PR TITLE
fix: decoupling SceneLoaderWrapper and ConnectionStates [MTT-6242]

### DIFF
--- a/Assets/Scripts/ConnectionManagement/ConnectionState/ClientConnectingState.cs
+++ b/Assets/Scripts/ConnectionManagement/ConnectionState/ClientConnectingState.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using Unity.Multiplayer.Samples.Utilities;
 using UnityEngine;
 
 namespace Unity.BossRoom.ConnectionManagement
@@ -68,8 +67,6 @@ namespace Unity.BossRoom.ConnectionManagement
                 {
                     throw new Exception("NetworkManager StartClient failed");
                 }
-
-                SceneLoaderWrapper.Instance.AddOnSceneEventCallback();
             }
             catch (Exception e)
             {

--- a/Assets/Scripts/ConnectionManagement/ConnectionState/HostingState.cs
+++ b/Assets/Scripts/ConnectionManagement/ConnectionState/HostingState.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using Unity.BossRoom.Infrastructure;
 using Unity.BossRoom.UnityServices.Lobbies;
 using Unity.Multiplayer.Samples.BossRoom;
@@ -26,8 +25,6 @@ namespace Unity.BossRoom.ConnectionManagement
 
         public override void Enter()
         {
-            SceneLoaderWrapper.Instance.AddOnSceneEventCallback();
-
             //The "BossRoom" server always advances to CharSelect immediately on start. Different games
             //may do this differently.
             SceneLoaderWrapper.Instance.LoadScene("CharSelect", useNetworkSceneManager: true);

--- a/Assets/Tests/Runtime/ConnectionManagementTests.cs
+++ b/Assets/Tests/Runtime/ConnectionManagementTests.cs
@@ -55,8 +55,6 @@ namespace Unity.BossRoom.Tests.Runtime
 
             public override void Start() { }
 
-            public override void AddOnSceneEventCallback() { }
-
             public override void LoadScene(string sceneName, bool useNetworkSceneManager, LoadSceneMode loadSceneMode = LoadSceneMode.Single) { }
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Changed
 * Replaced our polling for lobby updates with a subscription to the new Websocket based LobbyEvents (#805). This saves up a significant amount of bandwidth usage to and from the service, since updates are infrequent in this game. Now clients and hosts only use up bandwidth on the Lobby service when it is needed. With polling, we used to send a GET request per client once every 2s. The responses were between ~550 bytes and 900 bytes, so if we suppose an average of 725 bytes and 100 000 concurrent users (CCU), this amounted to around 725B * 30 calls per minute * 100 000 CCU = 2.175 GB per minute. Scaling this to a month would get us 93.96 TB per month. In our case, since the only changes to the lobbies happen when a user connects or disconnects, most of that data was not necessary and can be saved to reduce bandwidth usage. Since the cost of using the Lobby service depends on bandwidth usage, this would also save money on an actual game.
 * Simplified reconnection flow by offloading responsibility to ConnectionMethod (#804). Now the ClientReconnectingState uses the ConnectionMethod it is configured with to handle setting up reconnection (i.e. reconnecting to the Lobby before trying to reconnect to the Relay server if it is using Relay and Lobby). It can now also fail early and stop retrying if the lobby doesn't exist anymore.
-* Replaced our custom pool implementation using queues with ObjectPool (#824)
+* Replaced our custom pool implementation using queues with ObjectPool (#824)(#827)
 * Upgraded Boss Room to NGO 1.3.1 (#828) NetworkPrefabs inside NetworkManager's NetworkPrefabs list have been converted to NetworkPrefabsList ScriptableObject. 
 
 ### Cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 * ClientConnectedState now inherits from OnlineState instead of the base ConnectionState (#801)
 * UpdateRunner now sends the right value for deltaTime when updating its subscribers (#805)
 * Inputs are better sanitized when entering IP address and port (#821). Now all invalid characters are prevented, and UnityTransport's NetworkEndpoint.TryParse is used to verify the validity of the IP address and port that are entered before making the join/host button interactable.
+* Decoupled SceneLoaderWrapper and ConnectionStates (#830). The OnServerStarted and OnClientStarted callbacks available in NGO 1.4.0 allows us to remove the need for an external method to initialize the SceneLoaderWrapper after starting a NetworkingSession.
 
 ## [2.0.4] - 2022-12-13
 ### Changed

--- a/Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md
+++ b/Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [unreleased] - yyyy-mm-dd
 
+### Changed
+* Removed need for SceneLoaderWrapper.AddOnSceneEventCallback (#830). The OnServerStarted and OnClientStarted callbacks available in NGO 1.4.0 allows us to remove the need for an external method to initialize the SceneLoaderWrapper after starting a NetworkingSession.
+
 ## [1.5.1] - 2022-12-13
 ### Changed
 * Bumped RNSM to 1.1.0: Switched x axis units to seconds instead of frames now that it's available. This means adjusting the sample count to a lower value as well to 30 seconds, since the x axis was moving too slowly. (#788)

--- a/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/SceneLoaderWrapper.cs
+++ b/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/SceneLoaderWrapper.cs
@@ -21,6 +21,8 @@ namespace Unity.Multiplayer.Samples.Utilities
 
         bool IsNetworkSceneManagementEnabled => NetworkManager != null && NetworkManager.SceneManager != null && NetworkManager.NetworkConfig.EnableSceneManagement;
 
+        bool m_IsInitialized;
+
         public static SceneLoaderWrapper Instance { get; protected set; }
 
         public virtual void Awake()
@@ -39,32 +41,47 @@ namespace Unity.Multiplayer.Samples.Utilities
         public virtual void Start()
         {
             SceneManager.sceneLoaded += OnSceneLoaded;
+            NetworkManager.OnServerStarted += OnNetworkingSessionStarted;
+            NetworkManager.OnClientStarted += OnNetworkingSessionStarted;
+            NetworkManager.OnServerStopped += OnNetworkingSessionEnded;
+            NetworkManager.OnClientStopped += OnNetworkingSessionEnded;
+        }
+
+        void OnNetworkingSessionStarted()
+        {
+            // This prevents this to be called twice on a host, which receives both OnServerStarted and OnClientStarted callbacks
+            if (!m_IsInitialized)
+            {
+                if (IsNetworkSceneManagementEnabled)
+                {
+                    NetworkManager.SceneManager.OnSceneEvent += OnSceneEvent;
+                }
+
+                m_IsInitialized = true;
+            }
+        }
+
+        void OnNetworkingSessionEnded(bool unused)
+        {
+            if (m_IsInitialized)
+            {
+                if (IsNetworkSceneManagementEnabled)
+                {
+                    NetworkManager.SceneManager.OnSceneEvent -= OnSceneEvent;
+                }
+
+                m_IsInitialized = false;
+            }
         }
 
         public override void OnDestroy()
         {
             SceneManager.sceneLoaded -= OnSceneLoaded;
+            NetworkManager.OnServerStarted -= OnNetworkingSessionStarted;
+            NetworkManager.OnClientStarted -= OnNetworkingSessionStarted;
+            NetworkManager.OnServerStopped -= OnNetworkingSessionEnded;
+            NetworkManager.OnClientStopped -= OnNetworkingSessionEnded;
             base.OnDestroy();
-        }
-
-        public override void OnNetworkDespawn()
-        {
-            if (NetworkManager != null && NetworkManager.SceneManager != null)
-            {
-                NetworkManager.SceneManager.OnSceneEvent -= OnSceneEvent;
-            }
-        }
-
-        /// <summary>
-        /// Initializes the callback on scene events. This needs to be called right after initializing NetworkManager
-        /// (after StartHost, StartClient or StartServer)
-        /// </summary>
-        public virtual void AddOnSceneEventCallback()
-        {
-            if (IsNetworkSceneManagementEnabled)
-            {
-                NetworkManager.SceneManager.OnSceneEvent += OnSceneEvent;
-            }
         }
 
         /// <summary>

--- a/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/SceneLoaderWrapper.cs
+++ b/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/SceneLoaderWrapper.cs
@@ -77,10 +77,13 @@ namespace Unity.Multiplayer.Samples.Utilities
         public override void OnDestroy()
         {
             SceneManager.sceneLoaded -= OnSceneLoaded;
-            NetworkManager.OnServerStarted -= OnNetworkingSessionStarted;
-            NetworkManager.OnClientStarted -= OnNetworkingSessionStarted;
-            NetworkManager.OnServerStopped -= OnNetworkingSessionEnded;
-            NetworkManager.OnClientStopped -= OnNetworkingSessionEnded;
+            if (NetworkManager != null)
+            {
+                NetworkManager.OnServerStarted -= OnNetworkingSessionStarted;
+                NetworkManager.OnClientStarted -= OnNetworkingSessionStarted;
+                NetworkManager.OnServerStopped -= OnNetworkingSessionEnded;
+                NetworkManager.OnClientStopped -= OnNetworkingSessionEnded;
+            }
             base.OnDestroy();
         }
 


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
This PR removes SceneLoaderWrapper.AddOnSceneEventCallback and replaces it with registrations to NetworkManager OnServerStarted and OnClientStarted callbacks.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
[MTT-6242](https://jira.unity3d.com/browse/MTT-6242)

### Contribution checklist
 - [x] Tests have been added for boss room and/or utilities pack
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [n/a] An Index entry has been added in readme.md if applicable

