### PR TITLE
deleted default network prefabs asset

### DIFF
--- a/Assets/DefaultNetworkPrefabs.asset
+++ b/Assets/DefaultNetworkPrefabs.asset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4ea3d807af7c9ec66aebf48d9e112b0e3ba2fe55867d1f99ec53f744502aa727
-size 6447

--- a/Assets/DefaultNetworkPrefabs.asset.meta
+++ b/Assets/DefaultNetworkPrefabs.asset.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 164b10da014f4d749a423fe48ea7d685
-NativeFormatImporter:
-  externalObjects: {}
-  mainObjectFileID: 11400000
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
### Description
deleted the default network prefabs asset that I accidentally pushed

### Contribution checklist
 - [n/a] Tests have been added for boss room and/or utilities pack
 - [n/a] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [n/a] JIRA ticket ID is in the PR title or at least one commit message
 - [n/a] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [n/a] An Index entry has been added in readme.md if applicable

