### PR TITLE
feat: OnConnectionEvent callback usage in project and Utilities package [MTTB-1147]

### DIFF
--- a/Assets/Scripts/ConnectionManagement/ConnectionManager.cs
+++ b/Assets/Scripts/ConnectionManagement/ConnectionManager.cs
@@ -93,8 +93,7 @@ namespace Unity.BossRoom.ConnectionManagement
 
             m_CurrentState = m_Offline;
 
-            NetworkManager.OnClientConnectedCallback += OnClientConnectedCallback;
-            NetworkManager.OnClientDisconnectCallback += OnClientDisconnectCallback;
+            NetworkManager.OnConnectionEvent += OnConnectionEvent;
             NetworkManager.OnServerStarted += OnServerStarted;
             NetworkManager.ConnectionApprovalCallback += ApprovalCheck;
             NetworkManager.OnTransportFailure += OnTransportFailure;
@@ -103,8 +102,7 @@ namespace Unity.BossRoom.ConnectionManagement
 
         void OnDestroy()
         {
-            NetworkManager.OnClientConnectedCallback -= OnClientConnectedCallback;
-            NetworkManager.OnClientDisconnectCallback -= OnClientDisconnectCallback;
+            NetworkManager.OnConnectionEvent -= OnConnectionEvent;
             NetworkManager.OnServerStarted -= OnServerStarted;
             NetworkManager.ConnectionApprovalCallback -= ApprovalCheck;
             NetworkManager.OnTransportFailure -= OnTransportFailure;
@@ -123,14 +121,17 @@ namespace Unity.BossRoom.ConnectionManagement
             m_CurrentState.Enter();
         }
 
-        void OnClientDisconnectCallback(ulong clientId)
+        void OnConnectionEvent(NetworkManager networkManager, ConnectionEventData connectionEventData)
         {
-            m_CurrentState.OnClientDisconnect(clientId);
-        }
-
-        void OnClientConnectedCallback(ulong clientId)
-        {
-            m_CurrentState.OnClientConnected(clientId);
+            switch (connectionEventData.EventType)
+            {
+                case ConnectionEvent.ClientConnected:
+                    m_CurrentState.OnClientConnected(connectionEventData.ClientId);
+                    break;
+                case ConnectionEvent.ClientDisconnected:
+                    m_CurrentState.OnClientDisconnect(connectionEventData.ClientId);
+                    break;
+            }
         }
 
         void OnServerStarted()

--- a/Assets/Scripts/Gameplay/GameState/ServerBossRoomState.cs
+++ b/Assets/Scripts/Gameplay/GameState/ServerBossRoomState.cs
@@ -79,7 +79,7 @@ namespace Unity.BossRoom.Gameplay.GameState
             m_PersistentGameState.Reset();
             m_LifeStateChangedEventMessageSubscriber.Subscribe(OnLifeStateChangedEventMessage);
 
-            NetworkManager.Singleton.OnClientDisconnectCallback += OnClientDisconnect;
+            NetworkManager.Singleton.OnConnectionEvent += OnConnectionEvent;
             NetworkManager.Singleton.SceneManager.OnLoadEventCompleted += OnLoadEventCompleted;
             NetworkManager.Singleton.SceneManager.OnSynchronizeComplete += OnSynchronizeComplete;
 
@@ -93,7 +93,7 @@ namespace Unity.BossRoom.Gameplay.GameState
                 m_LifeStateChangedEventMessageSubscriber.Unsubscribe(OnLifeStateChangedEventMessage);
             }
 
-            NetworkManager.Singleton.OnClientDisconnectCallback -= OnClientDisconnect;
+            NetworkManager.Singleton.OnConnectionEvent -= OnConnectionEvent;
             NetworkManager.Singleton.SceneManager.OnLoadEventCompleted -= OnLoadEventCompleted;
             NetworkManager.Singleton.SceneManager.OnSynchronizeComplete -= OnSynchronizeComplete;
         }
@@ -138,12 +138,15 @@ namespace Unity.BossRoom.Gameplay.GameState
             }
         }
 
-        void OnClientDisconnect(ulong clientId)
+        void OnConnectionEvent(NetworkManager networkManager, ConnectionEventData connectionEventData)
         {
-            if (clientId != NetworkManager.Singleton.LocalClientId)
+            if (connectionEventData.EventType == ConnectionEvent.ClientDisconnected)
             {
-                // If a client disconnects, check for game over in case all other players are already down
-                StartCoroutine(WaitToCheckForGameOver());
+                if (connectionEventData.ClientId != networkManager.LocalClientId)
+                {
+                    // If a client disconnects, check for game over in case all other players are already down
+                    StartCoroutine(WaitToCheckForGameOver());
+                }
             }
         }
 

