### PR TITLE
fix: Yamato tests run on 2022.3.0

### DIFF
--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -30,4 +30,4 @@ projects:
       - name: com.unity.multiplayer.samples.coop
         path: Packages/com.unity.multiplayer.samples.coop
     test_editors:
-      - 2022.3
+      - 2022.3.0


### PR DESCRIPTION
### Description
This PR updates the Yamato project metafile to run tests on 2022.3.0. This will be reverted back come a new NGO version update, along with an LTs upgrade as well.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
N/A
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ N/A ] Tests have been added for boss room and/or utilities pack
 - [ N/A ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ N/A ] JIRA ticket ID is in the PR title or at least one commit message
 - [ N/A ] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [ N/A ] An Index entry has been added in readme.md if applicable

