### PR TITLE
chore: keeping Yamato tests at 2022.3.14 until editor is upgraded

### DIFF
--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -30,4 +30,4 @@ projects:
       - name: com.unity.multiplayer.samples.coop
         path: Packages/com.unity.multiplayer.samples.coop
     test_editors:
-      - 2022.3
+      - 2022.3.14


### PR DESCRIPTION
### Description
PR to keep project metafile version number locked at our current editor version, since Yamato is reporting failures at the latest 2022.3.x release.

This is a temporary addition, and will be reverted once KTLO is started, which will include editor bump.

<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
None, but [MTT-8160](https://jira.unity3d.com/browse/MTT-8160)- has been created to track this workaround for testing.
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
N/A - just looking for tests to succeed so that subsequent PRs targeting this version can be merged.
 - [ N/A ] Tests have been added for boss room and/or utilities pack
 - [ N/A  ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [ N/A ] Pull request has a meaningful description of its purpose
 - [ N/A ] All commits are accompanied by meaningful commit messages
 - [ N/A ] JIRA ticket ID is in the PR title or at least one commit message
 - [ N/A ] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [ N/A ] An Index entry has been added in readme.md if applicable

