### PR TITLE
fix: NullReferenceException logged when despawning non-spawned NetworkObjects [MTTB-1147]

### DIFF
--- a/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/LoadingProgressManager.cs
+++ b/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/LoadingProgressManager.cs
@@ -143,7 +143,10 @@ namespace Unity.Multiplayer.Samples.Utilities
                 {
                     var tracker = ProgressTrackers[clientId];
                     ProgressTrackers.Remove(clientId);
-                    tracker.NetworkObject.Despawn();
+                    if (tracker.NetworkObject.IsSpawned)
+                    {
+                        tracker.NetworkObject.Despawn();
+                    }
                     ClientUpdateTrackersRpc();
                 }
             }


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[MTT-1147](https://jira.unity3d.com/browse/MTTB-1147)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [ ] An Index entry has been added in readme.md if applicable

