### PR TITLE
Fix: Removed NetworkObject from Scene State Game Object [MTT-5234]

### DIFF
--- a/Assets/Prefabs/State/MainMenuState.prefab
+++ b/Assets/Prefabs/State/MainMenuState.prefab
@@ -9,7 +9,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3747962111577947793}
-  - component: {fileID: 499205456468354965}
   - component: {fileID: 8576152884213668000}
   - component: {fileID: 2665876610389888237}
   - component: {fileID: 7369153188685295691}
@@ -34,32 +33,12 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!114 &499205456468354965
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8576152884213668003}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 951099334
-  AlwaysReplicateAsRoot: 0
-  SynchronizeTransform: 0
-  ActiveSceneSynchronization: 0
-  SceneMigrationSynchronization: 1
-  DontDestroyWithOwner: 0
-  AutoObjectParentSync: 1
 --- !u!114 &8576152884213668000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -100,7 +79,9 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:718390f368afa76ac2579268b1d09eb7807496721bbc1f6cc1fc9fb6de2a74e1
-size 71522
+oid sha256:2f42f44e58e165cddd54ae1a554ec6e13212353e3fbc04756771b9e70f3cf371
+size 71441

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ca89d724f7bc5f0ef930a26462369191017995509ae4cdaefafe43010e62491
-size 68542
+oid sha256:718390f368afa76ac2579268b1d09eb7807496721bbc1f6cc1fc9fb6de2a74e1
+size 71522

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ## [Unreleased]
 
 ### Cleanup
-* Removed NetworkObject from MainMenuState
+* Removed NetworkObject from MainMenuState (#881)
 
 ## [2.4.0] - 2023-12-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 Additional documentation and release notes are available at [Multiplayer Documentation](https://docs-multiplayer.unity3d.com).
 
+## [Unreleased]
+
+### Cleanup
+* Removed NetworkObject from MainMenuState
+
 ## [2.4.0] - 2023-12-13
 
 ### Changed


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

I removed the NetworkObject component from the Main Menu Scene State Game Object as it does not need this one. Other scenes do need the NetworkObject for the scene state as far as I can see though. Please confirm if that is the case.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
[MTT-5234](https://jira.unity3d.com/browse/MTT-5234)

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [ ] An Index entry has been added in readme.md if applicable

