### PR TITLE
fix: resetting local user on profile change [MTT-11948]

### DIFF
--- a/Assets/Scripts/Gameplay/GameState/ClientMainMenuState.cs
+++ b/Assets/Scripts/Gameplay/GameState/ClientMainMenuState.cs
@@ -95,6 +95,11 @@ namespace Unity.BossRoom.Gameplay.GameState
             m_SignInSpinner.SetActive(false);
 
             Debug.Log($"Signed in. Unity Player ID {AuthenticationService.Instance.PlayerId}");
+            
+            m_LocalUser.ID = AuthenticationService.Instance.PlayerId; 
+            
+            // The local LobbyUser object will be hooked into UI before the LocalSession is populated during session join, so the LocalSession must know about it already when that happens.
+            m_LocalSession.AddUser(m_LocalUser);
         }
 
         private void OnSignInFailed()

--- a/Assets/Scripts/Gameplay/GameState/ClientMainMenuState.cs
+++ b/Assets/Scripts/Gameplay/GameState/ClientMainMenuState.cs
@@ -71,7 +71,7 @@ namespace Unity.BossRoom.Gameplay.GameState
             builder.RegisterComponent(m_IPUIMediator);
         }
 
-        private async void TrySignIn()
+        async void TrySignIn()
         {
             try
             {
@@ -88,21 +88,21 @@ namespace Unity.BossRoom.Gameplay.GameState
             }
         }
 
-        private void OnAuthSignIn()
+        void OnAuthSignIn()
         {
             m_SessionButton.interactable = true;
             m_UGSSetupTooltipDetector.enabled = false;
             m_SignInSpinner.SetActive(false);
 
             Debug.Log($"Signed in. Unity Player ID {AuthenticationService.Instance.PlayerId}");
-            
-            m_LocalUser.ID = AuthenticationService.Instance.PlayerId; 
-            
+
+            m_LocalUser.ID = AuthenticationService.Instance.PlayerId;
+
             // The local SessionUser object will be hooked into UI before the LocalSession is populated during session join, so the LocalSession must know about it already when that happens.
             m_LocalSession.AddUser(m_LocalUser);
         }
 
-        private void OnSignInFailed()
+        void OnSignInFailed()
         {
             if (m_SessionButton)
             {

--- a/Assets/Scripts/Gameplay/GameState/ClientMainMenuState.cs
+++ b/Assets/Scripts/Gameplay/GameState/ClientMainMenuState.cs
@@ -98,7 +98,7 @@ namespace Unity.BossRoom.Gameplay.GameState
             
             m_LocalUser.ID = AuthenticationService.Instance.PlayerId; 
             
-            // The local LobbyUser object will be hooked into UI before the LocalSession is populated during session join, so the LocalSession must know about it already when that happens.
+            // The local SessionUser object will be hooked into UI before the LocalSession is populated during session join, so the LocalSession must know about it already when that happens.
             m_LocalSession.AddUser(m_LocalUser);
         }
 

--- a/Assets/Scripts/UnityServices/Sessions/LocalSession.cs
+++ b/Assets/Scripts/UnityServices/Sessions/LocalSession.cs
@@ -213,9 +213,10 @@ namespace Unity.BossRoom.UnityServices.Sessions
             CopyDataFrom(info, localSessionUsers);
         }
 
-        public void Reset()
+        public void Reset(LocalSessionUser localUser)
         {
             CopyDataFrom(new SessionData(), new Dictionary<string, LocalSessionUser>());
+            AddUser(localUser);
         }
     }
 }

--- a/Assets/Scripts/UnityServices/Sessions/MultiplayerServicesFacade.cs
+++ b/Assets/Scripts/UnityServices/Sessions/MultiplayerServicesFacade.cs
@@ -227,7 +227,7 @@ namespace Unity.BossRoom.UnityServices.Sessions
         {
             CurrentUnitySession = null;
             m_LocalUser?.ResetState();
-            m_LocalSession?.Reset();
+            m_LocalSession?.Reset(m_LocalUser);
 
             // no need to disconnect Netcode, it should already be handled by Netcode's callback to disconnect
         }


### PR DESCRIPTION
### Description
This PR provides a fix for an error raised when changing profiles. The current LocalSessionUser needed to be added to the local session before attempting to remove when reseting a session. It has since been added to the initial login flow and whenever a profile is changed by the user.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[MTT-11948](https://jira.unity3d.com/browse/MTT-11948)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ N/A ] Tests have been added for boss room and/or utilities pack
 - [ N/A ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [ N/A ] An Index entry has been added in readme.md if applicable

