### PR TITLE
fix: v2.4.1 NGO update

### DIFF
--- a/Assets/Tests/Runtime/Unity.BossRoom.Tests.Runtime.asmdef
+++ b/Assets/Tests/Runtime/Unity.BossRoom.Tests.Runtime.asmdef
@@ -15,7 +15,8 @@
         "Unity.Netcode.TestHelpers.Runtime",
         "VContainer",
         "VContainer.EnableCodeGen",
-        "Unity.Collections"
+        "Unity.Collections",
+        "Unity.Netcode.Runtime.Tests"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
### Description

Since NGO v2.4.1 and above will now house testhelpers within the runtime tests assembly, we need to add the Unity.Netcode.Runtime.Tests to the BossRoom's tests asmdef.

### Issue Number(s)

NA

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [ ] An Index entry has been added in readme.md if applicable