--- a/Assets/Scripts/Infrastructure/PubSub/NetworkedMessageChannel.cs
+++ b/Assets/Scripts/Infrastructure/PubSub/NetworkedMessageChannel.cs
@@ -26,7 +26,7 @@ namespace Unity.BossRoom.Infrastructure
         void InjectDependencies(NetworkManager networkManager)
         {
             m_NetworkManager = networkManager;
-            m_NetworkManager.OnClientConnectedCallback += OnClientConnected;
+            m_NetworkManager.OnConnectionEvent += OnConnectionEvent;
             if (m_NetworkManager.IsListening)
             {
                 RegisterHandler();
@@ -40,14 +40,18 @@ namespace Unity.BossRoom.Infrastructure
                 if (m_NetworkManager != null && m_NetworkManager.CustomMessagingManager != null)
                 {
                     m_NetworkManager.CustomMessagingManager.UnregisterNamedMessageHandler(m_Name);
+                    m_NetworkManager.OnConnectionEvent -= OnConnectionEvent;
                 }
             }
             base.Dispose();
         }
 
-        void OnClientConnected(ulong clientId)
+        void OnConnectionEvent(NetworkManager networkManager, ConnectionEventData connectionEventData)
         {
-            RegisterHandler();
+            if (connectionEventData.EventType == ConnectionEvent.ClientConnected)
+            {
+                RegisterHandler();
+            }
         }
 
         void RegisterHandler()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,25 +26,26 @@ Additional documentation and release notes are available at [Multiplayer Documen
 * VContainer package upgraded from v1.11.0 to v1.14.0 (#896) This upgrade removes warning messages related to IL weaving as code gen is refactored in v1.14.0
 * Upgraded the project to the New Input System v1.11.2 (#897) Compatibility mode with the previous version has been disabled.
 * Upgraded editor version to 6000.0.42f1 and upgraded packages (#901):
- * com.unity.ai.navigation from v2.0.5 to v2.0.6
- * com.unity.collab-proxy from v2.6.0 to v2.7.1
- * com.unity.inputsystem from v1.11.2 to v1.13.1
- * com.unity.learn.iet-framework from v4.0.3 to v4.0.4
- * com.unity.memoryprofiler from v1.1.3 to v1.1.5
- * com.unity.netcode.gameobjects from v2.1.1 to v2.2.0
- * com.unity.render-pipelines-universal from v17.0.3 to v17.0.4
- * com.unity.services.multiplayer from v1.1.0 to v1.1.1
- * com.unity.test-framework from v1.4.5 to v1.4.6
+  * com.unity.ai.navigation from v2.0.5 to v2.0.6
+  * com.unity.collab-proxy from v2.6.0 to v2.7.1
+  * com.unity.inputsystem from v1.11.2 to v1.13.1
+  * com.unity.learn.iet-framework from v4.0.3 to v4.0.4
+  * com.unity.memoryprofiler from v1.1.3 to v1.1.5
+  * com.unity.netcode.gameobjects from v2.1.1 to v2.2.0
+  * com.unity.render-pipelines-universal from v17.0.3 to v17.0.4
+  * com.unity.services.multiplayer from v1.1.0 to v1.1.1
+  * com.unity.test-framework from v1.4.5 to v1.4.6
 * Upgraded editor version to 6000.0.44f1 and upgraded packages (#902):
- * com.unity.ide.rider from v3.0.34 to v3.0.35
- * com.unity.services.multiplayer from v1.1.1 to v1.1.2
- * com.unity.test-framework from v1.4.6 to v1.5.1
- * com.unity.transport from v2.4.0 to v2.5.0
- * com.unity.cinemachine from v.3.1.2 to 3.1.3
- * com.unity.services.authentication from 3.4.0 to 3.4.1
- * jp.hadashikick.vcontainer from 1.14.0 to 1.16.8
- * com.unity.memoryprofiler from 1.1.5 to 1.1.6
- * com.unity.timeline from 1.8.7 to 1.8.8
+  * com.unity.ide.rider from v3.0.34 to v3.0.35
+  * com.unity.services.multiplayer from v1.1.1 to v1.1.2
+  * com.unity.test-framework from v1.4.6 to v1.5.1
+  * com.unity.transport from v2.4.0 to v2.5.0
+  * com.unity.cinemachine from v.3.1.2 to 3.1.3
+  * com.unity.services.authentication from 3.4.0 to 3.4.1
+  * jp.hadashikick.vcontainer from 1.14.0 to 1.16.8
+  * com.unity.memoryprofiler from 1.1.5 to 1.1.6
+  * com.unity.timeline from 1.8.7 to 1.8.8
+* Upgraded the project to use Netcode for GameObject's recommended OnConnectionEvent callback (#907)
 
 ### Cleanup
 * Removed ParrelSync from the project (#890)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 * Fixed a visual issue where a selected party member's party HUD slot would be displayed as selected (green) when the same or new party member joins the session in-game (#899)
 * Fixed Render Graph API compatibility mode warning and switched active input handling settings to "both" for removing InvalidOperationException (#901) 
 * Fixed error logged when unsubscribing from Session events when removed from a Session (#905)
+* Fixed error logged when attempting to despawn an already despawned LoadingProgressTracker NetworkObject (#907)
 
 ## [2.5.0] - 2024-04-18
 

--- a/Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md
+++ b/Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 ### Changed
 * Replaced Lobby and Relay standalone packages with the Multiplayer Services package v1.0.2 (#892)
-* Removed UnityRelayUtilities
+  * Removed UnityRelayUtilities
 * Upgrading Editor version dependency to 6000.0 (#902)
 Upgrading package dependencies:
- *   Tutorial Framework upgraded to  v4.0.4
- *   Multiplayer Tools to v2.2.3
- *   Netcode for GameObjects to v2.2.0 
+  * Tutorial Framework upgraded to  v4.0.4
+  * Multiplayer Tools to v2.2.3
+  * Netcode for GameObjects to v2.2.0
+* Upgraded Utilities package to use Netcode for GameObject's recommended OnConnectionEvent callback (#907)
 
 ## [1.9.0] - 2024-04-18
 

--- a/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/LoadingProgressManager.cs
+++ b/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/LoadingProgressManager.cs
@@ -50,8 +50,7 @@ namespace Unity.Multiplayer.Samples.Utilities
         /// </summary>
         public float LocalProgress
         {
-            get => IsSpawned && ProgressTrackers.ContainsKey(NetworkManager.LocalClientId) ?
-                ProgressTrackers[NetworkManager.LocalClientId].Progress.Value : m_LocalProgress;
+            get => IsSpawned && ProgressTrackers.ContainsKey(NetworkManager.LocalClientId) ? ProgressTrackers[NetworkManager.LocalClientId].Progress.Value : m_LocalProgress;
             private set
             {
                 if (IsSpawned && ProgressTrackers.ContainsKey(NetworkManager.LocalClientId) && ProgressTrackers[NetworkManager.LocalClientId].IsSpawned)
@@ -72,12 +71,14 @@ namespace Unity.Multiplayer.Samples.Utilities
                 NetworkManager.OnConnectionEvent += OnConnectionEvent;
             }
         }
+
         public override void OnNetworkDespawn()
         {
             if (IsServer)
             {
                 NetworkManager.OnConnectionEvent -= OnConnectionEvent;
             }
+
             ProgressTrackers.Clear();
             onTrackersUpdated?.Invoke();
         }
@@ -117,9 +118,10 @@ namespace Unity.Multiplayer.Samples.Utilities
                     }
                 }
             }
+
             onTrackersUpdated?.Invoke();
         }
-        
+
         void OnConnectionEvent(NetworkManager networkManager, ConnectionEventData connectionEventData)
         {
             if (IsServer)

--- a/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/ServerAdditiveSceneLoader.cs
+++ b/Packages/com.unity.multiplayer.samples.coop/Utilities/SceneManagement/ServerAdditiveSceneLoader.cs
@@ -54,7 +54,7 @@ namespace Unity.Multiplayer.Samples.Utilities
             {
                 // Adding this to remove all pending references to a specific client when they disconnect, since objects
                 // that are destroyed do not generate OnTriggerExit events.
-                NetworkManager.OnClientDisconnectCallback += RemovePlayer;
+                NetworkManager.OnConnectionEvent += OnConnectionEvent;
 
                 NetworkManager.SceneManager.OnSceneEvent += OnSceneEvent;
                 m_PlayersInTrigger = new List<ulong>();
@@ -65,7 +65,7 @@ namespace Unity.Multiplayer.Samples.Utilities
         {
             if (IsServer)
             {
-                NetworkManager.OnClientDisconnectCallback -= RemovePlayer;
+                NetworkManager.OnConnectionEvent -= OnConnectionEvent;
                 NetworkManager.SceneManager.OnSceneEvent -= OnSceneEvent;
             }
         }
@@ -136,11 +136,14 @@ namespace Unity.Multiplayer.Samples.Utilities
             }
         }
 
-        void RemovePlayer(ulong clientId)
+        void OnConnectionEvent(NetworkManager networkManager, ConnectionEventData connectionEventData)
         {
-            // remove all references to this clientId. There could be multiple references if a single client owns
-            // multiple NetworkObjects with the m_PlayerTag, or if this script's GameObject has overlapping colliders
-            while (m_PlayersInTrigger.Remove(clientId)) { }
+            if (connectionEventData.EventType == ConnectionEvent.ClientDisconnected)
+            {
+                // remove all references to this clientId. There could be multiple references if a single client owns
+                // multiple NetworkObjects with the m_PlayerTag, or if this script's GameObject has overlapping colliders
+                while (m_PlayersInTrigger.Remove(connectionEventData.ClientId)) { }
+            }
         }
 
         IEnumerator WaitToUnloadCoroutine()


### PR DESCRIPTION
### Description
This PR upgrades the project to use the OnConnectionEvent callback from Netcode for GameObjects, in favour over the unrecommended OnClientConnected/OnClientDisconnected callbacks.

This PR also removes an unnecessary Despawn invocation on a NetworkObject that is already marked to despawn with owner.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[MTTB-1147](https://jira.unity3d.com/browse/MTTB-1147)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ N/A ] Tests have been added for boss room and/or utilities pack
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [ N/A ] An Index entry has been added in readme.md if applicable

