### PR TITLE
fix: NetworkVariable warnings on player spawns [MTT-7161]

### DIFF
--- a/Assets/Scripts/Gameplay/GameState/ServerBossRoomState.cs
+++ b/Assets/Scripts/Gameplay/GameState/ServerBossRoomState.cs
@@ -204,13 +204,13 @@ namespace Unity.BossRoom.Gameplay.GameState
                 }
             }
 
-            networkAvatarGuidState.AvatarGuid.Value =
-                persistentPlayer.NetworkAvatarGuidState.AvatarGuid.Value;
+            // instantiate new NetworkVariables with a default value to ensure they're ready for use on OnNetworkSpawn
+            networkAvatarGuidState.AvatarGuid = new NetworkVariable<NetworkGuid>(persistentPlayer.NetworkAvatarGuidState.AvatarGuid.Value);
 
             // pass name from persistent player to avatar
             if (newPlayer.TryGetComponent(out NetworkNameState networkNameState))
             {
-                networkNameState.Name.Value = persistentPlayer.NetworkNameState.Name.Value;
+                networkNameState.Name = new NetworkVariable<FixedPlayerName>(persistentPlayer.NetworkNameState.Name.Value);
             }
 
             // spawn players characters with destroyWithScene = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+## [unreleased] - yyyy-mm-dd
+
+### Fixed
+* Fixed NetworkVariable warnings that would be logged when a player was spawned (#863) For a player, certain NetworkVariable values were previously modified before the player's NetworkObject was spawned, resulting in warnings. Now, the NetworkVariable itself is instantiated on the server pre-spawn, such that it is instantiated with the new default value, ensuring the new default value is ready to be read on subsequent OnNetworkSpawn methods for said NetworkObject.
+
 ## [2.3.0] - 2023-09-07
 
 ### Changed


### PR DESCRIPTION
### Description
This PR fixes warnings generated when modifying a NetworkVariable before a player NetworkObject was spawned. Instead the NetworkVariable is spawned before the NetworkObject is spawned, ensuring the NetworkVariable is instantiated with the new default value, and so is ready to be consumed on OnNetworkSpawn methods -- a pattern we wish to keep.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[MTT-7161](https://jira.unity3d.com/browse/MTT-7161)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ N/A ] Tests have been added for boss room and/or utilities pack
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [ N/A ] An Index entry has been added in readme.md if applicable

