### PR TITLE
fix: name generation bounds fixed to include last item

### DIFF
--- a/Assets/Scripts/Gameplay/Configuration/NameGenerationData.cs
+++ b/Assets/Scripts/Gameplay/Configuration/NameGenerationData.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 using Random = UnityEngine.Random;
 
@@ -19,8 +18,8 @@ namespace Unity.BossRoom.Gameplay.Configuration
 
         public string GenerateName()
         {
-            var firstWord = FirstWordList[Random.Range(0, FirstWordList.Length - 1)];
-            var secondWord = SecondWordList[Random.Range(0, SecondWordList.Length - 1)];
+            var firstWord = FirstWordList[Random.Range(0, FirstWordList.Length)];
+            var secondWord = SecondWordList[Random.Range(0, SecondWordList.Length)];
 
             return firstWord + " " + secondWord;
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 * Fixed error logged when attempting to despawn an already despawned LoadingProgressTracker NetworkObject (#907)
 * Fixed error logged when a Melee action was acted on a Breakable object (#908)
 * Internal standards job fix (#915)
+* Fixed last index of names not being used (#922)
 
 ## [2.5.0] - 2024-04-18
 


### PR DESCRIPTION
### Description
Small PR to fix the bounds issue inside of the player name generation, where the last item in the arrays for first and last nam weren't being used.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[Issue 912](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/issues/912)
<!---
    Provide a list of fixed issues from Jira (GOMPS-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ ] Tests have been added for boss room and/or utilities pack
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file and/or [package changelog](../Packages/com.unity.multiplayer.samples.coop/CHANGELOG.md) file
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
 - [ ] An Index entry has been added in readme.md if applicable

