### PR TITLE
[MTT-11940] Fix: Rate Limited exceeded bug (same profile used join session via name)

### DIFF
--- a/Assets/Scripts/Gameplay/UI/UnityServicesUIHandler.cs
+++ b/Assets/Scripts/Gameplay/UI/UnityServicesUIHandler.cs
@@ -70,6 +70,10 @@ namespace Unity.BossRoom.Gameplay.UI
                         break;
                 }
             }
+            else
+            {
+                PopupManager.ShowPopupPanel("Unknown Issue", error.Message);
+            }
         }
 
         void OnDestroy()

--- a/Assets/Scripts/UnityServices/Sessions/MultiplayerServicesFacade.cs
+++ b/Assets/Scripts/UnityServices/Sessions/MultiplayerServicesFacade.cs
@@ -188,6 +188,11 @@ namespace Unity.BossRoom.UnityServices.Sessions
 
             try
             {
+                var joinedSessionList = await MultiplayerService.Instance.GetJoinedSessionIdsAsync();
+                if (joinedSessionList.Contains(sessionName))
+                {
+                    throw new Exception($"Already joined session {sessionName}") ;
+                }
                 var session = await m_MultiplayerServicesInterface.JoinSessionById(sessionName, m_LocalUser.GetDataForUnityServices());
                 return (true, session);
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 * Fixed error logged when unsubscribing from Session events when removed from a Session (#905)
 * Fixed error logged when attempting to despawn an already despawned LoadingProgressTracker NetworkObject (#907)
 * Fixed error logged when a Melee action was acted on a Breakable object (#908)
+* Fixed rate limit exceeded error popping up when trying to join session with already used profile (#909)
 
 ## [2.5.0] - 2024-04-18
 


### PR DESCRIPTION
… error

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
When trying to join a lobby session with the same profile as already within the existing profile instead of an error being thrown mentioning that the user would see the spinning wheel until two more users join and then get a rate limit excpection error.

Now instead immediately an error (UI message) gets thrown once the user tries to join the session and the user can continue to interact with the game after closing the error message ingame.

How to test:
1. Connect to project id in project settings
2. Go into play mode create a new profile within the "Change profile" screen, then leave play mode
3. Activate Player 2 in MPPM and after its activated start play mode
4. Switch to newly created profile (change profile button) and create a session  (start session button, then create session there)
5. With Player 2 change to same profile via switch profile and try to join session via name (click on name visible in list)
6. Witness error popping up "Already joined session (sessionName)" 


### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
https://jira.unity3d.com/browse/MTT-11940

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [ ] An Index entry has been added in readme.md if applicable

